### PR TITLE
fix(server): Group K — config layer thiserror migration + spawn_blocking init (#47, #48)

### DIFF
--- a/graphrag-server/src/config_endpoints.rs
+++ b/graphrag-server/src/config_endpoints.rs
@@ -3,9 +3,26 @@
 //! These endpoints allow dynamic configuration of the GraphRAG pipeline via JSON REST API
 
 use super::{config_handler, AppState};
+use crate::config_handler::ConfigError;
 use crate::models::ApiError;
 use actix_web::web::{Data, Json};
 use serde_json::json;
+
+/// Map [`ConfigError`] to the right [`ApiError`] variant for the HTTP boundary.
+///
+/// Parse and validation errors are both client errors (400) but with distinct
+/// shapes. NotSet is a 404 for read endpoints.
+fn config_error_to_api(err: ConfigError) -> ApiError {
+    match err {
+        ConfigError::Parse(e) => ApiError::BadRequest(format!("Invalid JSON: {}", e)),
+        ConfigError::Validation(errors) => {
+            ApiError::BadRequest(format!("Configuration validation failed: {:?}", errors))
+        },
+        ConfigError::NotSet => ApiError::NotFound(
+            "No configuration set. Use POST /api/config to initialize.".to_string(),
+        ),
+    }
+}
 
 /// GET /api/config - Get current configuration
 pub async fn get_config(state: Data<AppState>) -> Result<Json<serde_json::Value>, ApiError> {
@@ -15,19 +32,20 @@ pub async fn get_config(state: Data<AppState>) -> Result<Json<serde_json::Value>
         ));
     }
 
-    match state.config_manager.to_json().await {
-        Ok(config_json) => {
-            let config: serde_json::Value = serde_json::from_str(&config_json)
-                .map_err(|e| ApiError::InternalError(e.to_string()))?;
+    let config_json = state
+        .config_manager
+        .to_json()
+        .await
+        .map_err(config_error_to_api)?;
 
-            Ok(Json(json!({
-                "success": true,
-                "config": config,
-                "graphrag_initialized": state.graphrag.read().await.is_some()
-            })))
-        },
-        Err(e) => Err(ApiError::InternalError(e)),
-    }
+    let config: serde_json::Value =
+        serde_json::from_str(&config_json).map_err(|e| ApiError::InternalError(e.to_string()))?;
+
+    Ok(Json(json!({
+        "success": true,
+        "config": config,
+        "graphrag_initialized": state.graphrag.read().await.is_some()
+    })))
 }
 
 /// POST /api/config - Set configuration and initialize GraphRAG
