### PR TITLE
fix(cli): Group R — exit codes + subcommand dedup (#58, #59)

### DIFF
--- a/graphrag-cli/src/lib.rs
+++ b/graphrag-cli/src/lib.rs
@@ -182,9 +182,7 @@ pub async fn run() -> Result<()> {
                 config.display()
             );
 
-            let handler = handlers::graphrag::GraphRAGHandler::new();
-            let cfg = load_config_from_file(&config).await?;
-            handler.initialize(cfg).await?;
+            let _handler = init_handler(Some(config.clone())).await?;
 
             if cli.format == "json" {
                 println!(
@@ -202,10 +200,7 @@ pub async fn run() -> Result<()> {
                 document.display()
             );
 
-            let handler = handlers::graphrag::GraphRAGHandler::new();
-            let config_path = resolve_config_path(config);
-            let cfg = load_config_from_file(&config_path).await?;
-            handler.initialize(cfg).await?;
+            let handler = init_handler(config).await?;
             let result = handler.load_document_with_options(&document, false).await?;
 
             if cli.format == "json" {
@@ -224,11 +219,7 @@ pub async fn run() -> Result<()> {
                 query
             );
 
-            let handler = handlers::graphrag::GraphRAGHandler::new();
-            let config_path = resolve_config_path(config);
-            let cfg = load_config_from_file(&config_path).await?;
-            handler.initialize(cfg).await?;
-
+            let handler = init_handler(config).await?;
             let (answer, raw_results) = handler.query_with_raw(&query).await?;
 
             if cli.format == "json" {
@@ -251,10 +242,7 @@ pub async fn run() -> Result<()> {
             setup_logging(cli.debug)?;
             eprintln!("⚠️  `entities` is deprecated. Prefer: graphrag tui, then /entities");
 
-            let handler = handlers::graphrag::GraphRAGHandler::new();
-            let config_path = resolve_config_path(config);
-            let cfg = load_config_from_file(&config_path).await?;
-            handler.initialize(cfg).await?;
+            let handler = init_handler(config).await?;
             let entities = handler.get_entities(filter.as_deref()).await?;
 
             if cli.format == "json" {
@@ -277,10 +265,7 @@ pub async fn run() -> Result<()> {
             setup_logging(cli.debug)?;
             eprintln!("⚠️  `stats` is deprecated. Prefer: graphrag tui, then /stats");
 
-            let handler = handlers::graphrag::GraphRAGHandler::new();
-            let config_path = resolve_config_path(config);
-            let cfg = load_config_from_file(&config_path).await?;
-            handler.initialize(cfg).await?;
+            let handler = init_handler(config).await?;
 
             if let Some(stats) = handler.get_stats().await {
                 if cli.format == "json" {
@@ -342,6 +327,18 @@ async fn load_config_from_file(path: &std::path::Path) -> Result<graphrag_core::
     config::load_config(path).await
 }
 
+/// Construct, configure, and initialize a `GraphRAGHandler` for one-shot
+/// (deprecated) subcommands. Centralizes the per-subcommand boilerplate so
+/// future fixes (e.g. additional pre-flight checks) land everywhere at once
+/// instead of needing five identical edits. Closes the duplication side of #58.
+async fn init_handler(config: Option<PathBuf>) -> Result<handlers::graphrag::GraphRAGHandler> {
+    let handler = handlers::graphrag::GraphRAGHandler::new();
+    let config_path = resolve_config_path(config);
+    let cfg = load_config_from_file(&config_path).await?;
+    handler.initialize(cfg).await?;
+    Ok(handler)
+}
+
 /// Resolve the CLI `--config` argument to a concrete path, defaulting to
 /// `./graphrag.toml` if the user didn't pass one.
 ///
@@ -372,7 +369,11 @@ fn run_validate(config_file: &std::path::Path, format: &str) -> Result<()> {
         } else {
             println!("❌ File not found: {}", config_file.display());
         }
-        return Ok(());
+        // Exit non-zero so CI / Makefile callers see the failure (#59).
+        return Err(color_eyre::eyre::eyre!(
+            "Config file not found: {}",
+            config_file.display()
+        ));
     }
 
     let fmt = match detect_config_format(config_file) {
@@ -386,7 +387,9 @@ fn run_validate(config_file: &std::path::Path, format: &str) -> Result<()> {
             } else {
                 println!("❌ Unsupported file format. Use .toml, .json, or .json5");
             }
-            return Ok(());
+            return Err(color_eyre::eyre::eyre!(
+                "Unsupported config file format (use .toml/.json/.json5)"
+            ));
         },
     };
 
@@ -444,6 +447,7 @@ fn run_validate(config_file: &std::path::Path, format: &str) -> Result<()> {
             } else {
                 println!("❌ Invalid configuration:\n   {}", err);
             }
+            return Err(color_eyre::eyre::eyre!("Invalid configuration: {}", err));
         },
     }
 
@@ -520,6 +524,7 @@ async fn handle_workspace_commands(action: WorkspaceCommands) -> Result<()> {
             Err(e) => {
                 eprintln!("❌ Error loading workspace: {}", e);
                 eprintln!("\nList available workspaces with: graphrag workspace list");
+                return Err(color_eyre::eyre::eyre!("Workspace not found: {}", e));
             },
         },
         WorkspaceCommands::Delete { id } => {
@@ -878,4 +883,52 @@ fn setup_tui_logging() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // run_validate must propagate failure as Err so the process exits non-zero
+    // for CI / Makefile callers (regression for #59).
+    #[test]
+    fn run_validate_returns_err_for_missing_file() {
+        let nonexistent = std::path::PathBuf::from("/tmp/this-does-not-exist-graphrag-test.toml");
+        let result = run_validate(&nonexistent, "text");
+        assert!(
+            result.is_err(),
+            "missing config file must produce a non-zero exit, got Ok"
+        );
+    }
+
+    // An unsupported file extension is also an error condition.
+    #[test]
+    fn run_validate_returns_err_for_unsupported_extension() {
+        let tmp_dir = std::env::temp_dir();
+        let unsupported_path = tmp_dir.join("graphrag-validate-unsupported.xyz");
+        std::fs::write(&unsupported_path, "irrelevant").unwrap();
+
+        let result = run_validate(&unsupported_path, "text");
+        let _ = std::fs::remove_file(&unsupported_path);
+        assert!(
+            result.is_err(),
+            "unsupported file extension must produce non-zero exit"
+        );
+    }
+
+    // A syntactically broken TOML file must surface as Err. Pre-fix this would
+    // return Ok(()) after println — a hard regression for CI usage.
+    #[test]
+    fn run_validate_returns_err_for_invalid_toml_content() {
+        let tmp_dir = std::env::temp_dir();
+        let bad_toml = tmp_dir.join("graphrag-validate-bad.toml");
+        std::fs::write(&bad_toml, "{ this is not valid toml").unwrap();
+
+        let result = run_validate(&bad_toml, "text");
+        let _ = std::fs::remove_file(&bad_toml);
+        assert!(
+            result.is_err(),
+            "invalid TOML must produce a non-zero exit, got Ok"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Group **C5** from the parallel-fix dispatch. Two related CLI hygiene fixes in \`lib.rs\` only.

| Issue | Effect |
|---|---|
| #59 | \`run_validate\` and \`WorkspaceCommands::Info\` now return \`Err\` on failure, so \`graphrag validate bad.toml\` and \`graphrag workspace info <bad-id>\` exit non-zero — required for CI / Makefile usage. |
| #58 | The 5 deprecated one-shot subcommands (\`Init\` / \`Load\` / \`Query\` / \`Entities\` / \`Stats\`) all deduplicated through a new \`init_handler(config)\` helper. A future pre-flight or initialization fix lands in one place instead of needing five identical edits. The deprecated subcommands themselves stay (the \`eprintln\` already steers users to the TUI). |

Closes #58
Closes #59

## Test plan

- [x] \`cargo test -p graphrag-cli --lib\` — 43/43 (40 existing + 3 new for #59)
- [x] \`cargo build --workspace --exclude graphrag_py --exclude graphrag-wasm\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [ ] CI green
- [ ] Manual: \`graphrag validate /tmp/missing.toml; echo $?\` — should print 1, not 0.

## TDD note

Three regression tests for #59:
- \`run_validate_returns_err_for_missing_file\` — file-not-found path
- \`run_validate_returns_err_for_unsupported_extension\` — unsupported file format
- \`run_validate_returns_err_for_invalid_toml_content\` — parse failure (the highest-leverage CI break)

All three would have returned \`Ok(())\` on the unfixed code.

For #58 the dedup is a structural refactor with no behavior change to test. The 40 existing tests confirm no regressions.

## Out of scope

- Deleting the deprecated subcommands entirely — separate hard-break PR.
- \`app.rs::handle_export\` writing errors only to the status bar — that's a TUI surface, not a process-exit one (the issue mentioned it but the TUI doesn't *have* an exit code). Out of scope here.
- README updates: no public-API or workflow change at the user-visible level.