### PR TITLE
fix(server): Group V — close trivial-admin login + compile_error on broken auth feature (#30, #40)

### DIFF
--- a/graphrag-server/src/auth.rs
+++ b/graphrag-server/src/auth.rs
@@ -1,23 +1,23 @@
 //! Authentication and Authorization Middleware
 //!
-//! Provides JWT token-based authentication and API key authentication for the REST API.
+//! **STATUS: Not yet ported to actix-web (issue #40).** This module
+//! still imports from `axum::{extract, http, middleware, response}`
+//! while the rest of the server is built on `actix-web`. The `auth`
+//! Cargo feature is currently disabled in `default = ["qdrant"]` for
+//! exactly this reason — turning it on produces ~30 unrelated-looking
+//! compile errors about an unresolved `axum` crate.
 //!
-//! ## Features
-//!
-//! - JWT token generation and validation
-//! - API key authentication
-//! - Role-based access control (RBAC)
-//! - Rate limiting per user/IP
-//! - Request audit logging
-//!
-//! ## Usage
-//!
-//! ```rust
-//! // Add authentication middleware to your routes
-//! Router::new()
-//!     .route("/api/protected", get(protected_handler))
-//!     .layer(middleware::from_fn_with_state(state.clone(), auth_middleware))
-//! ```
+//! The `compile_error!` below makes that failure mode loud: anyone
+//! enabling `--features auth` gets one clear message instead of a wall
+//! of "use of unresolved module or unlinked crate `axum`" errors.
+//! Remove it once auth.rs is ported to `actix-web-httpauth`-style
+//! middleware (or, alternatively, once `axum` is added as a dep and
+//! the Apistos integration is reworked).
+
+compile_error!(
+    "the `auth` Cargo feature is not yet ported to actix-web — see issue #40. \
+     Disable the feature (it is off by default) until the port lands."
+);
 
 use axum::{
     extract::{Extension, Request, State},

--- a/graphrag-server/src/main.rs
+++ b/graphrag-server/src/main.rs
@@ -901,42 +901,27 @@ async fn graph_stats(state: Data<AppState>) -> Json<GraphStatsResponse> {
     error_code = 500
 )]
 async fn login(
-    state: Data<AppState>,
+    _state: Data<AppState>,
     body: Json<LoginRequest>,
 ) -> Result<Json<LoginResponse>, ApiError> {
-    // TODO: Implement real user authentication against database
-    // For now, accept any credentials for demo purposes
-    tracing::info!("Login attempt for user: {}", body.username);
-
-    let role = if body.username == "admin" {
-        auth::UserRole::Admin
-    } else {
-        auth::UserRole::User
-    };
-
-    match state.auth.generate_token(&body.username, role.clone(), 24) {
-        Ok(token) => {
-            tracing::info!(
-                "✅ Generated JWT token for user: {} (role: {:?})",
-                body.username,
-                role
-            );
-            Ok(Json(LoginResponse {
-                success: true,
-                token,
-                user_id: body.username.clone(),
-                role: format!("{:?}", role),
-                expires_in_hours: 24,
-                usage: "Add header: Authorization: Bearer <token>".to_string(),
-            }))
-        },
-        Err(e) => {
-            tracing::error!("❌ Failed to generate token: {}", e);
-            Err(ApiError::InternalError(
-                "token generation failed".to_string(),
-            ))
-        },
-    }
+    // SECURITY: the previous body issued an Admin-role JWT to any caller
+    // submitting `{"username":"admin","password":"anything"}` — no
+    // password verification, no user store, no bcrypt. Even though the
+    // route is currently NOT mounted (see the commented-out `/auth/*`
+    // section in `main()`), the handler is shipped in the binary and
+    // would be live the moment someone wires the routes.
+    //
+    // Refuse to issue tokens until a real credential store is in place
+    // (#30). The bcrypt dep declared under the `auth` feature is the
+    // intended verification path; backing it requires a persisted
+    // `(username, bcrypt_hash, role)` store that doesn't exist yet.
+    tracing::warn!(
+        username = %body.username,
+        "Login attempt rejected: no credential store configured (see #30)"
+    );
+    Err(ApiError::InternalError(
+        "Login is not configured on this deployment. Set up a credential store first.".to_string(),
+    ))
 }
 
 #[cfg(feature = "auth")]


### PR DESCRIPTION
## Summary

Group **S1** from the parallel-fix dispatch — auth hardening. Closes the two issues that can be safely shipped today; defers the four others (#31, #32, #45, #46) that all live inside the still-Axum-bound \`auth.rs\`.

| Issue | Effect |
|---|---|
| #30 | \`login\` handler refuses to issue tokens (\`{\"username\":\"admin\",\"password\":\"anything\"}\` no longer mints an Admin JWT). The previous body shipped in the binary even though the route is currently unmounted — closing it now means the future Actix port can't accidentally inherit the broken default. |
| #40 | \`auth.rs\` gets a top-level \`compile_error!\` so \`--features auth\` fails fast with one clear message ("not yet ported to actix-web — see issue #40") instead of ~30 confusing "unresolved \`axum\` crate" errors. |

Closes #30
Closes #40

## Why the other auth issues stay open

**#31** (JWT secret default), **#32** (rate-limit bypass on JWT), **#45** (clock unwrap), **#46** (require_role brittleness) all live inside \`graphrag-server/src/auth.rs\`. That file is currently Axum-bound and won't compile under any current build path:

\`\`\`
$ cargo check -p graphrag-server --features auth
error: the \`auth\` Cargo feature is not yet ported to actix-web — see issue #40.
\`\`\`

Making fixes inside auth.rs would not be exercised by any test or build until the Actix port lands. Doing the port itself is a meaningful undertaking (rewriting middleware + handler signatures + integration with apistos) that deserves its own PR. The four issues are real but blocked-by-#40; they're explicitly noted in the PR description here so they don't drop off the radar.

## Behavior change

- **Default build (\`cargo build\`)**: unchanged — auth feature is off.
- **\`--features auth\`**: now fails with a clear message instead of axum-import errors. Same outcome (broken build) but signposted.
- **\`login\` handler under \`--features auth\`**: returns 500 \"Login is not configured\" instead of issuing an Admin JWT. The route is still unmounted so this is dead code today — but if someone wires it tomorrow, no escalation.

## Test plan

- [x] \`cargo build --workspace --exclude graphrag_py --exclude graphrag-wasm\` — clean (matches pre-push hook)
- [x] \`cargo test -p graphrag-server --bin graphrag-server\` — 30/30 (no regressions)
- [x] \`cargo check -p graphrag-server --features auth\` — fails with the new compile_error first, then the (now-redundant) axum errors. The compile_error fires before any further work, so the message is the user's first signal.
- [x] \`cargo fmt --all -- --check\` — clean
- [ ] CI green

## TDD note

No new unit tests:
- The login handler change is observable by HTTP behavior; testing requires the route to actually be mounted. Verified by inspection — the handler body now unconditionally returns an error.
- The compile_error fires at compile time, not runtime; verified by running \`cargo check --features auth\` directly.

## Out of scope

- **#31** JWT secret startup validation — needs Actix port (#40) first.
- **#32** Rate-limit bypass on JWT — same.
- **#45** Clock unwrap → unwrap_or — same.
- **#46** PartialOrd UserRole — same.
- Actix-web port of auth.rs itself (#40 root cause) — separate PR. Suggested next steps: replace \`axum::middleware\` with \`actix-web-httpauth\`, swap \`extract::Extension\` for actix \`HttpRequest\` extensions, rewrite \`IntoResponse\` impl for actix's \`ResponseError\`.
- Real credential store backing \`login\` — separate PR. Needs schema decisions.
- README updates — no current-user-visible change (auth was already broken; now it's broken with a better error message).