### PR TITLE
fix(cli): Group S — atomic wizard write + UI smell cleanup (partial #62, partial #64)

### DIFF
--- a/graphrag-cli/src/app.rs
+++ b/graphrag-cli/src/app.rs
@@ -477,11 +477,7 @@ impl App {
                     .to_string()],
                 };
 
-                self.query_history.add_entry(entry.clone());
-
-                // Update info panel with query history
-                self.info_panel
-                    .add_query(entry.query, entry.duration_ms, entry.results_count);
+                self.record_query_history(entry);
 
                 // Update raw results viewer with search results
                 let mut raw_display = vec![
@@ -552,9 +548,7 @@ impl App {
                     )
                     .to_string()],
                 };
-                self.query_history.add_entry(entry.clone());
-                self.info_panel
-                    .add_query(entry.query, entry.duration_ms, entry.results_count);
+                self.record_query_history(entry);
 
                 // Populate raw results with source list
                 let mut raw_display = vec![
@@ -660,9 +654,7 @@ impl App {
                     )
                     .to_string()],
                 };
-                self.query_history.add_entry(entry.clone());
-                self.info_panel
-                    .add_query(entry.query, entry.duration_ms, entry.results_count);
+                self.record_query_history(entry);
 
                 self.raw_results_viewer.set_content(vec![
                     "REASON mode — query decomposition active".to_string(),
@@ -1003,6 +995,19 @@ impl App {
         }
 
         Ok(())
+    }
+
+    /// Record a completed query in **both** the master \`query_history\` (the
+    /// canonical 1000-entry store, exported via /export) and the InfoPanel's
+    /// 10-entry display cache. Centralizing in one method removes the
+    /// dual-write smell where each query handler had to remember to update
+    /// both stores (closes #64 item 2). The two stores still exist for
+    /// API-trait reasons (Component::render is &mut self, no slice param);
+    /// future Component-trait work can collapse them entirely.
+    fn record_query_history(&mut self, entry: QueryEntry) {
+        self.query_history.add_entry(entry.clone());
+        self.info_panel
+            .add_query(entry.query, entry.duration_ms, entry.results_count);
     }
 
     /// Resolve the per-platform XDG workspaces dir, surfacing a TUI error

--- a/graphrag-cli/src/lib.rs
+++ b/graphrag-cli/src/lib.rs
@@ -644,7 +644,20 @@ async fn run_setup_wizard(template: Option<String>, output: PathBuf) -> Result<(
         }
     }
 
-    fs::write(&output, config_content)?;
+    // Atomic write: stage to a sibling .tmp file, then rename. Ctrl-C during
+    // the write window no longer truncates the destination (the rename is
+    // atomic on POSIX/NTFS once the data is fully written). Closes the
+    // wizard half of #62.
+    let tmp_output = match output.extension() {
+        Some(ext) => {
+            let mut new_ext = std::ffi::OsString::from(ext);
+            new_ext.push(".tmp");
+            output.with_extension(new_ext)
+        },
+        None => output.with_extension("tmp"),
+    };
+    fs::write(&tmp_output, config_content)?;
+    fs::rename(&tmp_output, &output)?;
 
     println!("   ✅ Configuration saved to: {}\n", output.display());
     println!("╔════════════════════════════════════════════════════════════╗");

--- a/graphrag-cli/src/ui/components/help_overlay.rs
+++ b/graphrag-cli/src/ui/components/help_overlay.rs
@@ -58,13 +58,16 @@ impl super::Component for HelpOverlay {
         }
     }
 
-    fn render(&mut self, f: &mut Frame, _area: Rect) {
+    fn render(&mut self, f: &mut Frame, area: Rect) {
         if !self.visible {
             return;
         }
 
-        // Center the popup (60% x 60%)
-        let area = centered_rect(60, 70, f.area());
+        // Center the popup (60% x 60%) inside the caller's `area`. Earlier
+        // this read `f.area()` directly and silently ignored the caller's
+        // rectangle — broke trust whenever a parent layout passed a
+        // sub-region. Closes #64 item 4.
+        let area = centered_rect(60, 70, area);
 
         // Clear background
         f.render_widget(Clear, area);
@@ -80,7 +83,7 @@ impl super::Component for HelpOverlay {
             Line::from(vec![Span::styled("Global Shortcuts", self.theme.title())]),
             Line::from("━".repeat(55)),
             keybinding_line("?", "Toggle this help overlay", &self.theme),
-            keybinding_line("Ctrl+C / q", "Quit application", &self.theme),
+            keybinding_line("Ctrl+C", "Quit application", &self.theme),
             keybinding_line(
                 "Ctrl+N / Ctrl+P",
                 "Cycle focus: Input→Results→Raw→Info",


### PR DESCRIPTION
## Summary

Group **C4** from the parallel-fix dispatch. Three small, file-disjoint TUI hygiene fixes.

| Commit | Issue | Effect |
|---|---|---|
| \`0d09ab5\` | partial #62 | \`run_setup_wizard\` writes to \`output.tmp\` then \`fs::rename\` — Ctrl-C during the write window no longer truncates the destination file. |
| \`5ac8d43\` | #64 items 3,4 | \`HelpOverlay::render\` honors the caller's \`area\` param instead of recomputing from \`f.area()\`. Help text drops "/ q" since \`q\` was never bound. |
| \`503c9f3\` | #64 item 2 | Three query handlers consolidated through new \`App::record_query_history\` instead of each pushing to \`App::query_history\` and \`info_panel\` separately. |

## What's still open

**#62**: The query-history persistence half (\`QueryHistory::save\` is \`#[allow(dead_code)]\`, never called from \`Action::Quit\`) needs per-workspace context to be useful. The \`WorkspaceManager::query_history_path\` API exists but the workspace consolidation work in #52 (group C1) is the right home for wiring it. Splitting the persistence half out keeps this PR focused on the ship-now wizard fix.

**#64 item 1** (two \`WorkspaceManager\` types — CLI-local in \`workspace.rs\` vs. \`graphrag_core::persistence::WorkspaceManager\`) — also belongs to C1 (workspace consolidation).

So #62 and #64 stay open until C1 lands.

## Test plan

- [x] \`cargo test -p graphrag-cli --lib\` — 40/40 passing (no behavior change to test for the existing surface)
- [x] \`cargo build --workspace --exclude graphrag_py --exclude graphrag-wasm\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [ ] CI green
- [ ] Manual: \`graphrag setup --output /tmp/foo.toml\`, hit Ctrl-C right at the "saving" line — verify \`/tmp/foo.toml\` either doesn't exist or has the prior content (not zero-length).

## TDD note

No new unit tests added:
- The wizard atomic-write change is mechanical (rename instead of write); the value is in the failure mode (Ctrl-C during write) which can't be reliably triggered from a unit test.
- The help-overlay area param fix is a 1-line behavioral change; verifying it would need a TUI render harness.
- The dual-write dedup is structurally invariant (the two original \`add\` calls still happen, just from one method now).

The 40 existing CLI tests confirm no regressions on the surfaces touched.

## Out of scope

- #62 query-history persistence — sequenced after C1
- #64 item 1 (two WorkspaceManagers) — sequenced into C1
- README updates: no public-API or workflow change at the user-visible level.