### PR TITLE
fix(cli): Group P — startup robustness (#57, #60, #61)

### DIFF
--- a/graphrag-cli/src/app.rs
+++ b/graphrag-cli/src/app.rs
@@ -1005,6 +1005,22 @@ impl App {
         Ok(())
     }
 
+    /// Resolve the per-platform XDG workspaces dir, surfacing a TUI error
+    /// instead of silently writing to `./workspaces` if the platform doesn't
+    /// expose a data dir. Returns `None` and emits a status error when the
+    /// caller should bail out (closes #60 on the workspace path).
+    fn resolve_workspace_dir(&self) -> Option<PathBuf> {
+        if let Some(base) = dirs::data_dir() {
+            Some(base.join("graphrag").join("workspaces"))
+        } else {
+            let _ = self.action_tx.send(Action::SetStatus(
+                StatusType::Error,
+                "Cannot determine data directory; set $XDG_DATA_HOME".to_string(),
+            ));
+            None
+        }
+    }
+
     /// Handle loading workspace
     async fn handle_load_workspace(&mut self, name: String) -> Result<()> {
         if !self.graphrag.is_initialized().await {
@@ -1020,10 +1036,10 @@ impl App {
             name
         )))?;
 
-        // Get workspace directory from workspace_manager (default: ~/.graphrag/workspaces)
-        let workspace_dir = dirs::data_dir()
-            .map(|p| p.join("graphrag").join("workspaces"))
-            .unwrap_or_else(|| std::path::PathBuf::from("./workspaces"));
+        let workspace_dir = match self.resolve_workspace_dir() {
+            Some(p) => p,
+            None => return Ok(()),
+        };
 
         match self
             .graphrag
@@ -1065,9 +1081,10 @@ impl App {
 
     /// Handle listing workspaces
     async fn handle_list_workspaces(&mut self) -> Result<()> {
-        let workspace_dir = dirs::data_dir()
-            .map(|p| p.join("graphrag").join("workspaces"))
-            .unwrap_or_else(|| std::path::PathBuf::from("./workspaces"));
+        let workspace_dir = match self.resolve_workspace_dir() {
+            Some(p) => p,
+            None => return Ok(()),
+        };
 
         match self
             .graphrag
@@ -1108,9 +1125,10 @@ impl App {
             name
         )))?;
 
-        let workspace_dir = dirs::data_dir()
-            .map(|p| p.join("graphrag").join("workspaces"))
-            .unwrap_or_else(|| std::path::PathBuf::from("./workspaces"));
+        let workspace_dir = match self.resolve_workspace_dir() {
+            Some(p) => p,
+            None => return Ok(()),
+        };
 
         match self
             .graphrag
@@ -1157,9 +1175,10 @@ impl App {
             name
         )))?;
 
-        let workspace_dir = dirs::data_dir()
-            .map(|p| p.join("graphrag").join("workspaces"))
-            .unwrap_or_else(|| std::path::PathBuf::from("./workspaces"));
+        let workspace_dir = match self.resolve_workspace_dir() {
+            Some(p) => p,
+            None => return Ok(()),
+        };
 
         match self
             .graphrag

--- a/graphrag-cli/src/lib.rs
+++ b/graphrag-cli/src/lib.rs
@@ -203,7 +203,7 @@ pub async fn run() -> Result<()> {
             );
 
             let handler = handlers::graphrag::GraphRAGHandler::new();
-            let config_path = config.unwrap_or_else(|| PathBuf::from("./graphrag.toml"));
+            let config_path = resolve_config_path(config);
             let cfg = load_config_from_file(&config_path).await?;
             handler.initialize(cfg).await?;
             let result = handler.load_document_with_options(&document, false).await?;
@@ -225,7 +225,7 @@ pub async fn run() -> Result<()> {
             );
 
             let handler = handlers::graphrag::GraphRAGHandler::new();
-            let config_path = config.unwrap_or_else(|| PathBuf::from("./graphrag.toml"));
+            let config_path = resolve_config_path(config);
             let cfg = load_config_from_file(&config_path).await?;
             handler.initialize(cfg).await?;
 
