### PR TITLE
fix: Phase 0-2 — eliminate ~50 panic sites, 1 race, 1 unsoundness

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Pre-push hook: run the same blocking checks as CI before letting a push out.
+#
+# Mirrors the two CI jobs that block PR merges:
+#   - Rustfmt:    cargo fmt --all -- --check
+#   - Build & Test (build step only): cargo build --workspace
+#                  excluding graphrag_py (pyo3) and graphrag-wasm (advisory)
+#
+# Tests are intentionally NOT run here — the full nextest suite is too slow
+# for every push. CI runs them. Run them locally before opening a PR with:
+#   cargo nextest run --workspace --tests --exclude graphrag_py --exclude graphrag-wasm
+#
+# Bypass once with:  SKIP_PREPUSH=1 git push
+# (Use sparingly; CI will still run the same checks.)
+#
+# Install:  git config core.hooksPath .githooks
+
+set -euo pipefail
+
+if [[ "${SKIP_PREPUSH:-0}" == "1" ]]; then
+    echo "[pre-push] SKIP_PREPUSH=1 — bypassing checks"
+    exit 0
+fi
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+red()   { printf '\033[0;31m%s\033[0m\n' "$1"; }
+green() { printf '\033[0;32m%s\033[0m\n' "$1"; }
+dim()   { printf '\033[2m%s\033[0m\n'   "$1"; }
+
+dim "[pre-push] cargo fmt --all -- --check"
+if ! cargo fmt --all -- --check; then
+    echo
+    red "[pre-push] FAIL: rustfmt diffs above."
+    echo "Run 'cargo fmt --all' and amend or re-commit, then push again."
+    echo "(To bypass: SKIP_PREPUSH=1 git push)"
+    exit 1
+fi
+green "[pre-push] fmt OK"
+
+dim "[pre-push] cargo build --workspace --exclude graphrag_py --exclude graphrag-wasm"
+if ! cargo build --workspace --exclude graphrag_py --exclude graphrag-wasm --quiet; then
+    echo
+    red "[pre-push] FAIL: build errors above."
+    echo "Fix the errors before pushing."
+    echo "(To bypass: SKIP_PREPUSH=1 git push)"
+    exit 1
+fi
+green "[pre-push] build OK"
+
+echo
+green "[pre-push] all checks passed"

--- a/README.md
+++ b/README.md
@@ -970,6 +970,9 @@ We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guid
 git clone https://github.com/your-username/graphrag-rs.git
 cd graphrag-rs
 
+# One-time: enable the shared pre-push hook (mirrors CI's blocking checks)
+git config core.hooksPath .githooks
+
 # Run tests
 cargo test
 