@@ -46,7 +64,7 @@ pub async fn set_config(
         .config_manager
         .set_from_json(&config_json)
         .await
-        .map_err(|e| ApiError::BadRequest(e))?;
+        .map_err(config_error_to_api)?;
 
     // Get the validated config
     let config = state
@@ -55,17 +73,28 @@ pub async fn set_config(
         .await
         .ok_or(ApiError::InternalError("Failed to get config".to_string()))?;
 
-    // Initialize GraphRAG with the config
+    // Initialize GraphRAG with the config.
+    //
+    // `GraphRAG::new` and `initialize` are CPU/IO-bound sync calls that can
+    // take several seconds (loading embedding models, scanning workspace).
+    // Run them on the blocking pool so we don't park an async worker for
+    // the duration — every other handler that does
+    // `state.graphrag.read().await` would queue behind a parked worker.
     tracing::info!("Initializing GraphRAG with custom configuration...");
+    let graphrag = tokio::task::spawn_blocking(
+        move || -> Result<graphrag_core::GraphRAG, graphrag_core::GraphRAGError> {
+            let mut g = graphrag_core::GraphRAG::new(config)?;
+            g.initialize()?;
+            Ok(g)
+        },
+    )
+    .await
+    .map_err(|join_err| {
+        ApiError::InternalError(format!("GraphRAG init task panicked: {}", join_err))
+    })?
+    .map_err(|e| ApiError::InternalError(format!("GraphRAG initialization failed: {}", e)))?;
 
-    let mut graphrag = graphrag_core::GraphRAG::new(config)
-        .map_err(|e| ApiError::InternalError(format!("GraphRAG init failed: {}", e)))?;
-
-    graphrag
-        .initialize()
-        .map_err(|e| ApiError::InternalError(format!("GraphRAG initialization failed: {}", e)))?;
-
-    // Store the initialized GraphRAG
+    // Store the initialized GraphRAG (write lock is taken only for the swap)
     *state.graphrag.write().await = Some(graphrag);
 
     tracing::info!("✅ GraphRAG initialized successfully with custom configuration");

--- a/graphrag-server/src/config_handler.rs
+++ b/graphrag-server/src/config_handler.rs
@@ -10,6 +10,23 @@ use serde_json;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
+/// Errors produced by [`ConfigManager`].
+///
+/// Distinguishing parse from validation lets the API handler boundary map each
+/// case to the right HTTP status (both BadRequest, but the body shape differs)
+/// and lets future callers programmatically branch on the failure mode.
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigError {
+    #[error("failed to parse JSON: {0}")]
+    Parse(#[from] serde_json::Error),
+
+    #[error("configuration validation failed: {0:?}")]
+    Validation(Vec<String>),
+
+    #[error("no configuration set")]
+    NotSet,
+}
+
 /// Server configuration state
 #[derive(Clone)]
 pub struct ConfigManager {
@@ -29,16 +46,15 @@ impl ConfigManager {
     }
 
     /// Set configuration from JSON
-    pub async fn set_from_json(&self, json_str: &str) -> Result<(), String> {
-        // Parse JSON into Config
-        let config: Config =
-            serde_json::from_str(json_str).map_err(|e| format!("Failed to parse JSON: {}", e))?;
+    pub async fn set_from_json(&self, json_str: &str) -> Result<(), ConfigError> {
+        // Parse JSON into Config — `?` lifts serde_json::Error via #[from]
+        let config: Config = serde_json::from_str(json_str)?;
 
         // Validate configuration
         let errors = self.validate_config(&config).await;
         if !errors.is_empty() {
             *self.validation_errors.write().await = errors.clone();
-            return Err(format!("Configuration validation failed: {:?}", errors));
+            return Err(ConfigError::Validation(errors));
         }
 
         // Store configuration
@@ -95,12 +111,11 @@ impl ConfigManager {
     }
 
     /// Convert Config to JSON string
-    pub async fn to_json(&self) -> Result<String, String> {
+    pub async fn to_json(&self) -> Result<String, ConfigError> {
         let config = self.config.read().await;
         match config.as_ref() {
-            Some(cfg) => serde_json::to_string_pretty(cfg)
-                .map_err(|e| format!("Failed to serialize config: {}", e)),
-            None => Err("No configuration set".to_string()),
+            Some(cfg) => Ok(serde_json::to_string_pretty(cfg)?),
+            None => Err(ConfigError::NotSet),
         }
     }
 
@@ -369,5 +384,63 @@ mod tests {
         let json = serde_json::to_string(&invalid_config).unwrap();
         let result = manager.set_from_json(&json).await;
         assert!(result.is_err());
+    }
+
+    // Malformed JSON should produce a typed Parse error, not a freeform String
+    // (regression for #47: callers can now branch on the failure mode).
+    #[tokio::test]
+    async fn set_from_json_returns_parse_variant_on_malformed_input() {
+        let manager = ConfigManager::new();
+        let err = manager
+            .set_from_json("{not valid json")
+            .await
+            .expect_err("malformed JSON should error");
+        match err {
+            ConfigError::Parse(_) => {},
+            other => panic!("expected ConfigError::Parse, got: {other:?}"),
+        }
+    }
+
+    // A well-formed Config that fails semantic validation should produce a
+    // Validation variant carrying the structured error list. Build the JSON
+    // from the defaults so we exercise the validation path rather than
+    // tripping a missing-field parse error.
+    #[tokio::test]
+    async fn set_from_json_returns_validation_variant_with_error_list() {
+        let manager = ConfigManager::new();
+        let mut value: serde_json::Value =
+            serde_json::from_str(&ConfigManager::default_config_json())
+                .expect("default config JSON should parse");
+        value["chunk_size"] = serde_json::json!(0);
+        let json = serde_json::to_string(&value).unwrap();
+
+        let err = manager
+            .set_from_json(&json)
+            .await
+            .expect_err("zero chunk_size should fail validation");
+        match err {
+            ConfigError::Validation(errors) => {
+                assert!(
+                    !errors.is_empty(),
+                    "validation error list should be populated"
+                );
+                assert!(
+                    errors.iter().any(|e| e.contains("chunk_size")),
+                    "should mention chunk_size, got: {errors:?}"
+                );
+            },
+            other => panic!("expected ConfigError::Validation, got: {other:?}"),
+        }
+    }
+
+    // Reading config when none has been set returns a typed NotSet variant.
+    #[tokio::test]
+    async fn to_json_returns_not_set_variant_when_unconfigured() {
+        let manager = ConfigManager::new();
+        let err = manager
+            .to_json()
+            .await
+            .expect_err("unconfigured to_json should error");
+        assert!(matches!(err, ConfigError::NotSet));
     }
 }


### PR DESCRIPTION
## Summary

Group **S4** from the parallel-fix dispatch. Two related fixes in the config layer, file-disjoint from every other open server PR.

| Commit | Issue | Effect |
|---|---|---|
| \`a2393d4\` | #47 | Introduce \`ConfigError { Parse(serde_json::Error), Validation(Vec<String>), NotSet }\` (thiserror) and switch \`ConfigManager::set_from_json\`/\`to_json\` to return it instead of \`Result<_, String>\`. Brings the module in line with every other server module's error story. |
| \`05fbf38\` | #48 | Wrap \`GraphRAG::new\` + \`graphrag.initialize\` in \`tokio::task::spawn_blocking\` so the seconds-long sync init (loading embedding models, scanning workspace) doesn't park an async worker. The write lock is still taken only for the swap. |

Closes #47
Closes #48

## What's new in this PR

**`ConfigError`** lets callers programmatically branch on the failure mode. The handler boundary in \`config_endpoints.rs\` maps each variant:
- \`Parse\` → \`ApiError::BadRequest\` (400, with the underlying \`serde_json::Error\`)
- \`Validation\` → \`ApiError::BadRequest\` (400, with the structured error list)
- \`NotSet\` → \`ApiError::NotFound\` (404 for read endpoints)

**`spawn_blocking`** for init: previously, while one client's \`POST /api/config\` was in \`graphrag.initialize()?\`, every concurrent handler doing \`state.graphrag.read().await\` would be waiting on a parked worker. Now the runtime stays responsive throughout init.

## Test plan

- [x] \`cargo test -p graphrag-server --bin graphrag-server config_handler::tests\` — 7/7 (4 existing + 3 new)
- [x] \`cargo build --workspace --exclude graphrag_py --exclude graphrag-wasm\` — clean (matches pre-push hook)
- [x] \`cargo fmt --all -- --check\` — clean
- [ ] CI green

## TDD note

Followed Red-Green for #47:
- \`set_from_json_returns_parse_variant_on_malformed_input\`: drives the new \`Parse\` variant.
- \`set_from_json_returns_validation_variant_with_error_list\`: drives the new \`Validation\` variant. Note the test had to build the JSON from \`ConfigManager::default_config_json()\` and then mutate \`chunk_size\` to 0 — the existing \`test_validation\` test was actually hitting a *parse* error (missing required \`embeddings\` field) and only asserting \`is_err()\`, which is exactly the kind of structural opacity #47 calls out.
- \`to_json_returns_not_set_variant_when_unconfigured\`: drives the new \`NotSet\` variant.

For #48, no clean unit-level red test (the bug shape is "an async worker is parked"; verifying that requires runtime introspection or a multi-handler load test). Verified by inspection: \`GraphRAG::new\` and \`initialize\` are now the only statements inside a \`spawn_blocking\` closure.

## Out of scope

- README changes: no public-API or workflow change at the HTTP level (status codes and JSON shapes are unchanged).
- Refactoring \`config_handler.rs\` further (e.g. moving \`get_config_templates\` out of this file). Separate concern.