### PR TITLE
fix(core/persistence): Group N — surface silent data-loss paths (partial #23, partial #24)

### DIFF
--- a/graphrag-core/src/persistence/parquet.rs
+++ b/graphrag-core/src/persistence/parquet.rs
@@ -189,9 +189,24 @@ impl ParquetPersistence {
 
         // Load relationships
         let relationships = self.load_relationships()?;
+        let mut dropped_relationships: usize = 0;
         for relationship in relationships {
-            // Ignore errors for missing entities (they'll be logged)
-            let _ = graph.add_relationship(relationship);
+            // A relationship can fail to attach if its endpoints reference
+            // entities that aren't in the graph (schema drift between save/
+            // load, partial corruption, etc.). Don't crash the load — but
+            // also don't silently ignore: count and log so users see a
+            // signal instead of "queries return slightly wrong answers."
+            if graph.add_relationship(relationship).is_err() {
+                dropped_relationships += 1;
+            }
+        }
+        if dropped_relationships > 0 {
+            #[cfg(feature = "tracing")]
+            tracing::warn!(
+                "Parquet load: dropped {} relationship(s) whose endpoints \
+                 are not present in the graph (possible schema drift or partial corruption)",
+                dropped_relationships
+            );
         }
 
         #[cfg(feature = "tracing")]
@@ -204,7 +219,16 @@ impl ParquetPersistence {
         Ok(graph)
     }
 
-    /// Save entities to Parquet
+    /// Save entities to Parquet.
+    ///
+    /// **Lossy round-trip warning:** the current schema persists only
+    /// `mention_count` (a `usize`), not the `EntityMention` payload itself.
+    /// On load, entities are reconstructed with `mentions: Vec::new()`. The
+    /// entity-to-chunk provenance used by retrieval (`source_chunks`) is
+    /// derived from mentions and is therefore lost across save+load. A
+    /// warning is logged at save time when any entity has non-empty mentions
+    /// so users see the signal. Persisting full mentions in a separate
+    /// `entity_mentions.parquet` is tracked in #24.
     #[cfg(feature = "persistent-storage")]
     fn save_entities(&self, graph: &KnowledgeGraph) -> Result<()> {
         let entities: Vec<_> = graph.entities().collect();
@@ -213,6 +237,18 @@ impl ParquetPersistence {
             #[cfg(feature = "tracing")]
             tracing::warn!("No entities to save");
             return Ok(());
+        }
+
+        let entities_with_mentions = entities.iter().filter(|e| !e.mentions.is_empty()).count();
+        if entities_with_mentions > 0 {
+            #[cfg(feature = "tracing")]
+            tracing::warn!(
+                "Parquet save: {} of {} entities have mentions, but the current schema \
+                 persists only `mention_count` — full mention payloads will be lost on \
+                 reload. See issue #24.",
+                entities_with_mentions,
+                entities.len()
+            );
         }
 
         // Build Arrow schema for entities

--- a/graphrag-core/src/persistence/workspace.rs
+++ b/graphrag-core/src/persistence/workspace.rs
@@ -29,6 +29,13 @@ pub struct WorkspaceMetadata {
     pub description: Option<String>,
 }
 
+/// Current on-disk workspace metadata format version.
+///
+/// Bumped when the metadata schema changes in a backward-incompatible way.
+/// Loading a workspace whose `format_version` differs from this constant
+/// emits a warning (no migration story exists yet — see #23).
+pub const CURRENT_FORMAT_VERSION: &str = "1.0";
+
 impl WorkspaceMetadata {
     /// Create new workspace metadata
     pub fn new(name: String) -> Self {
@@ -41,7 +48,7 @@ impl WorkspaceMetadata {
             relationship_count: 0,
             document_count: 0,
             chunk_count: 0,
-            format_version: "1.0".to_string(),
+            format_version: CURRENT_FORMAT_VERSION.to_string(),
             description: None,
         }
     }
@@ -243,10 +250,24 @@ impl WorkspaceManager {
         {
             use super::parquet::ParquetPersistence;
             let parquet = ParquetPersistence::new(workspace_path.clone())?;
-            if let Ok(graph) = parquet.load_graph() {
-                #[cfg(feature = "tracing")]
-                tracing::info!("Loaded graph from Parquet: {}", workspace_name);
-                return Ok(graph);
+            match parquet.load_graph() {
+                Ok(graph) => {
+                    #[cfg(feature = "tracing")]
+                    tracing::info!("Loaded graph from Parquet: {}", workspace_name);
+                    return Ok(graph);
+                },
+                Err(_e) => {
+                    // Parquet load failed — fall through to JSON. Surface
+                    // the failure instead of silently degrading: the parquet
+                    // file might be corrupt, version-mismatched, or missing.
+                    #[cfg(feature = "tracing")]
+                    tracing::warn!(
+                        workspace = %workspace_name,
+                        error = %_e,
+                        "Parquet load failed; falling back to JSON. \
+                         Investigate the parquet artifact before relying on this load."
+                    );
+                },
             }
         }
 
@@ -277,7 +298,10 @@ impl WorkspaceManager {
         Ok(())
     }
 
-    /// Load workspace metadata
+    /// Load workspace metadata.
+    ///
+    /// Warns (without failing) if the on-disk `format_version` doesn't match
+    /// [`CURRENT_FORMAT_VERSION`]. There is no migration story yet — see #23.
     fn load_metadata(&self, workspace_name: &str) -> Result<WorkspaceMetadata> {
         let workspace_path = self.workspace_path(workspace_name);
         let metadata_path = workspace_path.join("metadata.toml");
@@ -293,6 +317,17 @@ impl WorkspaceManager {
             toml::from_str(&toml_string).map_err(|e| GraphRAGError::Config {
                 message: format!("Failed to parse metadata: {}", e),
             })?;
+
+        if metadata.format_version != CURRENT_FORMAT_VERSION {
+            #[cfg(feature = "tracing")]
+            tracing::warn!(
+                workspace = %workspace_name,
+                on_disk = %metadata.format_version,
+                expected = %CURRENT_FORMAT_VERSION,
+                "Workspace metadata format_version mismatch — proceeding without migration; \
+                 some fields may be missing or interpreted incorrectly (see issue #23)"
+            );
+        }
 
         Ok(metadata)
     }
@@ -365,5 +400,43 @@ mod tests {
 
         let loaded_graph = workspace.load_graph("test").unwrap();
         assert_eq!(loaded_graph.entity_count(), 0);
+    }
+
+    // Loading a workspace whose metadata declares a different format_version
+    // must succeed (we don't gate on it), but the version mismatch should be
+    // observable in the returned struct so callers / log inspection can see
+    // it (regression for #23).
+    #[test]
+    fn load_metadata_returns_on_disk_version_even_when_mismatched() {
+        let temp_dir = TempDir::new().unwrap();
+        let workspace = WorkspaceManager::new(temp_dir.path()).unwrap();
+        workspace.create_workspace("legacy").unwrap();
+
+        // Hand-write a metadata.toml with a deliberately stale format_version.
+        let stale_meta = WorkspaceMetadata {
+            name: "legacy".to_string(),
+            created_at: chrono::Utc::now(),
+            modified_at: chrono::Utc::now(),
+            entity_count: 0,
+            relationship_count: 0,
+            document_count: 0,
+            chunk_count: 0,
+            format_version: "0.0-prehistoric".to_string(),
+            description: None,
+        };
+        let toml_string = toml::to_string_pretty(&stale_meta).unwrap();
+        let meta_path = temp_dir.path().join("legacy").join("metadata.toml");
+        fs::write(meta_path, toml_string).unwrap();
+
+        let loaded = workspace.load_metadata("legacy").unwrap();
+        assert_eq!(loaded.format_version, "0.0-prehistoric");
+        assert_ne!(loaded.format_version, CURRENT_FORMAT_VERSION);
+    }
+
+    // Newly-written metadata always carries the current format version.
+    #[test]
+    fn new_metadata_carries_current_format_version() {
+        let m = WorkspaceMetadata::new("fresh".to_string());
+        assert_eq!(m.format_version, CURRENT_FORMAT_VERSION);
     }
 }


### PR DESCRIPTION
## Summary

Group **K2** from the parallel-fix dispatch — observability-and-warning fixes on the highest-leverage silent-data-loss paths in \`graphrag-core\` persistence. Both issues stay open because the proper fixes (a real migration story for #23, a separate \`entity_mentions.parquet\` for #24) are bigger PRs in their own right; this PR closes the "no signal that anything is wrong" gap so users at least see the problem.

| Commit | Issue | Effect |
|---|---|---|
| \`e13c543\` | partial #23 | Add \`CURRENT_FORMAT_VERSION\` constant; \`load_metadata\` warns on mismatch instead of silently accepting; \`load_graph\` warns when Parquet load fails before falling back to JSON. 2 regression tests. |
| \`540f777\` | partial #23 + partial #24 | Parquet \`load_graph\` no longer does \`let _ = graph.add_relationship(...)\` — counts dropped relationships and emits one aggregate \`tracing::warn!\`. \`save_entities\` warns when entities have non-empty mentions (since the schema drops them) and gains a doc-comment pointing at #24. |

Refs #23
Refs #24

## Why these stay open

**#23**: Three sites are addressed (format_version observability, parquet→json fallback, relationship-drop count). Three are not — \`unwrap_or("")\` for ID/document_id/content fields in \`core/mod.rs\` (would change API surface and is its own audit), and \`bincode::deserialize\` failure → cache miss in \`caching/distributed.rs\` (touches the L2 stats contract). A proper "refuse to load on version mismatch / run a migration" story is also a bigger design discussion. This PR makes the silent failures audible so users can react today.

**#24**: The proper fix is persisting \`EntityMention\` payloads in a separate \`entity_mentions.parquet\` joined on \`entity_id\`. That's a schema addition + load-time join + version bump, deserving its own PR. This PR (a) documents the lossy round-trip on \`save_entities\` and (b) emits a runtime warning at save time so users with non-empty mentions see the signal.

## Test plan

- [x] \`cargo test -p graphrag-core --lib persistence::\` — 6/6 (2 new + 4 existing)
- [x] \`cargo build --workspace --exclude graphrag_py --exclude graphrag-wasm\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [ ] CI green

## TDD note

For the format-version path, \`load_metadata_returns_on_disk_version_even_when_mismatched\` writes a metadata.toml with a stale \`format_version\` and asserts the load surfaces the on-disk value (not silently overwrites it with the current). \`new_metadata_carries_current_format_version\` pins the constant invariant so a future bump is observable.

The other warning paths (Parquet→JSON fallback, dropped relationships, entity mentions) are observability changes — adding a \`tracing::warn!\` doesn't have a meaningful unit-level red test. They were verified by code inspection and the build still passes the existing functional tests.

## Out of scope

- Real metadata migration story (#23 stays open)
- \`entity_mentions.parquet\` schema addition (#24 stays open)
- \`unwrap_or("")\` audit in \`core/mod.rs\` and \`caching/distributed.rs\` cache-miss-vs-decode-failure split (parts of #23 stay open)
- README updates: no public API or workflow change