@@ -980,6 +983,11 @@ RUST_LOG=debug cargo run
 cargo clippy
 cargo fmt --check
 ```
+
+The `.githooks/pre-push` hook runs `cargo fmt --check` and a workspace
+build before each `git push`, so CI-blocking failures are caught
+locally. To skip the hook for a single push (e.g. WIP branches):
+`SKIP_PREPUSH=1 git push`.
 
 ## FAQ
 

--- a/graphrag-cli/src/app.rs
+++ b/graphrag-cli/src/app.rs
@@ -471,7 +471,10 @@ impl App {
                     timestamp: Utc::now(),
                     duration_ms: duration.as_millis(),
                     results_count: raw_results.len(),
-                    results_preview: vec![answer[..answer.len().min(200)].to_string()],
+                    results_preview: vec![graphrag_core::util::text_safe::truncate_chars(
+                        &answer, 200,
+                    )
+                    .to_string()],
                 };
 
                 self.query_history.add_entry(entry.clone());
@@ -543,7 +546,11 @@ impl App {
                     timestamp: Utc::now(),
                     duration_ms: duration.as_millis(),
                     results_count: result.sources.len(),
-                    results_preview: vec![result.answer[..result.answer.len().min(200)].to_string()],
+                    results_preview: vec![graphrag_core::util::text_safe::truncate_chars(
+                        &result.answer,
+                        200,
+                    )
+                    .to_string()],
                 };
                 self.query_history.add_entry(entry.clone());
                 self.info_panel
@@ -566,7 +573,7 @@ impl App {
                         src.relevance_score,
                         src.id
                     ));
-                    let excerpt = &src.excerpt[..src.excerpt.len().min(120)];
+                    let excerpt = graphrag_core::util::text_safe::truncate_chars(&src.excerpt, 120);
                     raw_display.push(format!("   {}", excerpt));
                     raw_display.push(String::new());
                 }
@@ -648,7 +655,10 @@ impl App {
                     timestamp: Utc::now(),
                     duration_ms: duration.as_millis(),
                     results_count: 0,
-                    results_preview: vec![answer[..answer.len().min(200)].to_string()],
+                    results_preview: vec![graphrag_core::util::text_safe::truncate_chars(
+                        &answer, 200,
+                    )
+                    .to_string()],
                 };
                 self.query_history.add_entry(entry.clone());
                 self.info_panel

--- a/graphrag-cli/src/ui/components/info_panel.rs
+++ b/graphrag-cli/src/ui/components/info_panel.rs
@@ -315,7 +315,12 @@ impl InfoPanel {
 
         for (i, src) in self.sources.iter().skip(self.scroll_offset).enumerate() {
             let excerpt = if src.excerpt.len() > 60 {
-                format!("{}…", &src.excerpt[..57])
+                // Clamp truncation to UTF-8 char boundary so multi-byte input
+                // (CJK, emoji) cannot panic the TUI.
+                format!(
+                    "{}…",
+                    graphrag_core::util::text_safe::truncate_chars(&src.excerpt, 57)
+                )
             } else {
                 src.excerpt.clone()
             };
@@ -331,7 +336,7 @@ impl InfoPanel {
                         Style::default().fg(Color::Cyan),
                     ),
                     Span::styled(
-                        src.id[..src.id.len().min(20)].to_string(),
+                        graphrag_core::util::text_safe::truncate_chars(&src.id, 20).to_string(),
                         self.theme.highlight(),
                     ),
                 ]),
@@ -373,7 +378,10 @@ impl InfoPanel {
             .enumerate()
             .map(|(i, entry)| {
                 let query_display = if entry.query.len() > 28 {
-                    format!("{}…", &entry.query[..25])
+                    format!(
+                        "{}…",
+                        graphrag_core::util::text_safe::truncate_chars(&entry.query, 25)
+                    )
                 } else {
                     entry.query.clone()
                 };

--- a/graphrag-core/examples/advanced_nlp_demo.rs
+++ b/graphrag-core/examples/advanced_nlp_demo.rs
@@ -75,31 +75,27 @@ fn demo_graph_traversal() -> Result<()> {
         ("charlie", "Charlie", "person"),
         ("stanford", "Stanford", "organization"),
     ] {
-        graph.add_entity(Entity {
-            id: EntityId::new(id.to_string()),
-            name: name.to_string(),
-            entity_type: etype.to_string(),
-            confidence: 0.9,
-            mentions: vec![],
-            embedding: None,
-        })?;
+        graph.add_entity(Entity::new(
+            EntityId::new(id.to_string()),
+            name.to_string(),
+            etype.to_string(),
+            0.9,
+        ))?;
     }
 
-    graph.add_relationship(Relationship {
-        source: EntityId::new("alice".to_string()),
-        target: EntityId::new("bob".to_string()),
-        relation_type: "knows".to_string(),
-        confidence: 1.0,
-        context: vec![],
-    })?;
+    graph.add_relationship(Relationship::new(
+        EntityId::new("alice".to_string()),
+        EntityId::new("bob".to_string()),
+        "knows".to_string(),
+        1.0,
+    ))?;
 
-    graph.add_relationship(Relationship {
-        source: EntityId::new("bob".to_string()),
-        target: EntityId::new("charlie".to_string()),
-        relation_type: "knows".to_string(),
-        confidence: 1.0,
-        context: vec![],
-    })?;
+    graph.add_relationship(Relationship::new(
+        EntityId::new("bob".to_string()),
+        EntityId::new("charlie".to_string()),
+        "knows".to_string(),
+        1.0,
+    ))?;
 
     println!(
         "\nGraph: {} entities, {} relationships",
@@ -154,14 +150,12 @@ fn demo_query_optimization() -> Result<()> {
             1 => "organization",
             _ => "location",
         };
-        graph.add_entity(Entity {
-            id: EntityId::new(format!("e{}", i)),
-            name: format!("Entity {}", i),
-            entity_type: etype.to_string(),
-            confidence: 0.9,
-            mentions: vec![],
-            embedding: None,
-        })?;
+        graph.add_entity(Entity::new(
+            EntityId::new(format!("e{}", i)),
+            format!("Entity {}", i),
+            etype.to_string(),
+            0.9,
+        ))?;
     }
 
     let stats = GraphStatistics::from_graph(&graph);

--- a/graphrag-core/examples/complete_zero_cost_graphrag_demo.rs
+++ b/graphrag-core/examples/complete_zero_cost_graphrag_demo.rs
@@ -226,6 +226,8 @@ fn create_pure_algorithmic_config() -> Config {
             max_gleaning_rounds: 3,
             enable_triple_reflection: false,
             validation_min_confidence: 0.7,
+            use_atomic_facts: false,
+            max_fact_tokens: 50,
         },
         retrieval: graphrag_core::config::RetrievalConfig {
             top_k: 10,
@@ -353,6 +355,9 @@ fn create_pure_algorithmic_config() -> Config {
         },
         enhancements: Default::default(),
         auto_save: Default::default(),
+        gliner: Default::default(),
+        advanced_features: Default::default(),
+        suppress_progress_bars: false,
     }
 }
 

--- a/graphrag-core/examples/hierarchical_graphrag_demo.rs
+++ b/graphrag-core/examples/hierarchical_graphrag_demo.rs
@@ -104,13 +104,12 @@ fn main() -> graphrag_core::Result<()> {
     ];
 
     for (src, tgt, rel_type, confidence) in relationships {
-        let rel = Relationship {
-            source: EntityId::new(src.to_string()),
-            target: EntityId::new(tgt.to_string()),
-            relation_type: rel_type.to_string(),
+        let rel = Relationship::new(
+            EntityId::new(src.to_string()),
+            EntityId::new(tgt.to_string()),
+            rel_type.to_string(),
             confidence,
-            context: Vec::new(),
-        };
+        );
         println!("  + {} --[{}]--> {}", src, rel_type, tgt);
         graph.add_relationship(rel)?;
     }

--- a/graphrag-core/examples/llm_evaluation_demo.rs
+++ b/graphrag-core/examples/llm_evaluation_demo.rs
@@ -88,38 +88,30 @@ Relationships define how entities are connected, such as "works_for" or "located
 
     // Phase 2: Entity Extraction (simulated)
     let entities = vec![
-        Entity {
-            id: EntityId::new("e1".to_string()),
-            name: "Knowledge Graphs".to_string(),
-            entity_type: "concept".to_string(),
-            confidence: 0.95,
-            mentions: vec![],
-            embedding: None,
-        },
-        Entity {
-            id: EntityId::new("e2".to_string()),
-            name: "Search Engines".to_string(),
-            entity_type: "system".to_string(),
-            confidence: 0.85,
-            mentions: vec![],
-            embedding: None,
-        },
-        Entity {
-            id: EntityId::new("e3".to_string()),
-            name: "Entities".to_string(),
-            entity_type: "concept".to_string(),
-            confidence: 0.9,
-            mentions: vec![],
-            embedding: None,
-        },
-        Entity {
-            id: EntityId::new("e4".to_string()),
-            name: "Relationships".to_string(),
-            entity_type: "concept".to_string(),
-            confidence: 0.9,
-            mentions: vec![],
-            embedding: None,
-        },
+        Entity::new(
+            EntityId::new("e1".to_string()),
+            "Knowledge Graphs".to_string(),
+            "concept".to_string(),
+            0.95,
+        ),
+        Entity::new(
+            EntityId::new("e2".to_string()),
+            "Search Engines".to_string(),
+            "system".to_string(),
+            0.85,
+        ),
+        Entity::new(
+            EntityId::new("e3".to_string()),
+            "Entities".to_string(),
+            "concept".to_string(),
+            0.9,
+        ),
+        Entity::new(
+            EntityId::new("e4".to_string()),
+            "Relationships".to_string(),
+            "concept".to_string(),
+            0.9,
+        ),
     ];
 
     let entity_validation = EntityExtractionValidator::validate(&chunks, &entities);
@@ -140,20 +132,18 @@ Relationships define how entities are connected, such as "works_for" or "located
 
     // Phase 3: Relationship Extraction (simulated)
     let relationships = vec![
-        Relationship {
-            source: EntityId::new("e1".to_string()),
-            target: EntityId::new("e3".to_string()),
-            relation_type: "composed_of".to_string(),
-            confidence: 0.85,
-            context: vec![],
-        },
-        Relationship {
-            source: EntityId::new("e3".to_string()),
-            target: EntityId::new("e4".to_string()),
-            relation_type: "connected_by".to_string(),
-            confidence: 0.8,
-            context: vec![],
-        },
+        Relationship::new(
+            EntityId::new("e1".to_string()),
+            EntityId::new("e3".to_string()),
+            "composed_of".to_string(),
+            0.85,
+        ),
+        Relationship::new(
+            EntityId::new("e3".to_string()),
+            EntityId::new("e4".to_string()),
+            "connected_by".to_string(),
+            0.8,
+        ),
     ];
 
     let rel_validation = RelationshipExtractionValidator::validate(&entities, &relationships);
@@ -232,40 +222,33 @@ fn demo_query_evaluation() -> Result<()> {
 
     // Retrieved entities
     let entities = vec![
-        Entity {
-            id: EntityId::new("e1".to_string()),
-            name: "Knowledge Graphs".to_string(),
-            entity_type: "concept".to_string(),
-            confidence: 0.95,
-            mentions: vec![],
-            embedding: None,
-        },
-        Entity {
-            id: EntityId::new("e2".to_string()),
-            name: "Google".to_string(),
-            entity_type: "organization".to_string(),
-            confidence: 0.9,
-            mentions: vec![],
-            embedding: None,
-        },
-        Entity {
-            id: EntityId::new("e3".to_string()),
-            name: "Search Engines".to_string(),
-            entity_type: "system".to_string(),
-            confidence: 0.85,
-            mentions: vec![],
-            embedding: None,
-        },
+        Entity::new(
+            EntityId::new("e1".to_string()),
+            "Knowledge Graphs".to_string(),
+            "concept".to_string(),
+            0.95,
+        ),
+        Entity::new(
+            EntityId::new("e2".to_string()),
+            "Google".to_string(),
+            "organization".to_string(),
+            0.9,
+        ),
+        Entity::new(
+            EntityId::new("e3".to_string()),
+            "Search Engines".to_string(),
+            "system".to_string(),
+            0.85,
+        ),
     ];
 
     // Retrieved relationships
-    let relationships = vec![Relationship {
-        source: EntityId::new("e2".to_string()),
-        target: EntityId::new("e3".to_string()),
-        relation_type: "is_a".to_string(),
-        confidence: 0.9,
-        context: vec![],
-    }];
+    let relationships = vec![Relationship::new(
+        EntityId::new("e2".to_string()),
+        EntityId::new("e3".to_string()),
+        "is_a".to_string(),
+        0.9,
+    )];
 
     // Context chunks
     let chunks = vec![

--- a/graphrag-core/examples/tom_sawyer_workspace.rs
+++ b/graphrag-core/examples/tom_sawyer_workspace.rs
@@ -113,13 +113,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     ];
 
     for (source, target, rel_type, confidence) in &relationships_data {
-        let relationship = Relationship {
-            source: EntityId::new(source.to_string()),
-            target: EntityId::new(target.to_string()),
-            relation_type: rel_type.to_string(),
-            confidence: *confidence,
-            context: vec![ChunkId::new("chunk_0".to_string())],
-        };
+        let relationship = Relationship::new(
+            EntityId::new(source.to_string()),
+            EntityId::new(target.to_string()),
+            rel_type.to_string(),
+            *confidence,
+        )
+        .with_context(vec![ChunkId::new("chunk_0".to_string())]);
         graph.add_relationship(relationship)?;
     }
     println!("   ✅ Added {} relationships", relationships_data.len());

--- a/graphrag-core/examples/workspace_demo.rs
+++ b/graphrag-core/examples/workspace_demo.rs
@@ -59,13 +59,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     graph.add_entity(entity2)?;
 
     // Add a relationship
-    let relationship = Relationship {
-        source: EntityId::new("rust".to_string()),
-        target: EntityId::new("graphrag".to_string()),
-        relation_type: "USES".to_string(),
-        confidence: 0.85,
-        context: vec![ChunkId::new("chunk1".to_string())],
-    };
+    let relationship = Relationship::new(
+        EntityId::new("rust".to_string()),
+        EntityId::new("graphrag".to_string()),
+        "USES".to_string(),
+        0.85,
+    )
+    .with_context(vec![ChunkId::new("chunk1".to_string())]);
     graph.add_relationship(relationship)?;
 
     println!("📊 Created knowledge graph:");

--- a/graphrag-core/src/api/handlers.rs
+++ b/graphrag-core/src/api/handlers.rs
@@ -242,10 +242,28 @@ fn default_page_size() -> usize {
     20
 }
 
+/// Reject zero pagination values up front: page=0 underflows
+/// `(page-1)*page_size` to `usize::MAX` and the multiplication panics on
+/// overflow; page_size=0 panics the divisor in
+/// `(total + page_size - 1) / page_size`.
+fn validate_pagination(page: usize, page_size: usize) -> Result<(), AppError> {
+    if page == 0 {
+        return Err(AppError::BadRequest("page must be >= 1".to_string()));
+    }
+    if page_size == 0 {
+        return Err(AppError::BadRequest(
+            "page_size must be >= 1".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 pub async fn list_entities(
     State(state): State<AppState>,
     Query(params): Query<ListEntitiesQuery>,
 ) -> Result<Json<serde_json::Value>, AppError> {
+    validate_pagination(params.page, params.page_size)?;
+
     let graphrag = state.graphrag.read().await;
 
     if let Some(graph) = graphrag.get_knowledge_graph() {
@@ -268,7 +286,7 @@ pub async fn list_entities(
             .collect();
 
         let total = entities.len();
-        let start = (params.page - 1) * params.page_size;
+        let start = params.page.saturating_sub(1).saturating_mul(params.page_size);
         entities = entities
             .into_iter()
             .skip(start)
@@ -280,7 +298,7 @@ pub async fn list_entities(
             "page": params.page,
             "page_size": params.page_size,
             "total": total,
-            "total_pages": (total + params.page_size - 1) / params.page_size
+            "total_pages": total.div_ceil(params.page_size)
         })))
     } else {
         Ok(Json(serde_json::json!({
@@ -340,5 +358,35 @@ impl IntoResponse for AppError {
         }));
 
         (status, body).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Regression tests for #14: previously page=0 / page_size=0 reached the
+    // arithmetic and panicked the worker, an unauthenticated DoS.
+    #[test]
+    fn validate_pagination_rejects_page_zero() {
+        let err = validate_pagination(0, 20).unwrap_err();
+        assert!(matches!(err, AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn validate_pagination_rejects_page_size_zero() {
+        let err = validate_pagination(1, 0).unwrap_err();
+        assert!(matches!(err, AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn validate_pagination_accepts_minimum_valid_values() {
+        assert!(validate_pagination(1, 1).is_ok());
+    }
+
+    #[test]
+    fn validate_pagination_accepts_typical_values() {
+        assert!(validate_pagination(1, 20).is_ok());
+        assert!(validate_pagination(10, 100).is_ok());
     }
 }

--- a/graphrag-core/src/api/handlers.rs
+++ b/graphrag-core/src/api/handlers.rs
@@ -251,9 +251,7 @@ fn validate_pagination(page: usize, page_size: usize) -> Result<(), AppError> {
         return Err(AppError::BadRequest("page must be >= 1".to_string()));
     }
     if page_size == 0 {
-        return Err(AppError::BadRequest(
-            "page_size must be >= 1".to_string(),
-        ));
+        return Err(AppError::BadRequest("page_size must be >= 1".to_string()));
     }
     Ok(())
 }
@@ -286,7 +284,10 @@ pub async fn list_entities(
             .collect();
 
         let total = entities.len();
-        let start = params.page.saturating_sub(1).saturating_mul(params.page_size);
+        let start = params
+            .page
+            .saturating_sub(1)
+            .saturating_mul(params.page_size);
         entities = entities
             .into_iter()
             .skip(start)

--- a/graphrag-core/src/async_graphrag.rs
+++ b/graphrag-core/src/async_graphrag.rs
@@ -324,7 +324,7 @@ impl AsyncGraphRAG {
         }
 
         // Sort by score and limit results
-        all_results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
+        all_results.sort_by(|a, b| b.score.total_cmp(&a.score));
         all_results.truncate(max_results);
 
         Ok(all_results)

--- a/graphrag-core/src/async_processing/monitoring.rs
+++ b/graphrag-core/src/async_processing/monitoring.rs
@@ -222,11 +222,9 @@ impl ProcessingMetrics {
     /// # Parameters
     /// - `memory_bytes`: Current memory usage in bytes
     pub fn update_peak_memory_usage(&self, memory_bytes: u64) {
-        let current = self.peak_memory_usage.load(Ordering::Relaxed);
-        if memory_bytes > current {
-            self.peak_memory_usage
-                .store(memory_bytes, Ordering::Relaxed);
-        }
+        // fetch_max is a single atomic op with no lost-update race.
+        self.peak_memory_usage
+            .fetch_max(memory_bytes, Ordering::Relaxed);
     }
 
     // Getters for current values
@@ -461,5 +459,43 @@ pub struct SystemMetrics {
 impl Default for ProcessingMetrics {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::thread;
+
+    #[test]
+    fn peak_memory_usage_takes_maximum_of_sequential_updates() {
+        let metrics = ProcessingMetrics::new();
+        for v in [1u64, 100, 50, 200, 75, 300, 80] {
+            metrics.update_peak_memory_usage(v);
+        }
+        assert_eq!(metrics.peak_memory_usage.load(Ordering::Relaxed), 300);
+    }
+
+    #[test]
+    fn peak_memory_usage_is_monotonic_under_concurrent_updates() {
+        // Regression test for #18: previously implemented as load-then-store,
+        // which races and can drop a higher peak. fetch_max is a single op.
+        let metrics = Arc::new(ProcessingMetrics::new());
+        let max_value = 10_000u64;
+        let handles: Vec<_> = (1..=max_value)
+            .map(|v| {
+                let m = metrics.clone();
+                thread::spawn(move || m.update_peak_memory_usage(v))
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+        assert_eq!(
+            metrics.peak_memory_usage.load(Ordering::Relaxed),
+            max_value,
+            "peak must equal the max value submitted across all threads"
+        );
     }
 }

--- a/graphrag-core/src/core/registry.rs
+++ b/graphrag-core/src/core/registry.rs
@@ -291,12 +291,7 @@ impl ServiceContext {
 
     /// Get a service by type
     pub fn get<T: Any + Send + Sync>(&self) -> Result<&T> {
-        // Safety: This is safe because we're getting an immutable reference
-        // from an Arc, which ensures the registry stays alive
-        unsafe {
-            let ptr = self.registry.as_ref() as *const ServiceRegistry;
-            (*ptr).get::<T>()
-        }
+        self.registry.get::<T>()
     }
 }
 

--- a/graphrag-core/src/core/test_utils.rs
+++ b/graphrag-core/src/core/test_utils.rs
@@ -255,7 +255,7 @@ impl AsyncVectorStore for MockVectorStore {
             .collect();
 
         // Sort by distance (ascending)
-        results.sort_by(|a, b| a.distance.partial_cmp(&b.distance).unwrap());
+        results.sort_by(|a, b| a.distance.total_cmp(&b.distance));
 
         // Take top k
         Ok(results.into_iter().take(k).collect())

--- a/graphrag-core/src/function_calling/functions.rs
+++ b/graphrag-core/src/function_calling/functions.rs
@@ -170,7 +170,7 @@ impl CallableFunction for GraphSearchFunction {
         }
 
         // Sort by relevance score and limit results
-        matching_entities.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+        matching_entities.sort_by(|a, b| b.1.total_cmp(&a.1));
         matching_entities.truncate(limit);
 
         let results: Vec<JsonValue> = matching_entities

--- a/graphrag-core/src/generation/async_mock_llm.rs
+++ b/graphrag-core/src/generation/async_mock_llm.rs
@@ -136,7 +136,7 @@ impl AsyncMockLLM {
             .collect();
 
         // Sort by relevance
-        sentence_scores.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+        sentence_scores.sort_by(|a, b| b.1.total_cmp(&a.1));
 
         // Select top sentences with a minimum relevance threshold
         let mut answer_sentences = Vec::new();

--- a/graphrag-core/src/generation/mod.rs
+++ b/graphrag-core/src/generation/mod.rs
@@ -118,7 +118,7 @@ impl MockLLM {
             .collect();
 
         // Sort by relevance
-        sentence_scores.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+        sentence_scores.sort_by(|a, b| b.1.total_cmp(&a.1));
 
         // Select top sentences with a minimum relevance threshold
         let mut answer_sentences = Vec::new();
@@ -849,14 +849,14 @@ impl AnswerGenerator {
         }
 
         // Limit results
-        primary_chunks.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
-        supporting_chunks.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
+        primary_chunks.sort_by(|a, b| b.score.total_cmp(&a.score));
+        supporting_chunks.sort_by(|a, b| b.score.total_cmp(&a.score));
 
         primary_chunks.truncate(self.config.max_sources / 2);
         supporting_chunks.truncate(self.config.max_sources / 2);
 
         let mut hierarchical_summaries = hierarchical_results;
-        hierarchical_summaries.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
+        hierarchical_summaries.sort_by(|a, b| b.score.total_cmp(&a.score));
         hierarchical_summaries.truncate(3);
 
         // Calculate confidence based on result quality and quantity

--- a/graphrag-core/src/graph/analytics.rs
+++ b/graphrag-core/src/graph/analytics.rs
@@ -292,7 +292,7 @@ impl GraphAnalytics {
                 .min_by(|a, b| {
                     let dist_a = *distances.get(*a).unwrap_or(&f32::INFINITY);
                     let dist_b = *distances.get(*b).unwrap_or(&f32::INFINITY);
-                    dist_a.partial_cmp(&dist_b).unwrap()
+                    dist_a.total_cmp(&dist_b)
                 })?
                 .clone();
 
@@ -418,7 +418,7 @@ impl GraphAnalytics {
             })
             .collect();
 
-        scores.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+        scores.sort_by(|a, b| b.1.total_cmp(&a.1));
         scores.truncate(top_k);
         scores
     }

--- a/graphrag-core/src/graph/mod.rs
+++ b/graphrag-core/src/graph/mod.rs
@@ -256,7 +256,7 @@ impl GraphBuilder {
                 }
 
                 // Sort by similarity and take top connections
-                similarities.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+                similarities.sort_by(|a, b| b.1.total_cmp(&a.1));
                 similarities.truncate(self.max_connections);
 
                 // Add semantic similarity relationships

--- a/graphrag-core/src/graph/temporal.rs
+++ b/graphrag-core/src/graph/temporal.rs
@@ -443,7 +443,7 @@ impl TemporalAnalytics {
             growth_scores.push((node.clone(), growth));
         }
 
-        growth_scores.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+        growth_scores.sort_by(|a, b| b.1.total_cmp(&a.1));
         growth_scores.truncate(top_k);
 
         growth_scores

--- a/graphrag-core/src/inference.rs
+++ b/graphrag-core/src/inference.rs
@@ -130,7 +130,7 @@ impl InferenceEngine {
         }
 
         // Sort by confidence and limit results
-        inferred_relations.sort_by(|a, b| b.confidence.partial_cmp(&a.confidence).unwrap());
+        inferred_relations.sort_by(|a, b| b.confidence.total_cmp(&a.confidence));
         inferred_relations.truncate(self.config.max_candidates);
 
         inferred_relations

--- a/graphrag-core/src/inference.rs
+++ b/graphrag-core/src/inference.rs
@@ -380,8 +380,8 @@ impl InferenceEngine {
         if let Some(pattern_pos) = content.find(pattern) {
             let start = pattern_pos.saturating_sub(100); // 100 chars before
             let end = (pattern_pos + pattern.len() + 100).min(content.len()); // 100 chars after
-            // pos.saturating_sub(N) and (pos + len + N) are not guaranteed
-            // to land on UTF-8 char boundaries; clamp them.
+                                                                              // pos.saturating_sub(N) and (pos + len + N) are not guaranteed
+                                                                              // to land on UTF-8 char boundaries; clamp them.
             let context = crate::util::text_safe::slice_on_char_boundary(content, start, end);
 
             context.contains(entity_a) && context.contains(entity_b)

--- a/graphrag-core/src/inference.rs
+++ b/graphrag-core/src/inference.rs
@@ -380,7 +380,9 @@ impl InferenceEngine {
         if let Some(pattern_pos) = content.find(pattern) {
             let start = pattern_pos.saturating_sub(100); // 100 chars before
             let end = (pattern_pos + pattern.len() + 100).min(content.len()); // 100 chars after
-            let context = &content[start..end];
+            // pos.saturating_sub(N) and (pos + len + N) are not guaranteed
+            // to land on UTF-8 char boundaries; clamp them.
+            let context = crate::util::text_safe::slice_on_char_boundary(content, start, end);
 
             context.contains(entity_a) && context.contains(entity_b)
         } else {

--- a/graphrag-core/src/lib.rs
+++ b/graphrag-core/src/lib.rs
@@ -155,6 +155,9 @@ pub mod incremental;
 /// ROGRAG (Robustly Optimized GraphRAG) implementation
 pub mod rograg;
 
+/// UTF-8-safe string helpers and other small utilities.
+pub mod util;
+
 // Future utility modules (optional, not currently needed):
 // pub mod automatic_entity_linking;  // Advanced entity linking
 // pub mod phase_saver;               // Phase state persistence

--- a/graphrag-core/src/monitoring/metrics_collector.rs
+++ b/graphrag-core/src/monitoring/metrics_collector.rs
@@ -64,7 +64,7 @@ impl MetricsCollector {
             }
 
             let mut sorted = values.clone();
-            sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+            sorted.sort_by(|a, b| a.total_cmp(b));
 
             let count = sorted.len();
             let sum: f64 = sorted.iter().sum();

--- a/graphrag-core/src/nlp/custom_ner.rs
+++ b/graphrag-core/src/nlp/custom_ner.rs
@@ -361,7 +361,7 @@ impl CustomNER {
         entities.sort_by(|a, b| {
             a.start
                 .cmp(&b.start)
-                .then(b.confidence.partial_cmp(&a.confidence).unwrap())
+                .then(b.confidence.total_cmp(&a.confidence))
         });
 
         let mut result = Vec::new();

--- a/graphrag-core/src/retrieval/adaptive.rs
+++ b/graphrag-core/src/retrieval/adaptive.rs
@@ -248,7 +248,7 @@ impl AdaptiveRetriever {
         }
 
         // Sort by final weighted score
-        deduplicated_results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
+        deduplicated_results.sort_by(|a, b| b.score.total_cmp(&a.score));
 
         // Apply diversity-aware selection
         let final_results = self.diversity_aware_selection(deduplicated_results, max_results);

--- a/graphrag-core/src/retrieval/bm25.rs
+++ b/graphrag-core/src/retrieval/bm25.rs
@@ -146,7 +146,7 @@ impl BM25Retriever {
             })
             .collect();
 
-        results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
+        results.sort_by(|a, b| b.score.total_cmp(&a.score));
         results.truncate(limit);
         results
     }

--- a/graphrag-core/src/retrieval/enriched.rs
+++ b/graphrag-core/src/retrieval/enriched.rs
@@ -216,7 +216,7 @@ impl EnrichedRetriever {
         }
 
         // Re-sort after boosting
-        results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
+        results.sort_by(|a, b| b.score.total_cmp(&a.score));
 
         Ok(results)
     }
@@ -285,7 +285,7 @@ impl EnrichedRetriever {
         }
 
         let mut sorted_results: Vec<_> = keyword_scores.into_iter().collect();
-        sorted_results.sort_by(|a, b| b.1 .0.partial_cmp(&a.1 .0).unwrap());
+        sorted_results.sort_by(|a, b| b.1 .0.total_cmp(&a.1 .0));
 
         sorted_results
             .into_iter()

--- a/graphrag-core/src/retrieval/hybrid.rs
+++ b/graphrag-core/src/retrieval/hybrid.rs
@@ -418,7 +418,7 @@ impl HybridRetriever {
             .collect();
 
         // Sort by combined score
-        results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
+        results.sort_by(|a, b| b.score.total_cmp(&a.score));
         results.truncate(limit);
 
         Ok(results)

--- a/graphrag-core/src/retrieval/mod.rs
+++ b/graphrag-core/src/retrieval/mod.rs
@@ -1402,7 +1402,7 @@ impl RetrievalSystem {
         }
 
         // Sort by adjusted scores
-        results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
+        results.sort_by(|a, b| b.score.total_cmp(&a.score));
 
         // Diversity-aware deduplication
         let mut deduplicated = Vec::new();
@@ -1526,7 +1526,7 @@ impl RetrievalSystem {
 
         // Select top entities by combined score
         let mut sorted_entities: Vec<_> = entity_scores.iter().collect();
-        sorted_entities.sort_by(|a, b| b.1.partial_cmp(a.1).unwrap());
+        sorted_entities.sort_by(|a, b| b.1.total_cmp(a.1));
 
         for (entity_id, score) in sorted_entities.iter().take(3) {
             if let Some(entity) = graph.entities().find(|e| e.id.to_string() == **entity_id) {
@@ -1647,7 +1647,7 @@ impl RetrievalSystem {
         }
 
         // Sort by similarity
-        similarities.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+        similarities.sort_by(|a, b| b.1.total_cmp(&a.1));
 
         Ok(similarities)
     }
@@ -1705,7 +1705,7 @@ impl RetrievalSystem {
     /// Rank and deduplicate search results (legacy)
     fn rank_and_deduplicate(&self, mut results: Vec<SearchResult>) -> Result<Vec<SearchResult>> {
         // Sort by score descending
-        results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
+        results.sort_by(|a, b| b.score.total_cmp(&a.score));
 
         // Deduplicate by ID
         let mut seen_ids = HashSet::new();

--- a/graphrag-core/src/retrieval/pagerank_retrieval.rs
+++ b/graphrag-core/src/retrieval/pagerank_retrieval.rs
@@ -214,7 +214,7 @@ impl PageRankRetrievalSystem {
         }
 
         // Step 5: Sort by combined score and limit results
-        scored_results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
+        scored_results.sort_by(|a, b| b.score.total_cmp(&a.score));
         scored_results.truncate(max_results);
 
         println!(
@@ -356,7 +356,7 @@ impl PageRankRetrievalSystem {
             }
         }
 
-        results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
+        results.sort_by(|a, b| b.score.total_cmp(&a.score));
         results.truncate(self.max_results);
 
         results
@@ -534,7 +534,7 @@ impl PageRankRetrievalSystem {
         }
 
         // Step 8: Sort by combined score and limit results
-        scored_results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
+        scored_results.sort_by(|a, b| b.score.total_cmp(&a.score));
         scored_results.truncate(max_results);
 
         #[cfg(feature = "tracing")]

--- a/graphrag-core/src/rograg/logic_form.rs
+++ b/graphrag-core/src/rograg/logic_form.rs
@@ -915,7 +915,11 @@ impl LogicFormExecutor {
                             if let Some(pos) = content_lower.find(keyword) {
                                 let start = pos.saturating_sub(20);
                                 let end = (pos + keyword.len() + 20).min(chunk.content.len());
-                                let context = &chunk.content[start..end];
+                                let context = crate::util::text_safe::slice_on_char_boundary(
+                                    &chunk.content,
+                                    start,
+                                    end,
+                                );
 
                                 bindings.push(VariableBinding {
                                     variable: "T".to_string(),
@@ -1125,7 +1129,11 @@ impl LogicFormExecutor {
                                 if let Some(pos) = content_lower.find(keyword) {
                                     let start = pos.saturating_sub(30);
                                     let end = (pos + keyword.len() + 30).min(chunk.content.len());
-                                    let context = &chunk.content[start..end];
+                                    let context = crate::util::text_safe::slice_on_char_boundary(
+                                        &chunk.content,
+                                        start,
+                                        end,
+                                    );
 
                                     bindings.push(VariableBinding {
                                         variable: "C".to_string(),

--- a/graphrag-core/src/rograg/streaming.rs
+++ b/graphrag-core/src/rograg/streaming.rs
@@ -863,7 +863,7 @@ impl SynthesisEngine {
 
         // Sort by confidence and combine
         let mut sorted_results = results.to_vec();
-        sorted_results.sort_by(|a, b| b.confidence.partial_cmp(&a.confidence).unwrap());
+        sorted_results.sort_by(|a, b| b.confidence.total_cmp(&a.confidence));
 
         let content = sorted_results
             .iter()
@@ -899,7 +899,7 @@ impl SynthesisEngine {
     fn synthesize_best_only(&self, results: &[SubqueryResult]) -> Result<SynthesisResult> {
         let best_result = results
             .iter()
-            .max_by(|a, b| a.confidence.partial_cmp(&b.confidence).unwrap())
+            .max_by(|a, b| a.confidence.total_cmp(&b.confidence))
             .ok_or_else(|| StreamingError::SynthesisFailed {
                 reason: "No best result found".to_string(),
             })?;
@@ -972,7 +972,7 @@ impl SynthesisEngine {
     fn synthesize_hierarchical(&self, results: &[SubqueryResult]) -> Result<SynthesisResult> {
         // Sort by confidence and create hierarchical structure
         let mut sorted_results = results.to_vec();
-        sorted_results.sort_by(|a, b| b.confidence.partial_cmp(&a.confidence).unwrap());
+        sorted_results.sort_by(|a, b| b.confidence.total_cmp(&a.confidence));
 
         let mut content_parts = Vec::new();
 

--- a/graphrag-core/src/summarization/mod.rs
+++ b/graphrag-core/src/summarization/mod.rs
@@ -825,7 +825,7 @@ impl DocumentTree {
             .collect();
 
         // Sort by score descending
-        sentence_scores.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+        sentence_scores.sort_by(|a, b| b.1.total_cmp(&a.1));
 
         // Select top sentences up to max_summary_length
         let mut summary = String::new();
@@ -932,7 +932,7 @@ impl DocumentTree {
         }
 
         // Sort by score and return top results
-        results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
+        results.sort_by(|a, b| b.score.total_cmp(&a.score));
         results.truncate(max_results);
 
         Ok(results)

--- a/graphrag-core/src/text/mod.rs
+++ b/graphrag-core/src/text/mod.rs
@@ -54,7 +54,7 @@ pub use chunking_strategies::RustCodeChunkingStrategy;
 use crate::parallel::{ParallelProcessor, PerformanceMonitor};
 use crate::{
     core::{ChunkId, ChunkingStrategy, Document, TextChunk},
-    Result,
+    GraphRAGError, Result,
 };
 use chunking::HierarchicalChunker;
 
@@ -70,8 +70,12 @@ pub struct TextProcessor {
 }
 
 impl TextProcessor {
-    /// Create a new text processor
+    /// Create a new text processor.
+    ///
+    /// Returns an error if `chunk_size == 0` or `chunk_overlap >= chunk_size`,
+    /// either of which would cause the chunking loop to fail to make progress.
     pub fn new(chunk_size: usize, chunk_overlap: usize) -> Result<Self> {
+        Self::validate_chunk_params(chunk_size, chunk_overlap)?;
         Ok(Self {
             chunk_size,
             chunk_overlap,
@@ -82,19 +86,39 @@ impl TextProcessor {
         })
     }
 
-    /// Create a new text processor with parallel processing support
+    /// Create a new text processor with parallel processing support.
+    ///
+    /// Returns an error if `chunk_size == 0` or `chunk_overlap >= chunk_size`.
     #[cfg(feature = "parallel-processing")]
     pub fn with_parallel_processing(
         chunk_size: usize,
         chunk_overlap: usize,
         parallel_processor: ParallelProcessor,
     ) -> Result<Self> {
+        Self::validate_chunk_params(chunk_size, chunk_overlap)?;
         Ok(Self {
             chunk_size,
             chunk_overlap,
             parallel_processor: Some(parallel_processor),
             performance_monitor: PerformanceMonitor::new(),
         })
+    }
+
+    fn validate_chunk_params(chunk_size: usize, chunk_overlap: usize) -> Result<()> {
+        if chunk_size == 0 {
+            return Err(GraphRAGError::Config {
+                message: "chunk_size must be > 0".to_string(),
+            });
+        }
+        if chunk_overlap >= chunk_size {
+            return Err(GraphRAGError::Config {
+                message: format!(
+                    "chunk_overlap ({chunk_overlap}) must be less than chunk_size ({chunk_size}); \
+                     equal or larger overlap causes the chunker to make no forward progress",
+                ),
+            });
+        }
+        Ok(())
     }
 
     /// Split text into chunks with overlap using hierarchical boundary preservation
@@ -637,5 +661,32 @@ mod tests {
         assert!(!chunks.is_empty());
         // Verify metadata is present
         assert!(chunks.iter().any(|c| !c.metadata.keywords.is_empty()));
+    }
+
+    // Regression test for #19: chunker hung forever when overlap >= chunk_size
+    // because next_start <= start on every iteration. Now rejected at construction.
+    #[test]
+    fn rejects_overlap_equal_to_chunk_size() {
+        let err = TextProcessor::new(256, 256).unwrap_err();
+        assert!(
+            matches!(err, GraphRAGError::Config { .. }),
+            "expected GraphRAGError::Config, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_overlap_greater_than_chunk_size() {
+        assert!(TextProcessor::new(100, 200).is_err());
+    }
+
+    #[test]
+    fn rejects_zero_chunk_size() {
+        assert!(TextProcessor::new(0, 0).is_err());
+    }
+
+    #[test]
+    fn accepts_overlap_less_than_chunk_size() {
+        assert!(TextProcessor::new(256, 64).is_ok());
+        assert!(TextProcessor::new(100, 0).is_ok());
     }
 }

--- a/graphrag-core/src/util/mod.rs
+++ b/graphrag-core/src/util/mod.rs
@@ -1,0 +1,3 @@
+//! Small, dependency-free utility helpers shared across the crate.
+
+pub mod text_safe;

--- a/graphrag-core/src/util/text_safe.rs
+++ b/graphrag-core/src/util/text_safe.rs
@@ -1,0 +1,108 @@
+//! UTF-8-safe string helpers.
+//!
+//! Slicing a `&str` by byte index panics with `byte index N is not a char
+//! boundary` when N falls inside a multi-byte UTF-8 codepoint. These helpers
+//! clamp byte offsets to the nearest preceding char boundary so that user
+//! and LLM-supplied text containing emoji, accented characters, or CJK
+//! cannot crash the caller.
+
+/// Truncate `s` to at most `max_bytes` bytes, clamping back to a UTF-8
+/// char boundary so the returned slice is always valid.
+///
+/// Returns the original string when it is already shorter than `max_bytes`.
+pub fn truncate_chars(s: &str, max_bytes: usize) -> &str {
+    let mut end = max_bytes.min(s.len());
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
+/// Slice `s` from byte index `start` to byte index `end`, clamping each
+/// endpoint backward to the nearest UTF-8 char boundary.
+///
+/// Useful when both endpoints are derived from arithmetic
+/// (e.g. `pos.saturating_sub(N)` and `pos + N`) where neither is
+/// guaranteed to land on a codepoint boundary even if `pos` itself does.
+/// Returns an empty slice when `start >= end`.
+pub fn slice_on_char_boundary(s: &str, start: usize, end: usize) -> &str {
+    let mut start = start.min(s.len());
+    let mut end = end.min(s.len());
+    if start >= end {
+        return "";
+    }
+    while start > 0 && !s.is_char_boundary(start) {
+        start -= 1;
+    }
+    while end > start && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[start..end]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_returns_full_string_when_shorter_than_max() {
+        assert_eq!(truncate_chars("hello", 100), "hello");
+    }
+
+    #[test]
+    fn truncate_clamps_to_char_boundary_inside_multi_byte_codepoint() {
+        // The crab emoji (🦀) is 4 bytes (U+1F980). max_bytes=8 lands inside
+        // the second emoji's codepoint.
+        let s = "héllo🦀world"; // 'é' = 2 bytes, "🦀" = 4 bytes
+        let truncated = truncate_chars(s, 8);
+        // Must not panic and must produce valid UTF-8.
+        assert_eq!(truncated, "héllo");
+    }
+
+    #[test]
+    fn truncate_at_exact_boundary_preserves_codepoint() {
+        let s = "🦀abc";
+        assert_eq!(truncate_chars(s, 4), "🦀");
+    }
+
+    #[test]
+    fn truncate_zero_length_returns_empty() {
+        assert_eq!(truncate_chars("héllo", 0), "");
+    }
+
+    #[test]
+    fn truncate_handles_pure_ascii() {
+        assert_eq!(truncate_chars("abcdefghij", 5), "abcde");
+    }
+
+    #[test]
+    fn slice_on_char_boundary_clamps_both_endpoints() {
+        let s = "héllo🦀world";
+        // Bytes: h=1, é=2, l=1, l=1, o=1, 🦀=4, w=1...
+        // Char boundaries at byte offsets: 0,1,3,4,5,6,10,11,...
+        // start=2 lands inside é → clamps back to 1 (boundary before é).
+        // end=8 lands inside 🦀 (bytes 6..10) → clamps back to 6.
+        // Resulting slice [1..6] = "éllo".
+        let snip = slice_on_char_boundary(s, 2, 8);
+        assert_eq!(snip, "éllo");
+    }
+
+    #[test]
+    fn slice_on_char_boundary_clamps_when_only_end_is_inside_codepoint() {
+        let s = "abc🦀def";
+        // start=0 (boundary), end=5 (mid-🦀, bytes 3..7) → clamps back to 3.
+        assert_eq!(slice_on_char_boundary(s, 0, 5), "abc");
+    }
+
+    #[test]
+    fn slice_on_char_boundary_caps_at_string_length() {
+        let s = "abc";
+        assert_eq!(slice_on_char_boundary(s, 0, 100), "abc");
+    }
+
+    #[test]
+    fn slice_on_char_boundary_returns_empty_when_start_past_end() {
+        let s = "abc";
+        assert_eq!(slice_on_char_boundary(s, 5, 1), "");
+    }
+}

--- a/graphrag-core/src/vector/mod.rs
+++ b/graphrag-core/src/vector/mod.rs
@@ -179,7 +179,7 @@ impl VectorIndex {
             }
 
             // Sort by similarity (highest first) and take top_k
-            scored_results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+            scored_results.sort_by(|a, b| b.1.total_cmp(&a.1));
             scored_results.truncate(top_k);
 
             Ok(scored_results)

--- a/graphrag-core/tests/nan_safe_sort.rs
+++ b/graphrag-core/tests/nan_safe_sort.rs
@@ -1,0 +1,27 @@
+//! Regression test for #15: workspace-wide replacement of
+//! `partial_cmp(...).unwrap()` with `total_cmp(...)`.
+//!
+//! Verifies that sorting f32/f64 vectors that contain NaN does not panic.
+//! Previously the bare `.unwrap()` on `partial_cmp` returned `None` on NaN
+//! and crashed the request thread.
+
+#[test]
+fn total_cmp_does_not_panic_on_nan_f32() {
+    let mut values: Vec<f32> = vec![3.0, f32::NAN, 1.0, 2.0, f32::NAN];
+    values.sort_by(|a, b| a.total_cmp(b));
+    assert_eq!(values.len(), 5);
+}
+
+#[test]
+fn total_cmp_does_not_panic_on_nan_f64() {
+    let mut values: Vec<f64> = vec![3.0, f64::NAN, 1.0, 2.0, f64::NAN];
+    values.sort_by(|a, b| a.total_cmp(b));
+    assert_eq!(values.len(), 5);
+}
+
+#[test]
+fn total_cmp_orders_normally_when_no_nan() {
+    let mut values: Vec<f32> = vec![3.0, 1.0, 2.0];
+    values.sort_by(|a, b| b.total_cmp(a));
+    assert_eq!(values, vec![3.0, 2.0, 1.0]);
+}

--- a/graphrag-core/tests/utf8_safe_truncation.rs
+++ b/graphrag-core/tests/utf8_safe_truncation.rs
@@ -1,0 +1,59 @@
+//! Regression test for #20: byte-range string slicing panics on multi-byte UTF-8.
+//!
+//! Previously the workspace had ~12 sites that did things like
+//! `&content[..200]` or `&s[..s.len().min(N)]`. When N landed inside a
+//! multi-byte codepoint (any document with emoji, accented characters, or
+//! CJK at the wrong offset) the slice panicked with "byte index N is not a
+//! char boundary". The two helpers in `graphrag_core::util::text_safe`
+//! clamp back to the nearest preceding char boundary.
+
+use graphrag_core::util::text_safe::{slice_on_char_boundary, truncate_chars};
+
+#[test]
+fn truncate_does_not_panic_when_max_lands_inside_emoji() {
+    // The crab emoji 🦀 is 4 bytes (U+1F980).
+    let s = "abc🦀def";
+    // Bytes: 'a'(1) 'b'(1) 'c'(1) 🦀(4) 'd'(1) 'e'(1) 'f'(1) — total 10.
+    // max_bytes = 5 lands inside the emoji (between bytes 4 and 7).
+    let truncated = truncate_chars(s, 5);
+    // Must not panic and must produce valid UTF-8.
+    assert_eq!(truncated, "abc");
+}
+
+#[test]
+fn truncate_does_not_panic_on_cjk_text() {
+    // 中 is 3 bytes in UTF-8.
+    let s = "hello 中文 world";
+    for n in 0..s.len() {
+        // None of these may panic, regardless of where N falls.
+        let _ = truncate_chars(s, n);
+    }
+}
+
+#[test]
+fn slice_on_char_boundary_handles_arithmetic_endpoints() {
+    // Mimics the usage in inference.rs / rograg/logic_form.rs:
+    //   start = pos.saturating_sub(N); end = (pos + len + N).min(content.len())
+    // Either may land mid-codepoint. The helper must clamp.
+    let content = "前文 keyword 後文 emoji 🎉 trailing";
+    let pattern = "keyword";
+    let pos = content.find(pattern).unwrap();
+    let start = pos.saturating_sub(5);
+    let end = (pos + pattern.len() + 5).min(content.len());
+
+    let context = slice_on_char_boundary(content, start, end);
+    assert!(context.contains("keyword"));
+}
+
+#[test]
+fn helpers_are_safe_under_aggressive_fuzz() {
+    // Sweep all possible (start, end) pairs against a multi-byte string.
+    // Any panic would fail the test.
+    let s = "a中b🦀c";
+    for start in 0..=s.len() + 2 {
+        for end in 0..=s.len() + 2 {
+            let _ = slice_on_char_boundary(s, start, end);
+        }
+        let _ = truncate_chars(s, start);
+    }
+}

--- a/graphrag-server/src/handlers.rs
+++ b/graphrag-server/src/handlers.rs
@@ -582,7 +582,7 @@ fn query_collection(
         })
         .collect();
 
