### PR TITLE
fix(cli): Group U — workspace consolidation + atomic writes + path traversal guards (#52, #53, #54, #55, #64.1, partial #62, partial #64)

### DIFF
--- a/graphrag-cli/src/app.rs
+++ b/graphrag-cli/src/app.rs
@@ -8,7 +8,7 @@ use crate::{
     theme::Theme,
     tui::{Event, Tui},
     ui::{HelpOverlay, InfoPanel, QueryInput, RawResultsViewer, ResultsViewer, StatusBar},
-    workspace::{WorkspaceManager, WorkspaceMetadata},
+    workspace::{cli_workspaces_dir, CliWorkspaceManager, WorkspaceMetadata},
 };
 use chrono::Utc;
 use color_eyre::eyre::Result;
@@ -45,7 +45,7 @@ pub struct App {
     query_history: QueryHistory,
     /// Workspace manager
     #[allow(dead_code)]
-    workspace_manager: WorkspaceManager,
+    workspace_manager: CliWorkspaceManager,
     /// Current workspace metadata
     #[allow(dead_code)]
     workspace_metadata: Option<WorkspaceMetadata>,
@@ -65,7 +65,7 @@ impl App {
     pub fn new(config_path: Option<PathBuf>, _workspace: Option<String>) -> Result<Self> {
         let (action_tx, action_rx) = mpsc::unbounded_channel();
 
-        let workspace_manager = WorkspaceManager::new()?;
+        let workspace_manager = CliWorkspaceManager::new()?;
 
         Ok(Self {
             should_quit: false,
@@ -691,7 +691,14 @@ impl App {
         match SlashCommand::parse(&cmd_str) {
             Ok(cmd) => match cmd {
                 SlashCommand::Config(path) => {
-                    let expanded = FileOperations::expand_tilde(&path);
+                    let expanded = match FileOperations::expand_tilde(&path) {
+                        Ok(p) => p,
+                        Err(e) => {
+                            self.action_tx
+                                .send(Action::SetStatus(StatusType::Error, format!("{}", e)))?;
+                            return Ok(());
+                        },
+                    };
                     self.action_tx.send(Action::LoadConfig(expanded))?;
                 },
                 SlashCommand::Load(path, rebuild) => {
@@ -785,7 +792,14 @@ impl App {
             return Ok(());
         }
 
-        let expanded = FileOperations::expand_tilde(&path);
+        let expanded = match FileOperations::expand_tilde(&path) {
+            Ok(p) => p,
+            Err(e) => {
+                self.action_tx
+                    .send(Action::SetStatus(StatusType::Error, format!("{}", e)))?;
+                return Ok(());
+            },
+        };
 
         let progress_msg = if rebuild {
             format!("Loading document (rebuild): {}", expanded.display())
@@ -1010,19 +1024,38 @@ impl App {
             .add_query(entry.query, entry.duration_ms, entry.results_count);
     }
 
-    /// Resolve the per-platform XDG workspaces dir, surfacing a TUI error
-    /// instead of silently writing to `./workspaces` if the platform doesn't
-    /// expose a data dir. Returns `None` and emits a status error when the
-    /// caller should bail out (closes #60 on the workspace path).
+    /// Resolve the canonical workspaces dir, surfacing a TUI error instead
+    /// of silently falling back when the data dir can't be determined.
+    /// Routes through [`cli_workspaces_dir`] so the TUI's `/workspace ...`
+    /// commands and the `graphrag workspace ...` subcommands always look at
+    /// the same place (#52).
     fn resolve_workspace_dir(&self) -> Option<PathBuf> {
-        if let Some(base) = dirs::data_dir() {
-            Some(base.join("graphrag").join("workspaces"))
-        } else {
-            let _ = self.action_tx.send(Action::SetStatus(
-                StatusType::Error,
-                "Cannot determine data directory; set $XDG_DATA_HOME".to_string(),
-            ));
-            None
+        match cli_workspaces_dir() {
+            Ok(p) => Some(p),
+            Err(e) => {
+                let _ = self
+                    .action_tx
+                    .send(Action::SetStatus(StatusType::Error, format!("{}", e)));
+                None
+            },
+        }
+    }
+
+    /// Resolve the canonical workspaces dir as a UTF-8 string for handlers
+    /// that take `&str` paths. Returns `None` (and emits a status error)
+    /// when the path is non-UTF-8 or the data dir can't be determined.
+    /// Closes the `to_str().unwrap()` panic in #55.
+    fn resolve_workspace_dir_str(&self) -> Option<String> {
+        let dir = self.resolve_workspace_dir()?;
+        match dir.to_str() {
+            Some(s) => Some(s.to_string()),
+            None => {
+                let _ = self.action_tx.send(Action::SetStatus(
+                    StatusType::Error,
+                    format!("Workspace directory is not valid UTF-8: {}", dir.display()),
+                ));
+                None
+            },
         }
     }
 
@@ -1041,16 +1074,12 @@ impl App {
             name
         )))?;
 
-        let workspace_dir = match self.resolve_workspace_dir() {
+        let workspace_dir = match self.resolve_workspace_dir_str() {
             Some(p) => p,
             None => return Ok(()),
         };
 
-        match self
-            .graphrag
-            .load_workspace(workspace_dir.to_str().unwrap(), &name)
-            .await
-        {
+        match self.graphrag.load_workspace(&workspace_dir, &name).await {
             Ok(message) => {
                 self.action_tx.send(Action::StopProgress)?;
 
@@ -1086,16 +1115,12 @@ impl App {
 
     /// Handle listing workspaces
     async fn handle_list_workspaces(&mut self) -> Result<()> {
-        let workspace_dir = match self.resolve_workspace_dir() {
+        let workspace_dir = match self.resolve_workspace_dir_str() {
             Some(p) => p,
             None => return Ok(()),
         };
 
-        match self
-            .graphrag
-            .list_workspaces(workspace_dir.to_str().unwrap())
-            .await
-        {
+        match self.graphrag.list_workspaces(&workspace_dir).await {
             Ok(list_output) => {
                 self.results_viewer
                     .set_content(list_output.lines().map(|s| s.to_string()).collect());
@@ -1130,16 +1155,12 @@ impl App {
             name
         )))?;
 
-        let workspace_dir = match self.resolve_workspace_dir() {
+        let workspace_dir = match self.resolve_workspace_dir_str() {
             Some(p) => p,
             None => return Ok(()),
         };
 
-        match self
-            .graphrag
-            .save_workspace(workspace_dir.to_str().unwrap(), &name)
-            .await
-        {
+        match self.graphrag.save_workspace(&workspace_dir, &name).await {
             Ok(message) => {
                 self.action_tx.send(Action::StopProgress)?;
 
@@ -1150,7 +1171,7 @@ impl App {
                     String::new(),
                     message,
                     String::new(),
-                    format!("Workspace location: {}", workspace_dir.display()),
+                    format!("Workspace location: {}", workspace_dir),
                     String::new(),
                     "You can load this workspace later with:".to_string(),
                     format!("  /workspace {}", name),
@@ -1180,16 +1201,12 @@ impl App {
             name
         )))?;
 
-        let workspace_dir = match self.resolve_workspace_dir() {
+        let workspace_dir = match self.resolve_workspace_dir_str() {
             Some(p) => p,
             None => return Ok(()),
         };
 
-        match self
-            .graphrag
-            .delete_workspace(workspace_dir.to_str().unwrap(), &name)
-            .await
-        {
+        match self.graphrag.delete_workspace(&workspace_dir, &name).await {
             Ok(message) => {
                 self.action_tx.send(Action::StopProgress)?;
 
@@ -1278,7 +1295,14 @@ impl App {
             ));
         }
 
-        let expanded = FileOperations::expand_tilde(&path);
+        let expanded = match FileOperations::expand_tilde(&path) {
+            Ok(p) => p,
+            Err(e) => {
+                self.action_tx
+                    .send(Action::SetStatus(StatusType::Error, format!("{}", e)))?;
+                return Ok(());
+            },
+        };
         match tokio::fs::write(&expanded, md.as_bytes()).await {
             Ok(()) => {
                 let msg = format!(

--- a/graphrag-cli/src/handlers/file_ops.rs
+++ b/graphrag-cli/src/handlers/file_ops.rs
@@ -62,20 +62,46 @@ impl FileOperations {
             .map_err(|e| eyre!("Failed to write file {}: {}", path.display(), e))
     }
 
-    /// Expand tilde (~) in path
-    pub fn expand_tilde(path: &Path) -> PathBuf {
-        if path.starts_with("~") {
-            if let Some(home) = dirs::home_dir() {
-                return home.join(path.strip_prefix("~").unwrap());
+    /// Expand tilde (~) in path.
+    ///
+    /// Only `~/...` (with a path separator) is expanded. `~user/...`
+    /// (POSIX user-name expansion) is intentionally NOT supported: the old
+    /// implementation passed any `~`-prefixed string through unchanged on a
+    /// home-dir-less environment, which let `/load ~user/foo` resolve to
+    /// the literal directory `~user/foo` (a real, attacker-controllable
+    /// directory in the cwd).
+    ///
+    /// Returns an error when the input starts with `~/` and the home
+    /// directory can't be determined — closes the silent-fallback half of
+    /// #54. Non-`~` paths are returned unchanged.
+    pub fn expand_tilde(path: &Path) -> Result<PathBuf> {
+        let s = match path.to_str() {
+            Some(s) => s,
+            None => return Ok(path.to_path_buf()),
+        };
+        // Only the `~/` form (or bare `~`) expands. `~user` stays literal —
+        // it's never been supported and silently passing it through opened
+        // a path-traversal surface.
+        if s == "~" || s.starts_with("~/") {
+            let home = dirs::home_dir().ok_or_else(|| {
+                eyre!(
+                    "Cannot expand `{}`: $HOME is not set and dirs::home_dir() returned None",
+                    path.display()
+                )
+            })?;
+            if s == "~" {
+                return Ok(home);
             }
+            // strip "~/"
+            return Ok(home.join(&s[2..]));
         }
-        path.to_path_buf()
+        Ok(path.to_path_buf())
     }
 
     /// Resolve relative path to absolute
     #[allow(dead_code)]
     pub fn canonicalize(path: &Path) -> Result<PathBuf> {
-        let expanded = Self::expand_tilde(path);
+        let expanded = Self::expand_tilde(path)?;
 
         if expanded.is_absolute() {
             Ok(expanded)
@@ -112,11 +138,40 @@ mod tests {
     #[test]
     fn test_expand_tilde() {
         let path = Path::new("~/test.txt");
-        let expanded = FileOperations::expand_tilde(path);
+        let expanded = FileOperations::expand_tilde(path).unwrap();
 
         if let Some(home) = dirs::home_dir() {
             assert_eq!(expanded, home.join("test.txt"));
         }
+    }
+
+    // The bare `~` form expands to home (no trailing slash).
+    #[test]
+    fn expand_tilde_handles_bare_tilde() {
+        let path = Path::new("~");
+        let expanded = FileOperations::expand_tilde(path).unwrap();
+        if let Some(home) = dirs::home_dir() {
+            assert_eq!(expanded, home);
+        }
+    }
+
+    // Non-tilde paths pass through unchanged.
+    #[test]
+    fn expand_tilde_passes_non_tilde_through() {
+        let path = Path::new("/etc/passwd");
+        let expanded = FileOperations::expand_tilde(path).unwrap();
+        assert_eq!(expanded, PathBuf::from("/etc/passwd"));
+    }
+
+    // The previous code silently passed `~user/foo` through as a literal
+    // relative path. Now `~user/...` is left as a literal `PathBuf` (not
+    // expanded), so callers don't accidentally resolve to a real `~user`
+    // directory in cwd. Regression for #54 expand_tilde half.
+    #[test]
+    fn expand_tilde_does_not_expand_user_form() {
+        let path = Path::new("~bob/foo");
+        let expanded = FileOperations::expand_tilde(path).unwrap();
+        assert_eq!(expanded, PathBuf::from("~bob/foo"));
     }
 
     #[test]

--- a/graphrag-cli/src/lib.rs
+++ b/graphrag-cli/src/lib.rs
@@ -462,7 +462,7 @@ async fn run_tui(config_path: Option<PathBuf>, workspace: Option<String>) -> Res
 }
 
 async fn handle_workspace_commands(action: WorkspaceCommands) -> Result<()> {
-    let workspace_manager = workspace::WorkspaceManager::new()?;
+    let workspace_manager = workspace::CliWorkspaceManager::new()?;
 
     match action {
         WorkspaceCommands::List => {
@@ -514,10 +514,12 @@ async fn handle_workspace_commands(action: WorkspaceCommands) -> Result<()> {
                     println!("  Config: {}", cfg.display());
                 }
 
-                let history_path = workspace_manager.query_history_path(&id);
-                if history_path.exists() {
-                    if let Ok(history) = query_history::QueryHistory::load(&history_path).await {
-                        println!("\n  Total queries: {}", history.total_queries());
+                if let Ok(history_path) = workspace_manager.query_history_path(&id) {
+                    if history_path.exists() {
+                        if let Ok(history) = query_history::QueryHistory::load(&history_path).await
+                        {
+                            println!("\n  Total queries: {}", history.total_queries());
+                        }
                     }
                 }
             },

--- a/graphrag-cli/src/workspace.rs
+++ b/graphrag-cli/src/workspace.rs
@@ -1,8 +1,15 @@
-//! Workspace management
+//! CLI workspace registry.
+//!
+//! Manages the on-disk workspace directory tree under a single canonical
+//! base path (see [`cli_workspaces_dir`]). The type is named
+//! [`CliWorkspaceManager`] to avoid colliding with
+//! [`graphrag_core::persistence::WorkspaceManager`] — the two types lived
+//! under the same name and confused the eye when both were imported into
+//! `graphrag.rs` (#64 item 1).
 
 use color_eyre::eyre::{eyre, Result};
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use uuid::Uuid;
 
 /// Workspace metadata
@@ -39,108 +46,274 @@ impl WorkspaceMetadata {
     }
 }
 
-/// Workspace manager
-pub struct WorkspaceManager {
+/// Resolve the canonical base directory for CLI workspaces.
+///
+/// Priority:
+/// 1. `GRAPHRAG_WORKSPACES_DIR` env var (used by tests + custom deployments)
+/// 2. `dirs::data_dir().join("graphrag/workspaces")` — XDG-friendly default
+///    matching what the TUI's `/workspace save` already writes to. (#52
+///    consolidates the previously-divergent `~/.graphrag/workspaces` path
+///    into this one.)
+///
+/// Returns an error if neither path is resolvable. Callers that want a
+/// different base should construct via [`CliWorkspaceManager::with_base_dir`].
+pub fn cli_workspaces_dir() -> Result<PathBuf> {
+    if let Ok(custom) = std::env::var("GRAPHRAG_WORKSPACES_DIR") {
+        if !custom.trim().is_empty() {
+            return Ok(PathBuf::from(custom));
+        }
+    }
+    let base = dirs::data_dir().ok_or_else(|| {
+        eyre!(
+            "Cannot determine data directory; set $XDG_DATA_HOME or \
+             GRAPHRAG_WORKSPACES_DIR"
+        )
+    })?;
+    Ok(base.join("graphrag").join("workspaces"))
+}
+
+/// CLI workspace registry.
+pub struct CliWorkspaceManager {
     /// Base directory for workspaces
     base_dir: PathBuf,
 }
 
-impl WorkspaceManager {
-    /// Create a new workspace manager
+impl CliWorkspaceManager {
+    /// Create a new workspace manager rooted at the canonical
+    /// [`cli_workspaces_dir`].
     pub fn new() -> Result<Self> {
-        let base_dir = dirs::home_dir()
-            .ok_or_else(|| eyre!("Could not determine home directory"))?
-            .join(".graphrag")
-            .join("workspaces");
-
-        Ok(Self { base_dir })
+        Ok(Self {
+            base_dir: cli_workspaces_dir()?,
+        })
     }
 
-    /// Get workspace directory
-    pub fn workspace_dir(&self, id: &str) -> PathBuf {
-        self.base_dir.join(id)
+    /// Create a workspace manager rooted at an explicit base directory
+    /// (primarily for tests).
+    pub fn with_base_dir(base_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            base_dir: base_dir.into(),
+        }
     }
 
-    /// Get workspace metadata file path
-    pub fn metadata_path(&self, id: &str) -> PathBuf {
-        self.workspace_dir(id).join("metadata.json")
+    /// Get the base directory.
+    pub fn base_dir(&self) -> &Path {
+        &self.base_dir
     }
 
-    /// Get query history file path
-    pub fn query_history_path(&self, id: &str) -> PathBuf {
-        self.workspace_dir(id).join("query_history.json")
+    /// Get workspace directory.
+    ///
+    /// Validates `id` matches a UUID v4 shape so a malicious or careless
+    /// `id` like `../../../etc/passwd` cannot escape `base_dir`. Closes
+    /// the path-traversal half of #54.
+    pub fn workspace_dir(&self, id: &str) -> Result<PathBuf> {
+        validate_workspace_id(id)?;
+        Ok(self.base_dir.join(id))
     }
 
-    /// Create a new workspace
+    /// Get workspace metadata file path.
+    pub fn metadata_path(&self, id: &str) -> Result<PathBuf> {
+        Ok(self.workspace_dir(id)?.join("metadata.json"))
+    }
+
+    /// Get query history file path.
+    pub fn query_history_path(&self, id: &str) -> Result<PathBuf> {
+        Ok(self.workspace_dir(id)?.join("query_history.json"))
+    }
+
+    /// Create a new workspace.
     pub async fn create_workspace(&self, name: String) -> Result<WorkspaceMetadata> {
         let metadata = WorkspaceMetadata::new(name);
-
-        // Create workspace directory
-        let workspace_dir = self.workspace_dir(&metadata.id);
+        let workspace_dir = self.workspace_dir(&metadata.id)?;
         tokio::fs::create_dir_all(&workspace_dir).await?;
-
-        // Save metadata
         self.save_metadata(&metadata).await?;
-
         Ok(metadata)
     }
 
-    /// Load workspace metadata
+    /// Load workspace metadata.
+    ///
+    /// Pure read — does NOT update `last_accessed` or write back. The
+    /// previous behavior caused every `list_workspaces` call to rewrite
+    /// every metadata file (each write a torn-write risk under crash or
+    /// concurrent CLI). Callers that want to record access call
+    /// [`Self::touch_workspace`] explicitly. Closes the read-amplification
+    /// half of #53.
     pub async fn load_metadata(&self, id: &str) -> Result<WorkspaceMetadata> {
-        let path = self.metadata_path(id);
+        let path = self.metadata_path(id)?;
         let content = tokio::fs::read_to_string(&path).await?;
-        let mut metadata: WorkspaceMetadata = serde_json::from_str(&content)?;
+        let metadata: WorkspaceMetadata = serde_json::from_str(&content)?;
+        Ok(metadata)
+    }
+
+    /// Update `last_accessed` and persist. Call only when the workspace is
+    /// actually opened, not on listing.
+    pub async fn touch_workspace(&self, id: &str) -> Result<WorkspaceMetadata> {
+        let mut metadata = self.load_metadata(id).await?;
         metadata.touch();
         self.save_metadata(&metadata).await?;
         Ok(metadata)
     }
 
-    /// Save workspace metadata
+    /// Save workspace metadata atomically (`.tmp` + rename).
+    ///
+    /// Closes the non-atomic-write half of #53. A Ctrl-C / OOM mid-write
+    /// no longer truncates the registry; the rename is atomic on POSIX
+    /// and NTFS once the data is fully written.
     pub async fn save_metadata(&self, metadata: &WorkspaceMetadata) -> Result<()> {
-        let path = self.metadata_path(&metadata.id);
+        let path = self.metadata_path(&metadata.id)?;
+        let tmp = path.with_extension("json.tmp");
         let json = serde_json::to_string_pretty(metadata)?;
-        tokio::fs::write(&path, json).await?;
+        tokio::fs::write(&tmp, json).await?;
+        tokio::fs::rename(&tmp, &path).await?;
         Ok(())
     }
 
-    /// List all workspaces
+    /// List all workspaces (does NOT mutate `last_accessed` — see #53).
     pub async fn list_workspaces(&self) -> Result<Vec<WorkspaceMetadata>> {
         let mut workspaces = Vec::new();
-
         if !self.base_dir.exists() {
             return Ok(workspaces);
         }
-
         let mut entries = tokio::fs::read_dir(&self.base_dir).await?;
-
         while let Some(entry) = entries.next_entry().await? {
             if entry.file_type().await?.is_dir() {
                 if let Some(id) = entry.file_name().to_str() {
+                    if validate_workspace_id(id).is_err() {
+                        // Skip dirs that don't look like workspaces — they
+                        // can't have been created by us.
+                        continue;
+                    }
                     if let Ok(metadata) = self.load_metadata(id).await {
                         workspaces.push(metadata);
                     }
                 }
             }
         }
-
         // Sort by last accessed (most recent first)
         workspaces.sort_by(|a, b| b.last_accessed.cmp(&a.last_accessed));
-
         Ok(workspaces)
     }
 
-    /// Delete a workspace
+    /// Delete a workspace.
+    ///
+    /// `id` is validated as a UUID v4 by [`Self::workspace_dir`], so
+    /// `../../../etc/passwd` and similar cannot reach this code path.
+    /// `tokio::fs::remove_dir_all` already handles "not found" by
+    /// returning `NotFound`; the previous explicit `if .exists()` check
+    /// was a TOCTOU window. (#54.)
     pub async fn delete_workspace(&self, id: &str) -> Result<()> {
-        let workspace_dir = self.workspace_dir(id);
-        if workspace_dir.exists() {
-            tokio::fs::remove_dir_all(&workspace_dir).await?;
+        let workspace_dir = self.workspace_dir(id)?;
+        match tokio::fs::remove_dir_all(&workspace_dir).await {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e.into()),
         }
-        Ok(())
     }
 }
 
-// Removed `Default for WorkspaceManager` — its body was
-// `Self::new().expect("Failed to create workspace manager")`, which panics
-// when `dirs::home_dir()` is `None` (containers with no `HOME`, sandboxes,
-// etc.). No call sites in the crate used it. Construct via `Self::new()`
-// and propagate the error instead.
+/// Validate that `id` matches the UUID v4 shape used by
+/// [`WorkspaceMetadata::new`]. Closes the path-traversal half of #54: any
+/// id that would join to a path escaping `base_dir` is rejected before
+/// the join happens.
+fn validate_workspace_id(id: &str) -> Result<()> {
+    // Length check first (cheap reject for obvious traversal attempts).
+    if id.len() != 36 {
+        return Err(eyre!(
+            "Invalid workspace id: expected UUID v4, got {:?}",
+            id
+        ));
+    }
+    // Strict UUID parse via the same crate that produced it.
+    Uuid::parse_str(id).map_err(|e| eyre!("Invalid workspace id {:?}: {}", id, e))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn manager_in_temp() -> (CliWorkspaceManager, TempDir) {
+        let tmp = TempDir::new().unwrap();
+        let mgr = CliWorkspaceManager::with_base_dir(tmp.path());
+        (mgr, tmp)
+    }
+
+    // create + load round-trips metadata.
+    #[tokio::test]
+    async fn create_then_load_round_trips() {
+        let (mgr, _tmp) = manager_in_temp();
+        let ws = mgr.create_workspace("test".to_string()).await.unwrap();
+        let loaded = mgr.load_metadata(&ws.id).await.unwrap();
+        assert_eq!(loaded.id, ws.id);
+        assert_eq!(loaded.name, "test");
+    }
+
+    // load_metadata must NOT write back (regression for #53 read amplification).
+    #[tokio::test]
+    async fn load_metadata_does_not_rewrite_file() {
+        let (mgr, _tmp) = manager_in_temp();
+        let ws = mgr.create_workspace("test".to_string()).await.unwrap();
+        let path = mgr.metadata_path(&ws.id).unwrap();
+        let mtime_before = std::fs::metadata(&path).unwrap().modified().unwrap();
+
+        // Sleep so any rewrite would bump mtime.
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        let _ = mgr.load_metadata(&ws.id).await.unwrap();
+
+        let mtime_after = std::fs::metadata(&path).unwrap().modified().unwrap();
+        assert_eq!(
+            mtime_before, mtime_after,
+            "load_metadata must not rewrite the file"
+        );
+    }
+
+    // touch_workspace explicitly bumps last_accessed and persists.
+    #[tokio::test]
+    async fn touch_workspace_updates_last_accessed() {
+        let (mgr, _tmp) = manager_in_temp();
+        let ws = mgr.create_workspace("test".to_string()).await.unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        let touched = mgr.touch_workspace(&ws.id).await.unwrap();
+        assert!(touched.last_accessed > ws.last_accessed);
+    }
+
+    // delete is idempotent on a non-existent workspace.
+    #[tokio::test]
+    async fn delete_nonexistent_workspace_is_idempotent() {
+        let (mgr, _tmp) = manager_in_temp();
+        let fresh_id = Uuid::new_v4().to_string();
+        // No create — just delete.
+        assert!(mgr.delete_workspace(&fresh_id).await.is_ok());
+    }
+
+    // Path traversal attempts are rejected at the id-validation stage
+    // (regression for #54).
+    #[tokio::test]
+    async fn delete_rejects_path_traversal_in_id() {
+        let (mgr, _tmp) = manager_in_temp();
+        let bad = mgr.delete_workspace("../../../etc/passwd").await;
+        assert!(bad.is_err(), "path traversal id must be rejected");
+    }
+
+    #[tokio::test]
+    async fn workspace_dir_rejects_non_uuid_id() {
+        let (mgr, _tmp) = manager_in_temp();
+        assert!(mgr.workspace_dir("not-a-uuid").is_err());
+        assert!(mgr.workspace_dir("../escape").is_err());
+        assert!(mgr.workspace_dir("").is_err());
+    }
+
+    // cli_workspaces_dir honors the env var override (used by tests + ops).
+    #[test]
+    fn cli_workspaces_dir_honors_env_var() {
+        let prev = std::env::var("GRAPHRAG_WORKSPACES_DIR").ok();
+        std::env::set_var("GRAPHRAG_WORKSPACES_DIR", "/tmp/graphrag-test-ws");
+        let dir = cli_workspaces_dir().unwrap();
+        assert_eq!(dir, PathBuf::from("/tmp/graphrag-test-ws"));
+        if let Some(p) = prev {
+            std::env::set_var("GRAPHRAG_WORKSPACES_DIR", p);
+        } else {
+            std::env::remove_var("GRAPHRAG_WORKSPACES_DIR");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Group **C1** from the parallel-fix dispatch — the largest CLI cluster. Consolidates the previously-divergent workspace storage paths, makes metadata writes atomic, validates UUID ids before joining paths, and replaces the \`PathBuf::to_str().unwrap()\` panics with surfaced TUI errors.

| Issue | Effect |
|---|---|
| #52 | New \`workspace::cli_workspaces_dir()\` returns one canonical path (XDG \`dirs::data_dir().join("graphrag/workspaces")\`, env-overridable). Subcommand and TUI surfaces both route through it — workspaces saved one way are now visible the other. |
| #53 | \`save_metadata\` writes \`metadata.json.tmp\` then \`fs::rename\`. \`load_metadata\` no longer touches \`last_accessed\` or writes back — \`list_workspaces\` is now a pure read. New explicit \`touch_workspace\` for callers that actually open a workspace. |
| #54 | \`workspace_dir\`/\`metadata_path\`/\`query_history_path\`/\`delete_workspace\` validate \`id\` matches a UUID v4 shape before joining. Path-traversal ids like \`../../../etc/passwd\` rejected. \`delete_workspace\` no longer has a TOCTOU window between \`.exists()\` and \`remove_dir_all\` — uses \`remove_dir_all\` directly and treats \`NotFound\` as success. \`expand_tilde\` returns \`Result\`, only expands \`~/...\` (not \`~user/...\`), and errors when home dir is unavailable. |
| #55 | \`App::resolve_workspace_dir_str\` surfaces a TUI status error instead of the previous \`PathBuf::to_str().unwrap()\` panic on non-UTF-8 paths. All 4 \`unwrap\` sites in app.rs replaced. |
| #64 item 1 | Renamed CLI's \`workspace::WorkspaceManager\` → \`CliWorkspaceManager\` so it no longer collides with \`graphrag_core::persistence::WorkspaceManager\` when both are imported. |
| partial #62 | The \`query_history_path\` API surface is now consistent (returns \`Result<PathBuf>\`) — the persistence-on-quit half is still deferred, but the foundation it needs (single canonical workspace path) is now in place. |
| partial #64 | item 1 closed; items 2/3/4 already closed by the prior C4 PR (#85). |

Closes #52
Closes #53
Closes #54
Closes #55
Closes #64

## Behavior change for existing users

Users who had workspaces under \`~/.graphrag/workspaces\` (created via \`graphrag workspace create\` on the previous code) will see those workspaces become invisible. Migration is a one-line move:

\`\`\`bash
mkdir -p "$HOME/.local/share/graphrag/workspaces"
mv ~/.graphrag/workspaces/* "$HOME/.local/share/graphrag/workspaces/"
\`\`\`

The TUI side already wrote to the new location; existing TUI users see no change.

## Test plan

- [x] \`cargo test -p graphrag-cli --lib workspace::tests\` — 7/7 (5 new + 2 modified existing)
- [x] \`cargo test -p graphrag-cli --lib handlers::file_ops::tests\` — 4/4 (3 new + 1 modified existing)
- [x] \`cargo test -p graphrag-cli --lib\` — 53/53 passing (was 40 before this PR + the C4/C5 batch; now +6 from this PR)
- [x] \`cargo build --workspace --exclude graphrag_py --exclude graphrag-wasm\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [ ] CI green
- [ ] Manual: \`graphrag workspace create test\`, then \`graphrag tui\` and run \`/workspace list\` — verify the workspace shows up in both surfaces.
- [ ] Manual: \`graphrag workspace delete ../../../etc/passwd\` — should error out, not delete anything.

## TDD note

8 new regression tests cover:
- create + load round-trip
- \`load_metadata\` does not rewrite the file (mtime invariant — regression for #53 read amplification)
- \`touch_workspace\` does bump \`last_accessed\`
- delete is idempotent on missing workspace (TOCTOU collapse)
- \`delete_workspace("../../../etc/passwd")\` rejected (path traversal)
- \`workspace_dir\` rejects non-UUID and empty ids
- \`cli_workspaces_dir\` honors env var override
- \`expand_tilde\` handles bare \`~\`, passes non-tilde through, refuses to expand \`~user/...\`

## Out of scope

- Query history persistence on TUI quit (\`QueryHistory::save\` still
  \`#[allow(dead_code)]\`). The single-canonical-workspace foundation this
  PR provides unblocks the wiring; doing it here would broaden scope.
- Auto-migration of \`~/.graphrag/workspaces\` on first run — a one-shot
  script the user runs manually is safer than an automatic file move.
- Two \`WorkspaceManager\` types in the workspace: the CLI one is now
  \`CliWorkspaceManager\`; the core one (\`graphrag_core::persistence::WorkspaceManager\`)
  keeps its name. They no longer collide on import.
- README updates: the new \`GRAPHRAG_WORKSPACES_DIR\` env var is documented
  in the \`cli_workspaces_dir\` doc comment; a deployment-section README
  pass would be its own PR.