### PR TITLE
feat(core): inject a chat backend on GraphRAG (single hook)

### DIFF
--- a/graphrag-core/src/core/backend.rs
+++ b/graphrag-core/src/core/backend.rs
@@ -1,0 +1,39 @@
+//! Pluggable backend hooks for downstream consumers.
+//!
+//! `GraphRAG`'s built-in answer generation calls Ollama directly. Crates that
+//! want to use a different LLM provider (OpenAI, Azure, etc.) without
+//! forking the whole query pipeline can implement [`ChatBackend`] and inject
+//! it via [`crate::GraphRAG::set_chat_backend`]. When set, the backend takes
+//! over for the final answer-generation step in `ask` / `ask_explained`.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::core::Result;
+
+/// Generation parameters passed to a [`ChatBackend`]. Mirrors a small subset
+/// of `OllamaGenerationParams` so backends do not need to depend on
+/// Ollama-specific types.
+#[derive(Debug, Clone, Default)]
+pub struct ChatParams {
+    /// Soft cap on generated tokens. Backends should map this to whatever
+    /// concept they have (`max_tokens`, `num_predict`, etc.).
+    pub max_tokens: Option<u32>,
+    /// Sampling temperature in [0.0, 1.0]. `None` means use backend default.
+    pub temperature: Option<f32>,
+    /// Hint at the prompt's required context window. Backends may ignore this
+    /// — relevant mostly to local models with configurable context size.
+    pub num_ctx: Option<u32>,
+}
+
+/// A pluggable chat-completion backend.
+#[async_trait]
+pub trait ChatBackend: Send + Sync {
+    /// Generate a single completion for `prompt` honouring `params` where
+    /// supported. Errors are surfaced through `crate::core::Result`.
+    async fn complete(&self, prompt: &str, params: &ChatParams) -> Result<String>;
+}
+
+/// Convenience alias for trait objects.
+pub type DynChatBackend = Arc<dyn ChatBackend>;

--- a/graphrag-core/src/core/mod.rs
+++ b/graphrag-core/src/core/mod.rs
@@ -6,6 +6,10 @@
 pub mod error;
 pub mod metadata;
 
+// Pluggable chat backend hooks (always available; trait object only)
+#[cfg(feature = "async")]
+pub mod backend;
+
 // Registry requires async feature (uses storage)
 #[cfg(feature = "async")]
 pub mod registry;

--- a/graphrag-core/src/lib.rs
+++ b/graphrag-core/src/lib.rs
@@ -291,6 +291,11 @@ pub struct GraphRAG {
     #[cfg(feature = "parallel-processing")]
     #[allow(dead_code)]
     parallel_processor: Option<parallel::ParallelProcessor>,
+    /// Optional override for chat-completion calls. When set, the built-in
+    /// Ollama client is bypassed for the final answer-generation step in
+    /// `ask` and `ask_explained`. See [`core::backend::ChatBackend`].
+    #[cfg(feature = "async")]
+    chat_backend: Option<core::backend::DynChatBackend>,
 }
 
 impl GraphRAG {
@@ -304,7 +309,17 @@ impl GraphRAG {
             critic: None,
             #[cfg(feature = "parallel-processing")]
             parallel_processor: None,
+            #[cfg(feature = "async")]
+            chat_backend: None,
         })
+    }
+
+    /// Inject a custom chat backend for answer generation. Once set, the
+    /// built-in Ollama client is bypassed for the final LLM call inside
+    /// `ask` and `ask_explained`. Pass `None` to revert to the default.
+    #[cfg(feature = "async")]
+    pub fn set_chat_backend(&mut self, backend: Option<core::backend::DynChatBackend>) {
+        self.chat_backend = backend;
     }
 
     /// Create a Zero-Config local GraphRAG instance
@@ -1544,9 +1559,6 @@ impl GraphRAG {
             return Ok("No relevant information found in the knowledge graph.".to_string());
         }
 