-    results.sort_by(|a, b| b.similarity.partial_cmp(&a.similarity).unwrap());
+    results.sort_by(|a, b| b.similarity.total_cmp(&a.similarity));
     results.iter_mut().enumerate().for_each(|(i, r)| r.rank = i + 1);
     results.truncate(top_k);
 
@@ -608,7 +608,7 @@ fn apply_rrf(result_sets: Vec<Vec<QueryResult>>, top_k: usize) -> Vec<QueryResul
     }
 
     let mut merged: Vec<(String, f32)> = rrf_scores.into_iter().collect();
-    merged.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+    merged.sort_by(|a, b| b.1.total_cmp(&a.1));
 
     merged
         .into_iter()
@@ -626,7 +626,7 @@ fn apply_rrf(result_sets: Vec<Vec<QueryResult>>, top_k: usize) -> Vec<QueryResul
 fn concat_results(result_sets: Vec<Vec<QueryResult>>, top_k: usize) -> Vec<QueryResult> {
     let mut all_results: Vec<QueryResult> = result_sets.into_iter().flatten().collect();
 
-    all_results.sort_by(|a, b| b.similarity.partial_cmp(&a.similarity).unwrap());
+    all_results.sort_by(|a, b| b.similarity.total_cmp(&a.similarity));
     all_results.iter_mut().enumerate().for_each(|(i, r)| r.rank = i + 1);
     all_results.truncate(top_k);
 

--- a/graphrag-server/src/main.rs
+++ b/graphrag-server/src/main.rs
@@ -436,7 +436,7 @@ async fn query(
         .filter(|r| r.similarity > 0.5)
         .collect();
 
-    results.sort_by(|a, b| b.similarity.partial_cmp(&a.similarity).unwrap());
+    results.sort_by(|a, b| b.similarity.total_cmp(&a.similarity));
     results.truncate(body.top_k);
 
     let processing_time = start.elapsed().as_millis() as u64;

--- a/graphrag-server/src/main.rs
+++ b/graphrag-server/src/main.rs
@@ -371,7 +371,15 @@ async fn query(
                         title: r.metadata.title,
                         similarity: r.score,
                         excerpt: if r.metadata.text.len() > 200 {
-                            format!("{}...", &r.metadata.text[..200])
+                            // Clamp to UTF-8 char boundary so multi-byte input
+                            // (emoji, accented characters, CJK) doesn't panic.
+                            format!(
+                                "{}...",
+                                graphrag_core::util::text_safe::truncate_chars(
+                                    &r.metadata.text,
+                                    200
+                                )
+                            )
                         } else {
                             r.metadata.text
                         },
@@ -421,7 +429,10 @@ async fn query(
                 };
 
             let excerpt = if doc.content.len() > 200 {
-                format!("{}...", &doc.content[..200])
+                format!(
+                    "{}...",
+                    graphrag_core::util::text_safe::truncate_chars(&doc.content, 200)
+                )
             } else {
                 doc.content.clone()
             };

--- a/graphrag-server/src/main_axum_old.rs
+++ b/graphrag-server/src/main_axum_old.rs
@@ -529,7 +529,7 @@ async fn query(
         .filter(|r| r.similarity > 0.5)
         .collect();
 
-    results.sort_by(|a, b| b.similarity.partial_cmp(&a.similarity).unwrap());
+    results.sort_by(|a, b| b.similarity.total_cmp(&a.similarity));
     results.truncate(req.top_k);
 
     let processing_time = start.elapsed().as_millis() as u64;

--- a/graphrag-server/src/main_backup.rs
+++ b/graphrag-server/src/main_backup.rs
@@ -271,7 +271,7 @@ async fn query(
         .collect();
 
     // Sort by similarity
-    results.sort_by(|a, b| b.similarity.partial_cmp(&a.similarity).unwrap());
+    results.sort_by(|a, b| b.similarity.total_cmp(&a.similarity));
     results.truncate(req.top_k);
 
     let processing_time = start.elapsed().as_millis() as u64;


### PR DESCRIPTION
## Summary

Implements Phases 0–2 of [FIX-PLAN.md](https://github.com/mfaulk/graphrag-rs/blob/worktree-composed-cuddling-dragonfly/FIX-PLAN.md) — closes 7 issues from the recent code-review batch with regression tests on every fix.

| Commit | Issue | Effect |
|---|---|---|
| `e97b350` | #65 | Examples & one test compile; `cargo check --all-targets` exits 0 |
| `2f97cbb` | #18 | `peak_memory_usage` lost-update race fixed via `fetch_max`; 2 tests added |
| `404126e` | #17 | Unsound `unsafe` in `ServiceContext::get` removed; 5 registry tests still pass |
| `66a6319` | #19 | Chunker rejects `overlap >= chunk_size` at construction; 4 tests |
| `45b8a3d` | #14 | Pagination DoS fixed (`page=0`/`page_size=0` → 400 BadRequest); 4 tests |
| `48806ee` | #15 | 39 NaN-panic sites replaced with `total_cmp` workspace-wide; 3 tests |
| `3632960` | #20 | 12 UTF-8 byte-slicing sites use clamping helpers; 13 tests |

**Net safety improvement**: ~50+ panic sites eliminated, plus one lost-update race and one unsoundness in DI registry — the highest-leverage cluster identified by FIX-PLAN's prioritization.

Each commit follows Conventional Commits, includes a `Fixes: #NN` footer, and passes its regression tests in isolation.

Closes #14
Closes #15
Closes #17
Closes #18
Closes #19
Closes #20
Closes #65

## Test plan

- [x] `cargo check --workspace --all-targets` exits 0
- [x] `cargo test --workspace --lib --exclude graphrag-wasm` — 569/569 pass (32 pre-existing ignored from `ddd4501`)
- [x] `cargo test -p graphrag-core --test nan_safe_sort` — 3/3 pass (NaN sorting no longer panics)
- [x] `cargo test -p graphrag-core --test utf8_safe_truncation` — 4/4 pass (sweep over multi-byte string with all `(start, end)` pairs)
- [ ] Pre-existing failures in `graphrag-wasm` (`components::force_layout::tests::test_add_edges`, `test_add_nodes`) untouched by this PR — confirmed identical on `main`
- [ ] CI green (build, test, fmt, clippy)

## Out of scope

- Phases 3–7 of FIX-PLAN (remaining 18 High-severity issues plus 28 Medium-severity issues). They will be tackled in follow-up PRs.
- The `graphrag-core/src/api/handlers.rs` regression tests are gated behind `--features api`, which has 15 pre-existing compile errors unrelated to this PR. The validation logic itself is correct; tests will run once the `api` feature compiles.