### PR TITLE
fix(core): Group I — feature-flag hygiene (#3, partial #10)

### DIFF
--- a/graphrag-core/Cargo.toml
+++ b/graphrag-core/Cargo.toml
@@ -22,10 +22,26 @@ default = [
 # FEATURE BUNDLES - Simplified feature selection for common use cases
 # =============================================================================
 # Use these bundles instead of manually selecting individual features:
+#   cargo add graphrag-core --features minimal    # Smallest dep tree (custom backends)
 #   cargo add graphrag-core --features starter    # Quick start for new users
 #   cargo add graphrag-core --features full       # Production-ready setup
 #   cargo add graphrag-core --features wasm       # Browser/WASM deployment
 #   cargo add graphrag-core --features research   # Advanced research features
+#
+# Heavy transitive deps live behind opt-in features:
+#   persistent-storage / lancedb -> arrow + parquet (~25 crates, slow build)
+#   gliner                       -> gline-rs + ort + onnx (~40 crates, slow build)
+#   neural-embeddings / huggingface-hub -> candle + hf-hub (~50 crates, slow build)
+#   research / rograg            -> heavy CPU-side analytics deps
+# Stick to `minimal` or `starter` if you only need GraphRAG types + a custom
+# chat backend.
+
+## Minimal Bundle - Smallest dep tree for downstream crates with custom backends
+## Includes: async runtime, in-memory graph store, basic retrieval — nothing else
+## Best for: consumer crates that only want the GraphRAG type, Config,
+##           KnowledgeGraph, and ChatBackend trait. No HTTP client, no Ollama,
+##           no parallel processing, no parquet/arrow/gliner/candle.
+minimal = ["async", "memory-storage", "basic-retrieval"]
 
 ## Starter Bundle - Minimal setup for getting started quickly
 ## Includes: async runtime, Ollama LLM, memory storage, basic retrieval

--- a/graphrag-core/src/retrieval/mod.rs
+++ b/graphrag-core/src/retrieval/mod.rs
@@ -810,35 +810,36 @@ impl RetrievalSystem {
         Ok(())
     }
 
-    /// Parallel batch query processing with optimized workload distribution
-    /// Batch process multiple queries efficiently
+    /// Batch process multiple queries efficiently.
+    ///
+    /// With the `parallel-processing` feature, dispatches via the configured
+    /// `ParallelProcessor`. Without it, falls back to a plain sequential
+    /// hybrid-query loop.
     pub async fn batch_query(
         &mut self,
         queries: &[&str],
         graph: &KnowledgeGraph,
     ) -> Result<Vec<Vec<SearchResult>>> {
-        let processor =
-            self.parallel_processor
-                .as_ref()
-                .ok_or_else(|| crate::core::GraphRAGError::Config {
-                    message: "Parallel processor not initialized".to_string(),
-                })?;
-
-        if !processor.should_use_parallel(queries.len()) {
-            // Use sequential processing for small batches
-            let mut results = Vec::new();
-            for &query in queries {
-                results.push(self.hybrid_query(query, graph).await?);
-            }
-            return Ok(results);
-        }
-
         #[cfg(feature = "parallel-processing")]
         {
-            // For parallel query processing, we need to work around the borrowing limitations
-            // of the embedding generator. We'll use enhanced sequential processing with
-            // better monitoring and chunking for now.
+            let processor = self.parallel_processor.as_ref().ok_or_else(|| {
+                crate::core::GraphRAGError::Config {
+                    message: "Parallel processor not initialized".to_string(),
+                }
+            })?;
 
+            if !processor.should_use_parallel(queries.len()) {
+                // Use sequential processing for small batches
+                let mut results = Vec::new();
+                for &query in queries {
+                    results.push(self.hybrid_query(query, graph).await?);
+                }
+                return Ok(results);
+            }
+
+            // For parallel query processing, we need to work around the borrowing
+            // limitations of the embedding generator. We use enhanced sequential
+            // processing with better monitoring and chunking for now.
             let chunk_size = processor.config().chunk_batch_size.min(queries.len());
             tracing::debug!(
                 "Processing {} queries with enhanced sequential approach (chunk size: {})",


### PR DESCRIPTION
## Summary

Group **O1** from the parallel-fix dispatch — fixes a real compile error and improves the documented opt-in story for downstream crates with custom backends.

| Commit | Issue | Effect |
|---|---|---|
| \`9156e15\` | #3 | \`batch_query\` referenced \`self.parallel_processor\` outside any cfg gate. Restructure to wrap the parallel path in \`#[cfg(feature = "parallel-processing")]\` and the existing \`#[cfg(not(...))]\` fallback as the sequential branch. Public signature unchanged. |
| \`89860a7\` | partial #10 | Add a documented \`minimal = ["async", "memory-storage", "basic-retrieval"]\` bundle and expand the Cargo.toml docblock to call out which features pull in heavy transitive deps (arrow+parquet, gline-rs+ort, candle+hf-hub). |

Closes #3

## Repro for #3 (now passes)

\`\`\`bash
cargo build -p graphrag-core --no-default-features \\
  --features async,ollama,memory-storage,basic-retrieval,ureq
\`\`\`

Before this PR: \`error[E0609]: no field 'parallel_processor' on type '&mut RetrievalSystem'\`
After this PR: clean build.

## Why #10 stays open

Only the \`minimal\` bundle half is addressed. The "minimal builds in <15 s on a clean machine" target from the issue depends on per-machine factors and a full audit of optional deps; tighter bounds (e.g. dropping \`tokio\`'s default features, splitting heavier traits into separate features) would justify their own PR with measurements. The new bundle gives consumers a clear opt-in for "GraphRAG type + ChatBackend trait, nothing else" today; further dep-tree slimming can iterate from there.

## Test plan

- [x] \`cargo build -p graphrag-core --no-default-features --features async,ollama,memory-storage,basic-retrieval,ureq\` — clean (the failing repro from #3)
- [x] \`cargo build -p graphrag-core --no-default-features --features minimal\` — clean
- [x] \`cargo build --workspace --exclude graphrag_py --exclude graphrag-wasm\` — clean (matches pre-push hook)
- [x] \`cargo fmt --all -- --check\` — clean
- [ ] CI green

## Test rationale

#3 is verified by the repro — the same command-line that previously errored now exits 0. Adding a \`#[test]\` for "this combination of features compiles" isn't a thing in Cargo's test model; the build itself is the test. A CI matrix entry covering the minimal bundle would be a useful follow-up.

## Out of scope

- Tighter dep-tree slimming for #10 (e.g. tokio default-feature trimming, splitting heavyweight traits into smaller features). Worth a measured follow-up.
- README updates: the existing README documents bundles in the same place this Cargo.toml comment block lives. The \`minimal\` bundle is mentioned in the Cargo.toml docblock; a README sweep for bundle docs would be its own doc PR.