### PR TITLE
fix(server): Group Q — validation cleanup + error sanitization (#41, #42)

### DIFF
--- a/graphrag-server/src/config_endpoints.rs
+++ b/graphrag-server/src/config_endpoints.rs
@@ -90,9 +90,13 @@ pub async fn set_config(
     )
     .await
     .map_err(|join_err| {
-        ApiError::InternalError(format!("GraphRAG init task panicked: {}", join_err))
+        tracing::error!("GraphRAG init task panicked: {}", join_err);
+        ApiError::InternalError("GraphRAG init task panicked".to_string())
     })?
-    .map_err(|e| ApiError::InternalError(format!("GraphRAG initialization failed: {}", e)))?;
+    .map_err(|e| {
+        tracing::error!("GraphRAG initialization failed: {}", e);
+        ApiError::InternalError("GraphRAG initialization failed".to_string())
+    })?;
 
     // Store the initialized GraphRAG (write lock is taken only for the swap)
     *state.graphrag.write().await = Some(graphrag);

--- a/graphrag-server/src/main.rs
+++ b/graphrag-server/src/main.rs
@@ -354,11 +354,12 @@ async fn query(
         let query_embedding = match state.embeddings.generate_single(&body.query).await {
             Ok(embedding) => embedding,
             Err(e) => {
+                // Diagnostic detail goes to logs only; the response carries
+                // a generic component name (issue #41).
                 tracing::error!("Failed to generate query embedding: {}", e);
-                return Err(ApiError::InternalError(format!(
-                    "Failed to generate embedding: {}",
-                    e
-                )));
+                return Err(ApiError::InternalError(
+                    "embedding generation failed".to_string(),
+                ));
             },
         };
 
@@ -396,10 +397,8 @@ async fn query(
                 }));
             },
             Err(e) => {
-                return Err(ApiError::InternalError(format!(
-                    "Qdrant search failed: {}",
-                    e
-                )));
+                tracing::error!("Qdrant search failed: {}", e);
+                return Err(ApiError::InternalError("vector search failed".to_string()));
             },
         }
     }
@@ -497,10 +496,9 @@ async fn add_document(
             Ok(emb) => emb,
             Err(e) => {
                 tracing::error!("Failed to generate document embedding: {}", e);
-                return Err(ApiError::InternalError(format!(
-                    "Failed to generate embedding: {}",
-                    e
-                )));
+                return Err(ApiError::InternalError(
+                    "embedding generation failed".to_string(),
+                ));
             },
         };
 
@@ -527,10 +525,10 @@ async fn add_document(
                 }));
             },
             Err(e) => {
-                return Err(ApiError::InternalError(format!(
-                    "Failed to add document to Qdrant: {}",
-                    e
-                )));
+                tracing::error!("Failed to add document to Qdrant: {}", e);
+                return Err(ApiError::InternalError(
+                    "document storage failed".to_string(),
+                ));
             },
         }
     }
@@ -628,10 +626,10 @@ async fn delete_document(
                 }));
             },
             Err(e) => {
-                return Err(ApiError::InternalError(format!(
-                    "Failed to delete from Qdrant: {}",
-                    e
-                )));
+                tracing::error!("Failed to delete from Qdrant: {}", e);
+                return Err(ApiError::InternalError(
+                    "document delete failed".to_string(),
+                ));
             },
         }
     }
@@ -738,10 +736,10 @@ async fn build_graph(state: Data<AppState>) -> Result<Json<BuildGraphResponse>, 
                 }));
             },
             Err(e) => {
-                return Err(ApiError::InternalError(format!(
-                    "Failed to access Qdrant: {}",
-                    e
-                )));
+                tracing::error!("Failed to access Qdrant: {}", e);
+                return Err(ApiError::InternalError(
+                    "vector store access failed".to_string(),
+                ));
             },
         }
     }
@@ -879,10 +877,9 @@ async fn login(
         },
         Err(e) => {
             tracing::error!("❌ Failed to generate token: {}", e);
-            Err(ApiError::InternalError(format!(
-                "Token generation failed: {}",
-                e
-            )))
+            Err(ApiError::InternalError(
+                "token generation failed".to_string(),
+            ))
         },
     }
 }
@@ -932,10 +929,9 @@ async fn create_api_key(
         },
         Err(e) => {
             tracing::error!("❌ Failed to create API key: {}", e);
-            Err(ApiError::InternalError(format!(
-                "API key creation failed: {}",
-                e
-            )))
+            Err(ApiError::InternalError(
+                "API key creation failed".to_string(),
+            ))
         },
     }
 }

--- a/graphrag-server/src/validation.rs
+++ b/graphrag-server/src/validation.rs
@@ -1,17 +1,23 @@
 //! Input validation middleware and utilities for GraphRAG Server
 //!
 //! Provides request validation, sanitization, and security checks.
