### PR TITLE
refactor(core): Group H — locking-strategy hardening (#29 partial)

### DIFF
--- a/graphrag-core/src/entity/gliner_extractor.rs
+++ b/graphrag-core/src/entity/gliner_extractor.rs
@@ -14,7 +14,7 @@ use gliner::model::{
     pipeline::{relation::RelationPipeline, span::SpanPipeline, token::TokenPipeline},
 };
 use orp::{model::Model, params::RuntimeParameters, pipeline::Pipeline};
-use parking_lot::RwLock;
+use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::sync::Arc;
 
 use crate::{
@@ -78,10 +78,24 @@ impl GLiNERExtractor {
             .to_string()
     }
 
-    /// Ensure the ONNX model is loaded, loading it if necessary.
-    fn ensure_model_loaded(&self) -> Result<(), GraphRAGError> {
-        let mut guard = self.model.write();
-        if guard.is_none() {
+    /// Return a read guard on the loaded model, loading it lazily if needed.
+    ///
+    /// Atomic against TOCTOU: the read guard returned here is held by the
+    /// caller for the entire extraction. Callers that previously called
+    /// `ensure_model_loaded` followed by a fresh `model.read()` could observe
+    /// `None` if a future "unload model" path were added between the two
+    /// acquisitions. Returning the guard from one call closes that window.
+    fn read_or_load_model(&self) -> Result<RwLockReadGuard<'_, Option<Model>>, GraphRAGError> {
+        // Fast path: model already loaded — take a read guard and return it.
+        let read_guard = self.model.read();
+        if read_guard.is_some() {
+            return Ok(read_guard);
+        }
+        drop(read_guard);
+
+        // Slow path: take a write guard, load if still needed, then downgrade.
+        let mut write_guard = self.model.write();
+        if write_guard.is_none() {
             #[allow(unused_mut)]
             let mut rt_params = RuntimeParameters::default();
             if self.config.use_gpu {
@@ -97,9 +111,9 @@ impl GLiNERExtractor {
                     message: format!("Failed to load GLiNER model: {e}"),
                 }
             })?;
-            *guard = Some(model);
+            *write_guard = Some(model);
         }
-        Ok(())
+        Ok(RwLockWriteGuard::downgrade(write_guard))
     }
 
     /// Perform joint NER + RE on a single text chunk (synchronous / blocking).
@@ -116,10 +130,10 @@ impl GLiNERExtractor {
         &self,
         chunk: &TextChunk,
     ) -> Result<(Vec<Entity>, Vec<Relationship>), GraphRAGError> {
-        self.ensure_model_loaded()?;
-
-        let guard = self.model.read();
-        let model = guard.as_ref().expect("model loaded");
+        let guard = self.read_or_load_model()?;
+        let model = guard
+            .as_ref()
+            .expect("read_or_load_model guarantees Some on success");
         let tokenizer = Self::resolve_tokenizer_path(&self.config);
         let params = Parameters::default();
 

--- a/graphrag-core/src/monitoring/metrics_collector.rs
+++ b/graphrag-core/src/monitoring/metrics_collector.rs
@@ -155,10 +155,16 @@ impl AsyncMetricsCollector for MetricsCollector {
         }
 
         let key = Self::metric_key(name, tags);
-        let gauge = self
-            .gauges
-            .entry(key)
-            .or_insert_with(|| Arc::new(std::sync::RwLock::new(0.0)));
+        // Clone the Arc out of the DashMap entry so the shard RefMut is dropped
+        // before we take the inner RwLock — preventing any future maintainer who
+        // turns this body genuinely async from holding a sync DashMap lock across
+        // an inner-lock acquisition.
+        let gauge = Arc::clone(
+            &self
+                .gauges
+                .entry(key)
+                .or_insert_with(|| Arc::new(std::sync::RwLock::new(0.0))),
+        );
 
         *gauge.write().unwrap() = value;
     }
@@ -169,10 +175,12 @@ impl AsyncMetricsCollector for MetricsCollector {
         }
 
         let key = Self::metric_key(name, tags);
-        let hist = self
-            .histograms
-            .entry(key)
-            .or_insert_with(|| Arc::new(std::sync::RwLock::new(Vec::new())));
+        let hist = Arc::clone(
+            &self
+                .histograms
+                .entry(key)
+                .or_insert_with(|| Arc::new(std::sync::RwLock::new(Vec::new()))),
+        );
 
         hist.write().unwrap().push(value);
     }


### PR DESCRIPTION
## Summary

Group **K4** from the parallel-fix dispatch — two of the three sub-items in #29. Both are "safe today, fragile under maintenance" cleanups in disjoint files.

| Commit | Sub-item | Effect |
|---|---|---|
| \`04f1ec9\` | #29 item 2 (\`metrics_collector.rs\`) | \`gauge\`/\`histogram\` now clone the \`Arc<RwLock<_>>\` out of the \`DashMap\` entry before taking the inner lock — drops the shard \`RefMut\` first so a future maintainer who turns these bodies genuinely async can't introduce a sync-lock-across-await deadlock |
| \`47a6a04\` | #29 item 3 (\`gliner_extractor.rs\`) | Replace \`ensure_model_loaded\` (which released its write guard) followed by a fresh \`self.model.read()\` with a single \`read_or_load_model\` that returns the read guard. Closes the TOCTOU window between load and use — atomic against any future "unload model" feature |

## What's NOT here

**#29 item 1** — \`EnhancedToolRegistry::get_function_caller(&self) -> Arc<Mutex<FunctionCaller>>\` leaking the locking strategy through the public API — is **not** included. The change is a public-API one (the issue suggests \`with_caller<R>(&self, f: impl FnOnce(&mut FunctionCaller) -> R) -> R\`, which is a breaking signature change). Worth its own PR with explicit deprecation strategy. Issue #29 stays open until that lands.

## Test plan

- [x] \`cargo build --workspace --exclude graphrag_py --exclude graphrag-wasm\` — clean (matches pre-push hook)
- [x] \`cargo check -p graphrag-core --features gliner\` — clean (validates the gliner-gated module)
- [x] \`cargo test -p graphrag-core --lib monitoring\` — 4 passed (existing coverage)
- [x] \`cargo fmt --all -- --check\` — clean
- [ ] CI green

## Test rationale

No new regression tests added. The metrics fix is a pure invariant strengthening (drop a held guard sooner) with no observable behavior change at the unit level — the bug shape it prevents requires a future \`.await\` insertion that doesn't exist yet. The gliner fix is similarly pre-emptive: the TOCTOU window only matters once an unload path exists. Adding a unit test today would only assert "it still works in the common path", which existing call-site coverage already does.

A meaningful regression test for the gliner TOCTOU would need a real ONNX model (\`gline-rs\` v1.0.1), which is too heavy for CI; the code path is exercised by integration when \`--features gliner\` runs against a real model.

## Out of scope

- #29 item 1 (registry public API) — follow-up
- README updates — none needed; no public-API or workflow changes
- Auditing other \`async fn\` bodies for the same shard-RefMut pattern (there is one — could be a separate sweep)