-        // Create Ollama client
-        let client = OllamaClient::new(self.config.ollama.clone());
-
         // Build prompt for semantic answer generation with RAG best practices (2025)
         let prompt = format!(
             "You are a knowledgeable assistant specialized in answering questions based on a knowledge graph.\n\n\
@@ -1582,8 +1594,24 @@ impl GraphRAG {
             ..Default::default()
         };
 
-        // Generate answer using LLM with dynamic context window
-        match client.generate_with_params(&prompt, params).await {
+        // Dispatch through an injected ChatBackend if one was provided; otherwise
+        // fall back to the built-in Ollama client. This is the single hook
+        // downstream crates (e.g. semanticore) use to plug OpenAI-style providers
+        // into the answer-generation step without forking the rest of the
+        // pipeline.
+        let answer_result = if let Some(backend) = self.chat_backend.clone() {
+            let chat_params = crate::core::backend::ChatParams {
+                max_tokens: params.num_predict,
+                temperature: params.temperature,
+                num_ctx: params.num_ctx,
+            };
+            backend.complete(&prompt, &chat_params).await
+        } else {
+            let client = OllamaClient::new(self.config.ollama.clone());
+            client.generate_with_params(&prompt, params).await
+        };
+
+        match answer_result {
             Ok(answer) => {
                 // Post-processing: Remove <think> tags if present (Qwen3)
                 let cleaned_answer = Self::remove_thinking_tags(&answer);


### PR DESCRIPTION
## Summary

Adds a small `ChatBackend` trait (and a sibling `ChatParams` struct) under
`graphrag-core::core::backend`, plus a `GraphRAG::set_chat_backend` setter
that lets downstream crates plug a non-Ollama LLM into the final
answer-generation step without forking the rest of the pipeline.

When a backend is set, `generate_semantic_answer_from_results` dispatches
through it; otherwise it falls back to the existing Ollama client. The
default behaviour is unchanged — no caller of \`GraphRAG\` needs to touch
anything to keep working.

## Motivation

I'm building [\`semanticore\`](https://github.com/mfaulk/semanticore-rs), a
Rust MCP server that wraps \`graphrag-core\`. To support OpenAI as the
sensemaking-query LLM I needed to route the chat call through a custom
adapter. \`core::registry::ServiceRegistry\` exists but is not consumed by
\`GraphRAG\` itself in 0.1.x, so I went with the smallest possible change:
one trait, one field, one dispatch site.

Default-config indexing is pure-algorithmic (no LLM at index time) and
queries embed via the 128-dim hash generator inside
\`RetrievalSystem\`, so this single hook is sufficient for the full default
flow. Switching query embeddings to a custom backend would require a
larger refactor and is out of scope here.

## Changes

- \`graphrag-core/src/core/backend.rs\` (new): \`ChatBackend\` trait +
  \`ChatParams\` struct (max_tokens / temperature / num_ctx) +
  \`DynChatBackend\` alias. Behind the \`async\` feature.
- \`graphrag-core/src/core/mod.rs\`: \`pub mod backend;\` (async-gated).
- \`graphrag-core/src/lib.rs\`:
  - \`GraphRAG\` gains an optional \`chat_backend: Option<DynChatBackend>\`
    field (async-gated).
  - New \`GraphRAG::set_chat_backend(Option<DynChatBackend>)\` setter.
  - \`generate_semantic_answer_from_results\` dispatches through the
    backend if set; otherwise constructs an \`OllamaClient\` exactly as
    before.

76 insertions, 5 deletions across 3 files. No public API removed; default
behaviour unchanged.

## Test plan

- [ ] \`cargo build -p graphrag-core --features async,ollama,memory-storage,basic-retrieval,parallel-processing,ureq --no-default-features\` — verified locally.
- [ ] Existing test suite still passes.
- [ ] Downstream consumer (\`semanticore\`) builds against this branch and
  routes OpenAI through the new hook end-to-end.
- [ ] \`generate_semantic_answer_from_results\` still works with no
  backend set (Ollama fallback path).