### PR TITLE
fix(cli): persist query history across TUI sessions (#62 finish)

### DIFF
--- a/graphrag-cli/src/app.rs
+++ b/graphrag-cli/src/app.rs
@@ -8,7 +8,9 @@ use crate::{
     theme::Theme,
     tui::{Event, Tui},
     ui::{HelpOverlay, InfoPanel, QueryInput, RawResultsViewer, ResultsViewer, StatusBar},
-    workspace::{cli_workspaces_dir, CliWorkspaceManager, WorkspaceMetadata},
+    workspace::{
+        cli_workspaces_dir, global_query_history_path, CliWorkspaceManager, WorkspaceMetadata,
+    },
 };
 use chrono::Utc;
 use color_eyre::eyre::Result;
@@ -67,6 +69,33 @@ impl App {
 
         let workspace_manager = CliWorkspaceManager::new()?;
 
+        // Best-effort restore of the previous session's query history (#62).
+        // Failure is silent: a fresh install has no history file, and a
+        // corrupt one shouldn't block TUI startup. Worst case the user
+        // starts with an empty history — same as the prior behavior.
+        let query_history = match global_query_history_path() {
+            Ok(path) if path.exists() => {
+                // Use blocking std::fs here because we're not in a tokio
+                // context yet; QueryHistory::load is async only because the
+                // existing API was async. A small sync read at startup is
+                // fine and simpler than spawning a runtime just for this.
+                match std::fs::read_to_string(&path)
+                    .ok()
+                    .and_then(|s| serde_json::from_str::<QueryHistory>(&s).ok())
+                {
+                    Some(h) => h,
+                    None => {
+                        tracing::warn!(
+                            path = %path.display(),
+                            "Could not parse query history file; starting fresh"
+                        );
+                        QueryHistory::new()
+                    },
+                }
+            },
+            _ => QueryHistory::new(),
+        };
+
         Ok(Self {
             should_quit: false,
             tui: Tui::new()?,
@@ -79,7 +108,7 @@ impl App {
             info_panel: InfoPanel::new(),
             status_bar: StatusBar::new(),
             help_overlay: HelpOverlay::new(),
-            query_history: QueryHistory::new(),
+            query_history,
             workspace_manager,
             workspace_metadata: None,
             config_path,
@@ -182,6 +211,23 @@ impl App {
                     help_overlay.render(f, f.area());
                 }
             })?;
+        }
+
+        // Persist query history before tearing down (#62). Best-effort —
+        // a write failure shouldn't block TUI shutdown; log and continue.
+        match global_query_history_path() {
+            Ok(path) => {
+                if let Err(e) = self.query_history.save(&path).await {
+                    tracing::warn!(
+                        path = %path.display(),
+                        error = %e,
+                        "Failed to persist query history on exit"
+                    );
+                }
+            },
+            Err(e) => {
+                tracing::warn!("Cannot resolve query history path: {e}");
+            },
         }
 
         // Exit TUI mode

--- a/graphrag-cli/src/query_history.rs
+++ b/graphrag-cli/src/query_history.rs
@@ -77,11 +77,18 @@ impl QueryHistory {
         self.entries.len()
     }
 
-    /// Save to file
-    #[allow(dead_code)]
+    /// Save to file (atomic via `.tmp` + rename — same pattern as
+    /// `CliWorkspaceManager::save_metadata`, see #53).
     pub async fn save(&self, path: &PathBuf) -> Result<()> {
+        // Ensure the parent dir exists; the data dir won't be there on a
+        // fresh install until something writes into it.
+        if let Some(parent) = path.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
         let json = serde_json::to_string_pretty(self)?;
-        tokio::fs::write(path, json).await?;
+        let tmp = path.with_extension("json.tmp");
+        tokio::fs::write(&tmp, json).await?;
+        tokio::fs::rename(&tmp, path).await?;
         Ok(())
     }
 

--- a/graphrag-cli/src/workspace.rs
+++ b/graphrag-cli/src/workspace.rs
@@ -72,6 +72,20 @@ pub fn cli_workspaces_dir() -> Result<PathBuf> {
     Ok(base.join("graphrag").join("workspaces"))
 }
 
+/// Resolve the path for the global query history file (workspace-agnostic).
+///
+/// Lives in the data dir alongside the workspaces tree, *not* inside any
+/// workspace, so the TUI can persist its in-memory `App::query_history`
+/// without needing an active workspace context. (Workspace-scoped history
+/// is a separate enhancement that requires the active-workspace plumbing
+/// not currently in place — see #62.)
+pub fn global_query_history_path() -> Result<PathBuf> {
+    Ok(cli_workspaces_dir()?
+        .parent()
+        .ok_or_else(|| eyre!("workspaces dir has no parent"))?
+        .join("query_history.json"))
+}
+
 /// CLI workspace registry.
 pub struct CliWorkspaceManager {
     /// Base directory for workspaces


### PR DESCRIPTION
## Summary

Closes the persistence half of #62. \`QueryHistory::save\` was \`#[allow(dead_code)]\` and never invoked; the TUI accumulated history in memory and dropped it on exit. Wired up via a workspace-agnostic global path so persistence ships today without needing the active-workspace plumbing (which doesn't exist yet).

| Change | Purpose |
|---|---|
| \`workspace::global_query_history_path()\` | Returns \`<data_dir>/graphrag/query_history.json\` — sibling to the workspaces tree, not inside any workspace |
| \`QueryHistory::save\` | No longer \`#[allow(dead_code)]\`. Uses the same atomic write pattern as \`CliWorkspaceManager::save_metadata\` (\`.tmp\` + \`fs::rename\`, see #53). Auto-creates parent dir. |
| \`App::new\` | Best-effort restores the previous session's history at startup |
| \`App::run\` | Saves before TUI teardown. Both failure paths log and continue. |

Closes #62

## What's NOT here

Workspace-scoped history (\`<workspace>/query_history.json\` per workspace) is a future enhancement that needs the active-workspace state tracked through the TUI. The current global path is the minimum useful shipment.

## Test plan

- [x] \`cargo test -p graphrag-cli --lib\` — 53/53 passing
- [x] \`cargo build --workspace --exclude graphrag_py --exclude graphrag-wasm\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [ ] CI green
- [ ] Manual: run \`graphrag tui\`, execute a query, exit. Re-run TUI — verify the History tab shows the prior query.

## Out of scope

- Workspace-scoped history (sequenced after active-workspace plumbing)
- #27 dead-code audit (34 \`#[allow(dead_code)]\` sites — needs per-call-site judgement; deferred to a follow-up to avoid mis-call risk)