@@ -252,7 +252,7 @@ pub async fn run() -> Result<()> {
             eprintln!("⚠️  `entities` is deprecated. Prefer: graphrag tui, then /entities");
 
             let handler = handlers::graphrag::GraphRAGHandler::new();
-            let config_path = config.unwrap_or_else(|| PathBuf::from("./graphrag.toml"));
+            let config_path = resolve_config_path(config);
             let cfg = load_config_from_file(&config_path).await?;
             handler.initialize(cfg).await?;
             let entities = handler.get_entities(filter.as_deref()).await?;
@@ -278,7 +278,7 @@ pub async fn run() -> Result<()> {
             eprintln!("⚠️  `stats` is deprecated. Prefer: graphrag tui, then /stats");
 
             let handler = handlers::graphrag::GraphRAGHandler::new();
-            let config_path = config.unwrap_or_else(|| PathBuf::from("./graphrag.toml"));
+            let config_path = resolve_config_path(config);
             let cfg = load_config_from_file(&config_path).await?;
             handler.initialize(cfg).await?;
 
@@ -314,10 +314,13 @@ pub async fn run() -> Result<()> {
             book,
             questions,
         }) => {
-            if !cli.debug {
-                std::env::set_var("RUST_LOG", "error");
-            }
-            setup_logging(cli.debug)?;
+            // Bench wants quieter logs by default. Configure the EnvFilter
+            // directly via `setup_logging_with_level("error")` instead of
+            // `env::set_var("RUST_LOG", "error")` — the latter mutates the
+            // process-wide environment after `#[tokio::main]` has already
+            // spawned worker threads, which is a documented data race
+            // (and `unsafe` in the 2024 edition).
+            setup_logging_with_level(cli.debug, "error")?;
 
             let q_vec: Vec<String> = questions.split('|').map(|s| s.to_string()).collect();
             handlers::bench::run_benchmark(&config, &book, q_vec).await?;
@@ -337,6 +340,23 @@ pub async fn run() -> Result<()> {
 
 async fn load_config_from_file(path: &std::path::Path) -> Result<graphrag_core::Config> {
     config::load_config(path).await
+}
+
+/// Resolve the CLI `--config` argument to a concrete path, defaulting to
+/// `./graphrag.toml` if the user didn't pass one.
+///
+/// Logs the absolute resolved path on stderr so users running
+/// `graphrag query foo` from an arbitrary directory see *which* config the
+/// fallback picked up. Closes the silent half of #60.
+fn resolve_config_path(arg: Option<PathBuf>) -> PathBuf {
+    let path = arg.unwrap_or_else(|| PathBuf::from("./graphrag.toml"));
+    let resolved = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+    eprintln!(
+        "📄 config: {} (resolved: {})",
+        path.display(),
+        resolved.display()
+    );
+    path
 }
 
 fn run_validate(config_file: &std::path::Path, format: &str) -> Result<()> {
@@ -784,22 +804,41 @@ pub fn install_panic_hook() {
     }));
 }
 
+/// Default log level used by `setup_logging` for non-debug runs.
+/// Pass an override into `setup_logging_with_level` for commands that need
+/// quieter output (e.g. `bench`).
+const DEFAULT_LOG_LEVEL: &str = "info";
+
 fn setup_logging(debug: bool) -> Result<()> {
+    setup_logging_with_level(debug, DEFAULT_LOG_LEVEL)
+}
+
+fn setup_logging_with_level(debug: bool, non_debug_level: &str) -> Result<()> {
     use tracing_subscriber::EnvFilter;
 
     let filter = if debug {
         EnvFilter::new("graphrag_cli=debug,graphrag_core=debug")
     } else {
-        EnvFilter::new("graphrag_cli=info,graphrag_core=info")
+        EnvFilter::new(format!(
+            "graphrag_cli={lvl},graphrag_core={lvl}",
+            lvl = non_debug_level
+        ))
     };
 
-    tracing_subscriber::fmt()
+    // `try_init` instead of `init`: panics if a global default subscriber is
+    // already set (would trip integration tests that boot the CLI twice or
+    // any future re-entrant code path). Demote the duplicate to a `warn!`
+    // and continue with whatever subscriber is already installed.
+    if let Err(e) = tracing_subscriber::fmt()
         .with_env_filter(filter)
         .with_writer(std::io::stderr)
         .with_target(false)
         .with_file(true)
         .with_line_number(true)
-        .init();
+        .try_init()
+    {
+        tracing::warn!("tracing subscriber already initialized; keeping the existing one ({e})");
+    }
 
     Ok(())
 }
@@ -824,14 +863,19 @@ fn setup_tui_logging() -> Result<()> {
 
     let filter = EnvFilter::new("graphrag_cli=warn,graphrag_core=warn");
 
-    tracing_subscriber::fmt()
+    if let Err(e) = tracing_subscriber::fmt()
         .with_env_filter(filter)
         .with_writer(Arc::new(file))
         .with_target(false)
         .with_file(false)
         .with_line_number(false)
         .with_ansi(false)
-        .init();
+        .try_init()
+    {
+        // Subscriber already installed (e.g. tests bootstrapping the TUI
+        // twice). Keep going; the existing subscriber wins.
+        eprintln!("warning: tracing subscriber already initialized; reusing existing ({e})");
+    }
 
     Ok(())
 }

--- a/graphrag-cli/src/tui.rs
+++ b/graphrag-cli/src/tui.rs
@@ -82,11 +82,18 @@ impl Tui {
                         maybe_event = reader.next() => {
                             match maybe_event {
                                 Some(Ok(evt)) => {
-                                    // Handle resize events specially
+                                    // Pick exactly one channel per crossterm event:
+                                    // resize → `Event::Resize` (specialized);
+                                    // everything else → `Event::Crossterm`. The
+                                    // previous code emitted both for a resize, so
+                                    // any future component reacting to
+                                    // `Event::Crossterm(Resize(..))` would fire
+                                    // twice.
                                     if let CrosstermEvent::Resize(w, h) = evt {
                                         let _ = event_tx.send(Event::Resize(w, h));
+                                    } else {
+                                        let _ = event_tx.send(Event::Crossterm(evt));
                                     }
-                                    let _ = event_tx.send(Event::Crossterm(evt));
                                 }
                                 Some(Err(_)) => {}
                                 None => break,

--- a/graphrag-cli/src/workspace.rs
+++ b/graphrag-cli/src/workspace.rs
@@ -139,8 +139,8 @@ impl WorkspaceManager {
     }
 }
 
-impl Default for WorkspaceManager {
-    fn default() -> Self {
-        Self::new().expect("Failed to create workspace manager")
-    }
-}
+// Removed `Default for WorkspaceManager` — its body was
+// `Self::new().expect("Failed to create workspace manager")`, which panics
+// when `dirs::home_dir()` is `None` (containers with no `HOME`, sandboxes,
+// etc.). No call sites in the crate used it. Construct via `Self::new()`
+// and propagate the error instead.


### PR DESCRIPTION
## Summary

Group **C2** from the parallel-fix dispatch — six startup-plumbing tripwires across three issues, all in CLI hot-path code.

| Commit | Issues | Effect |
|---|---|---|
| \`a17ab11\` | #57 (item 1), #60 (config side), #61 | \`setup_logging\` uses \`try_init\` so re-entrant runs no longer panic; \`Bench\` arm uses a new \`setup_logging_with_level(\"error\")\` instead of mutating \`RUST_LOG\` after tokio is up; deprecated subcommands route \`--config\` defaulting through \`resolve_config_path\` which logs the absolute resolved path. |
| \`86519ad\` | #57 (items 2 & 3), #60 (workspace side) | \`App::resolve_workspace_dir\` returns \`None\` and emits a TUI status error instead of silently writing to \`./workspaces\`; \`Default for WorkspaceManager\` removed (it panicked when \`dirs::home_dir()\` was \`None\`); TUI event loop emits exactly one channel per crossterm event so future Resize consumers can't fire twice. |

Closes #57
Closes #60
Closes #61

## Per-issue map

**#57** (latent panics):
- Item 1 (\`setup_logging\` / \`setup_tui_logging\` \`.init()\` panic) — fixed via \`.try_init()\`.
- Item 2 (\`Default for WorkspaceManager\` panicking on \`HOME=\`) — removed entirely (no call sites).
- Item 3 (Resize double-fire) — \`tui.rs\` now picks one channel per event.

**#60** (silent path fallback):
- App.rs side (4 \`./workspaces\` fallbacks) — \`resolve_workspace_dir\` surfaces a TUI error instead.
- Lib.rs side (4 \`./graphrag.toml\` defaults) — \`resolve_config_path\` logs the absolute path on stderr so users see what was picked.

**#61** (\`env::set_var\` after tokio runtime up):
- New \`setup_logging_with_level(debug, non_debug_level)\` helper. \`Bench\` arm calls it directly with \`\"error\"\` instead of mutating the env var.

## Test plan

- [x] \`cargo test -p graphrag-cli --lib\` — 40/40 passing
- [x] \`cargo build --workspace --exclude graphrag_py --exclude graphrag-wasm\` — clean (matches pre-push hook)
- [x] \`cargo fmt --all -- --check\` — clean
- [ ] CI green
- [ ] Manual smoke: \`graphrag tui\` from \`/tmp\` — verify silent-cwd-write is gone (would need a sandbox where \`dirs::data_dir()\` returns None to drive the new error path).
- [ ] Manual smoke: \`graphrag bench --config c.toml --book b.txt --questions \"q?\"\` — verify quiet logs without RUST_LOG manipulation.

## TDD note

No new unit tests added in this PR — each fix is structurally observable rather than behaviorally testable at the unit level:

- \`try_init\` vs \`init\` — would need to install a global subscriber first then call again; doable but heavy for the value (re-running \`run()\` from a single test process isn't a realistic scenario today).
- \`env::set_var\` removal — observable as the absence of \`env::set_var\` in the diff; testing the data race itself requires a multi-thread harness.
- \`Default\` removal — confirmed by the build (no callers).
- Resize dedup — verified by inspection (\`else\` branch is now exclusive).
- \`resolve_workspace_dir\` / \`resolve_config_path\` extraction — happy path covered by existing TUI integration but the \`None\` branch needs a sandbox.

The 40 existing CLI tests continue to pass with no regressions, and the issue claims were verified against current code before fixing.

## Out of scope

- Logging the resolved \`./workspaces\` *absolute path* in the existing flow (the logging hook is in lib.rs config-path side; the workspace side just errors out which is already loud).
- Refactoring \`WorkspaceManager::new\` itself to accept an explicit base dir (would consolidate with #52, deferred to a separate workspace-consolidation PR).
- README updates: no public-API or workflow change at the user-visible level.