+//!
+//! Length limits below are byte-based (not codepoint/grapheme counts) — they
+//! exist to bound DoS surface, not to mirror user-visible character counts.
+//! Error messages refer to "bytes" so multi-byte UTF-8 input behaves
+//! predictably (a CJK paragraph hits the byte limit much earlier than a
+//! "characters"-worded message would suggest).
 
 /// Maximum request body size (10MB)
 pub const MAX_BODY_SIZE: usize = 10 * 1024 * 1024;
 
-/// Maximum query length
+/// Maximum query length, in bytes
 pub const MAX_QUERY_LENGTH: usize = 10_000;
 
-/// Maximum document title length
+/// Maximum document title length, in bytes
 pub const MAX_TITLE_LENGTH: usize = 500;
 
-/// Maximum document content length (5MB of text)
+/// Maximum document content length, in bytes (5MB of text)
 pub const MAX_CONTENT_LENGTH: usize = 5 * 1024 * 1024;
 
 /// Maximum top_k value for queries
@@ -37,23 +43,20 @@ pub fn validate_query(query: &str) -> Result<(), ValidationError> {
 
     if query.len() > MAX_QUERY_LENGTH {
         return Err(ValidationError {
-            error: format!(
-                "Query exceeds maximum length of {} characters",
-                MAX_QUERY_LENGTH
-            ),
+            error: format!("Query exceeds maximum length of {} bytes", MAX_QUERY_LENGTH),
             field: Some("query".to_string()),
             max_length: Some(MAX_QUERY_LENGTH),
         });
     }
 
-    // Check for potentially malicious patterns
-    if contains_sql_injection_patterns(query) {
-        return Err(ValidationError {
-            error: "Query contains potentially malicious patterns".to_string(),
-            field: Some("query".to_string()),
-            max_length: None,
-        });
-    }
+    // Note: removed the SQL-injection blocklist that previously lived here.
+    // None of the configured backends (Qdrant, in-memory) are SQL — there is
+    // no SQL surface to inject into, so the check was producing false
+    // positives on legitimate questions ("What does the SQL DROP TABLE
+    // clause do?") while masking real concerns (prompt injection into
+    // Ollama, payload injection into Qdrant filters). Real injection
+    // hardening should live next to the backend that actually parses the
+    // input, not as a generic substring match here.
 
     Ok(())
 }
@@ -70,10 +73,7 @@ pub fn validate_title(title: &str) -> Result<(), ValidationError> {
 
     if title.len() > MAX_TITLE_LENGTH {
         return Err(ValidationError {
-            error: format!(
-                "Title exceeds maximum length of {} characters",
-                MAX_TITLE_LENGTH
-            ),
+            error: format!("Title exceeds maximum length of {} bytes", MAX_TITLE_LENGTH),
             field: Some("title".to_string()),
             max_length: Some(MAX_TITLE_LENGTH),
         });
@@ -95,7 +95,7 @@ pub fn validate_content(content: &str) -> Result<(), ValidationError> {
     if content.len() > MAX_CONTENT_LENGTH {
         return Err(ValidationError {
             error: format!(
-                "Content exceeds maximum length of {} characters",
+                "Content exceeds maximum length of {} bytes",
                 MAX_CONTENT_LENGTH
             ),
             field: Some("content".to_string()),
@@ -135,30 +135,13 @@ pub fn sanitize_string(input: &str) -> String {
         .collect()
 }
 
-/// Check for common SQL injection patterns (basic check)
-fn contains_sql_injection_patterns(input: &str) -> bool {
-    let lower = input.to_lowercase();
-    let dangerous_patterns = [
-        "drop table",
-        "drop database",
-        "delete from",
-        "insert into",
-        "update set",
-        "; --",
-        "' or '1'='1",
-        "\" or \"1\"=\"1",
-        "union select",
-        "exec(",
-        "execute(",
-    ];
-
-    dangerous_patterns
-        .iter()
-        .any(|pattern| lower.contains(pattern))
-}
-
 // Note: Request body size limits are now configured in main.rs using
-// PayloadConfig and JsonConfig with MAX_BODY_SIZE constant
+// PayloadConfig and JsonConfig with MAX_BODY_SIZE constant.
+//
+// The previous `contains_sql_injection_patterns` helper was removed: none
+// of the configured backends are SQL, so the substring blocklist (`drop
+// table`, `delete from`, etc.) only produced false positives on legitimate
+// queries. See #42.
 
 #[cfg(test)]
 mod tests {
@@ -170,10 +153,30 @@ mod tests {
         assert!(validate_query("What is GraphRAG?").is_ok());
         assert!(validate_query("A".repeat(1000).as_str()).is_ok());
 
-        // Invalid queries
+        // Invalid queries (length-based only — no SQL substring matching)
         assert!(validate_query("").is_err());
         assert!(validate_query(&"A".repeat(MAX_QUERY_LENGTH + 1)).is_err());
-        assert!(validate_query("'; DROP TABLE users; --").is_err());
+    }
+
+    // Legitimate questions that *talk about* SQL must pass (regression for
+    // #42 — the old SQL-injection blocklist 400'd these).
+    #[test]
+    fn validate_query_accepts_questions_that_mention_sql_keywords() {
+        assert!(validate_query("What does the SQL DROP TABLE clause do?").is_ok());
+        assert!(validate_query("How do I write an INSERT INTO statement?").is_ok());
+        assert!(validate_query("Compare DELETE FROM and TRUNCATE.").is_ok());
+        assert!(validate_query("'; DROP TABLE users; --").is_ok());
+    }
+
+    // Length errors must mention "bytes" (not "characters") — see #42.
+    #[test]
+    fn validate_query_length_error_says_bytes_not_characters() {
+        let err = validate_query(&"A".repeat(MAX_QUERY_LENGTH + 1)).expect_err("too long");
+        assert!(
+            err.error.contains("bytes"),
+            "expected 'bytes' in length error, got: {}",
+            err.error
+        );
     }
 
     #[test]
@@ -205,18 +208,6 @@ mod tests {
         assert_eq!(sanitize_string("Normal text"), "Normal text");
     }
 
-    #[test]
-    fn test_sql_injection_detection() {
-        assert!(contains_sql_injection_patterns("'; DROP TABLE users; --"));
-        assert!(contains_sql_injection_patterns("' OR '1'='1"));
-        assert!(contains_sql_injection_patterns(
-            "UNION SELECT * FROM passwords"
-        ));
-        assert!(!contains_sql_injection_patterns(
-            "What is the drop in temperature?"
-        ));
-        assert!(!contains_sql_injection_patterns(
-            "Normal query about tables"
-        ));
-    }
+    // (test_sql_injection_detection removed alongside the
+    // contains_sql_injection_patterns helper — see #42.)
 }


### PR DESCRIPTION
## Summary

Group **S2** from the parallel-fix dispatch. Two server-side hygiene fixes that share the "stop saying things to clients you don't mean" theme.

| Commit | Issue | Effect |
|---|---|---|
| \`9bfa39b\` | #42 | Validation length errors say "bytes" (matching what \`str::len()\` actually checks). Removed the substring SQL-injection blocklist that 400'd legitimate questions about SQL keywords without protecting any actual SQL surface. 2 regression tests. |
| \`3a8bfce\` | #41 | 8 \`ApiError::InternalError(format!("...: {}", e))\` sites in \`main.rs\` and \`config_endpoints.rs\` now log the full diagnostic via \`tracing::error!\` and return a generic component-level message ("vector search failed", "embedding generation failed", etc.) — anonymous callers can no longer fingerprint the deployment from response bodies. |

Closes #41
Closes #42

## Why now

**#42**: The SQL blocklist had three side effects:
- 400'd legitimate questions like "What does the SQL DROP TABLE clause do?"
- Created a false sense of security (none of the configured backends are SQL)
- Masked the real injection surface (Ollama prompts, Qdrant filter payloads) by suggesting validation was already in place.

The bytes-vs-characters mismatch wasn't a security bug, just a documentation lie that bit users with multi-byte content far below the documented limit.

**#41**: Concrete leakage examples that were going to clients verbatim:
- \`tonic::Status\` errors carrying internal endpoint URIs and gRPC method paths
- \`qdrant_client\` errors carrying collection schema details
- \`ollama_rs\` errors carrying model names and host URLs
- \`tokio::task::JoinError\` carrying panic backtraces

After this PR, all of those go to logs (where operators see them) and clients get a short generic message.

## Test plan

- [x] \`cargo test -p graphrag-server --bin graphrag-server validation\` — 9/9 (5 existing modified + 2 new + 2 unrelated config tests)
- [x] \`cargo build --workspace --exclude graphrag_py --exclude graphrag-wasm\` — clean (matches pre-push hook)
- [x] \`cargo fmt --all -- --check\` — clean
- [ ] CI green

## TDD note

For #42:
- \`validate_query_accepts_questions_that_mention_sql_keywords\` codifies the 4 prior false positives. On the unfixed code (where the SQL blocklist still ran) all four would 400.
- \`validate_query_length_error_says_bytes_not_characters\` pins the message wording so a future "characters" regression fails red.

For #41 there's no clean unit-level red test (the leakage is observable in HTTP response bodies, which requires a request pipeline). Verified by inspection: every \`format!("...: {}", e)\` payload in the 8 sites is replaced with a static string, and a corresponding \`tracing::error!\` carries the underlying \`e\` to logs.

## Behavior change call-out

API clients will now see less informative \`message\` fields on 5xx responses. The \`error\` *field name* and HTTP status code are unchanged, but a downstream consumer relying on regex-matching the message text will break. This is the intended fix per the issue.

## Out of scope

- Adding a correlation ID to error responses so logs can be matched to user reports — useful follow-up but a separate concern (would touch the \`ApiError\` shape).
- Replacing \`unwrap_or_else\` for the JWT secret default at \`main.rs:172/191\` — that's part of the auth-hardening cluster (#31, S1).
- README / docs updates: HTTP status codes and JSON shape are unchanged, so no API docs need to move.