### PR TITLE
feat(examples): add sales-transcripts end-to-end demo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8382,6 +8382,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "sales-transcripts-demo"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "arrow",
+ "clap",
+ "graphrag-core",
+ "parquet",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "ureq",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "graphrag-cli",
     "graphrag_py",
     "graphrag",
+    "examples/sales-transcripts-demo",
 ]
 exclude = ["examples/web-app"]
 resolver = "2"

--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ New to GraphRAG? Start here:
 - 🏗️ **[Pipeline Architecture](graphrag-core/PIPELINE_ARCHITECTURE.md)** - Technical deep dive into implementation details
 - 💡 **[Examples](examples/)** - Hands-on code examples from basic to advanced
 - 📊 **[Multi-Document Pipeline](examples/MULTI_DOCUMENT_PIPELINE.md)** - Production-ready example with benchmarks
+- 🤝 **[Sales-Transcripts Demo](examples/sales-transcripts-demo/)** - End-to-end ingest → index → query against the public `gwenshap/sales-transcripts` Hugging Face dataset
 - ⚙️ **[Pipeline Architecture](graphrag-core/PIPELINE_ARCHITECTURE.md)** - Detailed 7-phase configuration & performance guide
 
 ### Complete 7-Stage Pipeline Schema

--- a/examples/sales-transcripts-demo/.gitignore
+++ b/examples/sales-transcripts-demo/.gitignore
@@ -1,0 +1,5 @@
+data/raw/
+data/txt/
+output/
+workspace/
+target/

--- a/examples/sales-transcripts-demo/Cargo.toml
+++ b/examples/sales-transcripts-demo/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "sales-transcripts-demo"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+description = "End-to-end demo: ingest gwenshap/sales-transcripts (HuggingFace), index, query"
+
+[lib]
+path = "src/lib.rs"
+
+[[bin]]
+name = "sales-fetch"
+path = "src/bin/fetch.rs"
+
+[[bin]]
+name = "sales-to-text"
+path = "src/bin/to_text.rs"
+
+[[bin]]
+name = "sales-pipeline"
+path = "src/bin/pipeline.rs"
+
+[dependencies]
+graphrag-core = { path = "../../graphrag-core", features = ["async", "memory-storage", "basic-retrieval"] }
+tokio = { workspace = true }
+anyhow = "1"
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+clap = { workspace = true }
+
+# Parquet ingestion (HuggingFace ships datasets as parquet)
+arrow = { workspace = true, features = ["ipc"] }
+parquet = { version = "57", default-features = false, features = ["arrow", "snap"] }
+
+# HF download (reuse the workspace HTTP client)
+ureq = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/examples/sales-transcripts-demo/README.md
+++ b/examples/sales-transcripts-demo/README.md
@@ -1,0 +1,103 @@
+# Sales-Transcripts End-to-End Demo
+
+End-to-end ingest → index → query against the public
+[`gwenshap/sales-transcripts`](https://huggingface.co/datasets/gwenshap/sales-transcripts)
+dataset on Hugging Face.
+
+The demo pulls Hugging Face's auto-converted parquet shard at
+`refs/convert/parquet/default/train/0000.parquet` — that's 995 rows of pure
+transcript text (~140 KB compressed). The dataset card reports 1,935 rows and
+~34 MB total because it counts a separate config that bundles pre-computed
+OpenAI embeddings; we don't need those here, since `graphrag-core` builds its
+own.
+
+This crate is a self-contained reference for embedding `graphrag-core` into your
+own project: a small library entry point (`run_pipeline`) plus three thin
+binaries (`fetch`, `to_text`, `pipeline`) that wire it together.
+
+## Run the demo (zero-LLM, ~2 seconds)
+
+```bash
+# 1. Download the parquet shard from Hugging Face (~140 KB, no auth required).
+cargo run -p sales-transcripts-demo --bin sales-fetch
+
+# 2. Flatten parquet into per-transcript .txt files (cap with --limit for speed).
+cargo run -p sales-transcripts-demo --bin sales-to-text -- --limit 200
+
+# 3. Build the graph and answer a curated query set.
+cargo run -p sales-transcripts-demo --bin sales-pipeline
+```
+
+The default mode (`--mode hash`) uses pattern-based entity extraction and hash
+embeddings — no API keys, no Ollama, no model downloads. End-to-end on 200
+transcripts takes around 2 seconds.
+
+## Run with local LLM synthesis (Ollama)
+
+```bash
+ollama pull mistral-nemo
+ollama pull nomic-embed-text
+
+cargo run -p sales-transcripts-demo --bin sales-pipeline -- \
+  --mode ollama \
+  --transcripts examples/sales-transcripts-demo/data/txt
+```
+
+`--mode ollama` enables LLM-driven entity extraction (gleaning) and answer
+synthesis. Embeddings still come from the configured Ollama model. Expect
+roughly 30s–2min depending on transcript count and your local hardware.
+
+## Run via the graphrag CLI / TUI
+
+The demo ships two JSON5 configs that work with the existing graphrag-cli flows:
+
+```bash
+# Non-interactive bench against the hash-only config.
+cargo run -p graphrag-cli -- bench \
+  --config examples/sales-transcripts-demo/configs/sales_hash_only.json5 \
+  --book examples/sales-transcripts-demo/data/all.txt \
+  --questions "What products are mentioned?|What objections come up most?"
+
+# Interactive TUI with local Ollama.
+cargo run -p graphrag-cli -- tui \
+  --config examples/sales-transcripts-demo/configs/sales_ollama.json5
+```
+
+For TUI use, generate the concatenated `data/all.txt` from per-transcript files:
+
+```bash
+cat examples/sales-transcripts-demo/data/txt/*.txt \
+  > examples/sales-transcripts-demo/data/all.txt
+```
+
+## Layout
+
+| Path | What it does |
+| --- | --- |
+| `src/lib.rs` | `run_pipeline(transcripts_dir, config) -> DemoSession` — one-call ingest+index, returns a session you keep asking. |
+| `src/bin/fetch.rs` | Downloads `gwenshap/sales-transcripts` parquet shard from HF (no `huggingface-cli` required, just `ureq`). |
+| `src/bin/to_text.rs` | Reads parquet via `arrow`/`parquet`, writes one `transcript_NNNN.txt` per row. |
+| `src/bin/pipeline.rs` | The full demo: builds Config programmatically, runs ingest+index+query loop, prints `ask_explained` answers with sources. |
+| `configs/sales_hash_only.json5` | Algorithmic mode, no API keys. Drives `graphrag-cli bench` / `tui`. |
+| `configs/sales_ollama.json5` | Semantic mode, local Ollama. Drives `graphrag-cli bench` / `tui`. |
+| `tests/pipeline_smoke.rs` | TDD smoke test: ingest 6 committed sample transcripts, assert retrieval surfaces the recurring entity. Runs in CI without API keys. |
+| `tests/fixtures/sample_transcripts/` | 6 hand-crafted transcripts referencing "Helio Analytics" and "Northwind Logistics" — the smoke test's input. |
+
+## Hybrid mode (cloud embeddings + local Ollama chat)
+
+Not yet wired end-to-end. `graphrag-core` currently constructs a hash embedder
+unconditionally inside `RetrievalSystem::new` regardless of
+`config.embeddings.backend`, so setting `backend = "openai"` has no runtime
+effect (acknowledged in-tree at `graphrag-core/src/retrieval/mod.rs:75-81`).
+Tracked in [#91](https://github.com/mfaulk/graphrag-rs/issues/91).
+
+A native Anthropic / OpenAI **chat** backend (separate from embeddings) is
+tracked in [#90](https://github.com/mfaulk/graphrag-rs/issues/90).
+
+## What zero-LLM mode actually delivers
+
+A heads-up so the demo output isn't surprising: with `--mode hash`, entity
+extraction is regex + capitalization heuristics and answer "synthesis" is just
+top-3 retrieved chunks concatenated. You'll see entities like `PERSON_repthanks`
+extracted from `**Sales Rep**: Thanks` — that's the algorithmic pipeline working
+as designed, not a bug. Switch to `--mode ollama` for a coherent experience.

--- a/examples/sales-transcripts-demo/configs/sales_hash_only.json5
+++ b/examples/sales-transcripts-demo/configs/sales_hash_only.json5
@@ -1,0 +1,131 @@
+// Zero-LLM config for the sales-transcripts demo.
+//
+// - Algorithmic entity extraction (regex + capitalization), no Ollama, no API keys.
+// - Hash embeddings (fallback_to_hash) — fast, deterministic, no model download.
+// - Tuned for short multi-turn transcripts (~200 chars each):
+//     chunk_size 256 / overlap 40 keeps each transcript in ~one chunk.
+//
+// Usage:
+//   cargo run -p graphrag-cli -- bench \
+//     --config examples/sales-transcripts-demo/configs/sales_hash_only.json5 \
+//     --book examples/sales-transcripts-demo/data/all.txt \
+//     --questions "What products are sold?|What objections come up most?"
+{
+  "mode": {
+    "approach": "algorithmic"
+  },
+  "general": {
+    "output_dir": "./examples/sales-transcripts-demo/workspace/hash_only",
+    "log_level": "info",
+    "max_threads": 4
+  },
+  "pipeline": {
+    "workflows": ["extract_text", "extract_entities", "build_graph", "detect_communities"],
+    "parallel_execution": true,
+    "text_extraction": {
+      "chunk_size": 256,
+      "chunk_overlap": 40,
+      "min_chunk_size": 60,
+      "clean_control_chars": true,
+      "normalize_whitespace": true
+    },
+    "entity_extraction": {
+      "model_name": "none",
+      "temperature": 0.0,
+      "max_tokens": 1200,
+      "entity_types": ["PERSON", "ORG", "PRODUCT", "PAIN_POINT", "OBJECTION"],
+      "confidence_threshold": 0.6
+    },
+    "graph_building": {
+      "relation_scorer": "cosine_similarity",
+      "min_relation_score": 0.4,
+      "max_connections_per_node": 20,
+      "bidirectional_relations": true
+    },
+    "community_detection": {
+      "algorithm": "leiden",
+      "resolution": 0.8,
+      "min_community_size": 2,
+      "max_community_size": 20
+    }
+  },
+  "text_processing": {
+    "enabled": true,
+    "chunk_size": 256,
+    "chunk_overlap": 40,
+    "min_chunk_size": 60,
+    "max_chunk_size": 800,
+    "normalize_whitespace": true,
+    "remove_artifacts": true,
+    "extract_keywords": true,
+    "keyword_min_score": 0.15
+  },
+  "entity_extraction": {
+    "enabled": true,
+    "min_confidence": 0.6,
+    "use_gleaning": false,
+    "max_gleaning_rounds": 0,
+    "gleaning_improvement_threshold": 0.08,
+    "semantic_merging": true,
+    "merge_similarity_threshold": 0.85,
+    "automatic_linking": true,
+    "linking_confidence_threshold": 0.7
+  },
+  "graph_construction": {
+    "enabled": true,
+    "incremental_updates": true,
+    "use_pagerank": true,
+    "pagerank_damping": 0.85,
+    "pagerank_iterations": 50,
+    "pagerank_convergence": 0.0001,
+    "extract_relationships": true,
+    "relationship_confidence_threshold": 0.5
+  },
+  "vector_processing": {
+    "enabled": true,
+    "embedding_model": "none",
+    "embedding_dimensions": 384,
+    "use_hnsw_index": true,
+    "hnsw_ef_construction": 200,
+    "hnsw_m": 16,
+    "similarity_threshold": 0.7
+  },
+  "query_processing": {
+    "enabled": true,
+    "use_advanced_pipeline": true,
+    "use_intent_classification": true,
+    "use_concept_extraction": true,
+    "use_temporal_parsing": false,
+    "confidence_threshold": 0.5
+  },
+  "ollama": {
+    "enabled": false,
+    "host": "http://localhost",
+    "port": 11434,
+    "chat_model": "none",
+    "embedding_model": "none",
+    "timeout_seconds": 120,
+    "max_retries": 3,
+    "fallback_to_hash": true,
+    "max_tokens": 1200,
+    "temperature": 0.0,
+    "generation": {
+      "temperature": 0.0,
+      "top_p": 0.9,
+      "max_tokens": 1500,
+      "stream": false
+    }
+  },
+  "performance": {
+    "batch_processing": true,
+    "batch_size": 50,
+    "worker_threads": 4,
+    "memory_limit_mb": 2048,
+    "cache_embeddings": true
+  },
+  "auto_save": {
+    "enabled": true,
+    "base_dir": "./examples/sales-transcripts-demo/workspace",
+    "workspace_name": "sales_hash_only"
+  }
+}

--- a/examples/sales-transcripts-demo/configs/sales_ollama.json5
+++ b/examples/sales-transcripts-demo/configs/sales_ollama.json5
@@ -1,0 +1,136 @@
+// Local-Ollama config for the sales-transcripts demo.
+//
+// - Semantic entity extraction via local Ollama (mistral-nemo:latest).
+// - Local Ollama nomic-embed-text for embeddings.
+// - No API keys required, but needs Ollama running:
+//     ollama pull mistral-nemo
+//     ollama pull nomic-embed-text
+//
+// Note: cloud embeddings (e.g. OpenAI text-embedding-3-small) are not yet
+// wired end-to-end. graphrag-cli's JSON5 loader hardcodes embeddings.backend
+// to "ollama" in SetConfig::to_graphrag_config, and graphrag-core's
+// RetrievalSystem ignores the configured backend regardless. Tracked in
+// graphrag-rs#91.
+//
+// Usage:
+//   cargo run -p graphrag-cli -- tui \
+//     --config examples/sales-transcripts-demo/configs/sales_ollama.json5
+{
+  "mode": {
+    "approach": "semantic"
+  },
+  "general": {
+    "output_dir": "./examples/sales-transcripts-demo/workspace/ollama",
+    "log_level": "info",
+    "max_threads": 4
+  },
+  "pipeline": {
+    "workflows": ["extract_text", "extract_entities", "build_graph", "detect_communities"],
+    "parallel_execution": true,
+    "text_extraction": {
+      "chunk_size": 256,
+      "chunk_overlap": 40,
+      "min_chunk_size": 60,
+      "clean_control_chars": true,
+      "normalize_whitespace": true
+    },
+    "entity_extraction": {
+      "model_name": "mistral-nemo:latest",
+      "temperature": 0.1,
+      "max_tokens": 1500,
+      "entity_types": ["PERSON", "ORG", "PRODUCT", "PAIN_POINT", "OBJECTION"],
+      "confidence_threshold": 0.6
+    },
+    "graph_building": {
+      "relation_scorer": "cosine_similarity",
+      "min_relation_score": 0.4,
+      "max_connections_per_node": 20,
+      "bidirectional_relations": true
+    },
+    "community_detection": {
+      "algorithm": "leiden",
+      "resolution": 0.8,
+      "min_community_size": 2,
+      "max_community_size": 20
+    }
+  },
+  "text_processing": {
+    "enabled": true,
+    "chunk_size": 256,
+    "chunk_overlap": 40,
+    "min_chunk_size": 60,
+    "max_chunk_size": 800,
+    "normalize_whitespace": true,
+    "remove_artifacts": true,
+    "extract_keywords": true,
+    "keyword_min_score": 0.15
+  },
+  "entity_extraction": {
+    "enabled": true,
+    "min_confidence": 0.6,
+    "use_gleaning": true,
+    "max_gleaning_rounds": 1,
+    "gleaning_improvement_threshold": 0.08,
+    "semantic_merging": true,
+    "merge_similarity_threshold": 0.85,
+    "automatic_linking": true,
+    "linking_confidence_threshold": 0.7
+  },
+  "graph_construction": {
+    "enabled": true,
+    "incremental_updates": true,
+    "use_pagerank": true,
+    "pagerank_damping": 0.85,
+    "pagerank_iterations": 50,
+    "pagerank_convergence": 0.0001,
+    "extract_relationships": true,
+    "relationship_confidence_threshold": 0.5
+  },
+  "vector_processing": {
+    "enabled": true,
+    "embedding_model": "nomic-embed-text",
+    "embedding_dimensions": 768,
+    "use_hnsw_index": true,
+    "hnsw_ef_construction": 200,
+    "hnsw_m": 16,
+    "similarity_threshold": 0.7
+  },
+  "query_processing": {
+    "enabled": true,
+    "use_advanced_pipeline": true,
+    "use_intent_classification": true,
+    "use_concept_extraction": true,
+    "use_temporal_parsing": false,
+    "confidence_threshold": 0.5
+  },
+  "ollama": {
+    "enabled": true,
+    "host": "http://localhost",
+    "port": 11434,
+    "chat_model": "mistral-nemo:latest",
+    "embedding_model": "nomic-embed-text",
+    "timeout_seconds": 180,
+    "max_retries": 3,
+    "fallback_to_hash": true,
+    "max_tokens": 1500,
+    "temperature": 0.1,
+    "generation": {
+      "temperature": 0.1,
+      "top_p": 0.9,
+      "max_tokens": 1500,
+      "stream": false
+    }
+  },
+  "performance": {
+    "batch_processing": true,
+    "batch_size": 50,
+    "worker_threads": 4,
+    "memory_limit_mb": 4096,
+    "cache_embeddings": true
+  },
+  "auto_save": {
+    "enabled": true,
+    "base_dir": "./examples/sales-transcripts-demo/workspace",
+    "workspace_name": "sales_ollama"
+  }
+}

--- a/examples/sales-transcripts-demo/src/bin/fetch.rs
+++ b/examples/sales-transcripts-demo/src/bin/fetch.rs
@@ -1,0 +1,87 @@
+use std::fs::{self, File};
+use std::io;
+use std::path::PathBuf;
+
+use anyhow::{anyhow, Context, Result};
+use clap::Parser;
+
+const DEFAULT_URL: &str =
+    "https://huggingface.co/datasets/gwenshap/sales-transcripts/resolve/refs%2Fconvert%2Fparquet/default/train/0000.parquet";
+
+const DEFAULT_OUTPUT: &str = "examples/sales-transcripts-demo/data/raw/0000.parquet";
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "sales-fetch",
+    about = "Download the gwenshap/sales-transcripts parquet shard from HuggingFace"
+)]
+struct Args {
+    /// Override the source URL (defaults to the HF auto-converted parquet shard).
+    #[arg(long, default_value = DEFAULT_URL)]
+    url: String,
+
+    /// Destination path for the downloaded parquet file.
+    #[arg(short, long, default_value = DEFAULT_OUTPUT)]
+    output: PathBuf,
+
+    /// Re-download even if the destination file already exists.
+    #[arg(long)]
+    force: bool,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+
+    if args.output.exists() && !args.force {
+        println!(
+            "{} already exists — pass --force to re-download",
+            args.output.display()
+        );
+        return Ok(());
+    }
+
+    if let Some(parent) = args.output.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("create_dir_all({})", parent.display()))?;
+    }
+
+    println!("downloading {} → {}", args.url, args.output.display());
+    let response = ureq::get(&args.url)
+        .call()
+        .map_err(|e| anyhow!("HTTP GET {}: {e}", args.url))?;
+
+    let status = response.status();
+    if !(200..300).contains(&status) {
+        return Err(anyhow!("unexpected HTTP status: {}", status));
+    }
+
+    // Atomic write: stream to a sibling .tmp file, then rename. If the HTTP
+    // body drops mid-stream, the destination path is left untouched and a
+    // subsequent run (without --force) will retry instead of feeding a
+    // half-written file to the parquet parser.
+    let mut tmp_path = args.output.clone();
+    let tmp_name = match args.output.file_name() {
+        Some(n) => format!("{}.tmp", n.to_string_lossy()),
+        None => {
+            return Err(anyhow!(
+                "output path has no file name: {}",
+                args.output.display()
+            ))
+        },
+    };
+    tmp_path.set_file_name(&tmp_name);
+
+    let mut reader = response.into_reader();
+    let bytes = {
+        let mut tmp_file =
+            File::create(&tmp_path).with_context(|| format!("create {}", tmp_path.display()))?;
+        io::copy(&mut reader, &mut tmp_file)
+            .with_context(|| format!("write {}", tmp_path.display()))?
+    };
+
+    fs::rename(&tmp_path, &args.output)
+        .with_context(|| format!("rename {} -> {}", tmp_path.display(), args.output.display()))?;
+
+    println!("wrote {} bytes to {}", bytes, args.output.display());
+    Ok(())
+}

--- a/examples/sales-transcripts-demo/src/bin/pipeline.rs
+++ b/examples/sales-transcripts-demo/src/bin/pipeline.rs
@@ -1,0 +1,133 @@
+use std::path::PathBuf;
+
+use anyhow::Result;
+use clap::{Parser, ValueEnum};
+use sales_transcripts_demo::run_pipeline;
+
+#[derive(Copy, Clone, Debug, ValueEnum)]
+enum Mode {
+    /// Algorithmic extraction + hash embeddings. Zero deps, deterministic, fast.
+    Hash,
+    /// Semantic extraction via local Ollama (mistral-nemo + nomic-embed-text).
+    /// Requires `ollama serve` running locally and both models pulled.
+    Ollama,
+}
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "sales-pipeline",
+    about = "End-to-end demo: ingest sales-transcripts → build graph → answer queries"
+)]
+struct Args {
+    /// Directory of per-transcript .txt files (output of `sales-to-text`).
+    #[arg(
+        short,
+        long,
+        default_value = "examples/sales-transcripts-demo/data/txt"
+    )]
+    transcripts: PathBuf,
+
+    /// Pipeline mode.
+    #[arg(short, long, value_enum, default_value_t = Mode::Hash)]
+    mode: Mode,
+
+    /// Pipe-separated query list. Each query is run with `ask_explained`.
+    #[arg(
+        short,
+        long,
+        default_value = "What products are mentioned across these transcripts?\
+                        |What objections do customers raise about pricing?\
+                        |What integration concerns come up?\
+                        |Which customers are blocked by procurement timelines?"
+    )]
+    queries: String,
+}
+
+#[allow(clippy::field_reassign_with_default)]
+fn build_config(mode: Mode) -> graphrag_core::Config {
+    let mut config = graphrag_core::Config::default();
+    config.chunk_size = 256;
+    config.chunk_overlap = 40;
+    config.text.chunk_size = 256;
+    config.text.chunk_overlap = 40;
+    config.top_k_results = Some(5);
+    config.entities.entity_types = vec![
+        "PERSON".to_string(),
+        "ORG".to_string(),
+        "PRODUCT".to_string(),
+        "PAIN_POINT".to_string(),
+        "OBJECTION".to_string(),
+    ];
+
+    match mode {
+        Mode::Hash => {
+            config.approach = "algorithmic".to_string();
+            config.ollama.enabled = false;
+            config.embeddings.fallback_to_hash = true;
+        },
+        Mode::Ollama => {
+            config.approach = "semantic".to_string();
+            config.ollama.enabled = true;
+            config.ollama.chat_model = "mistral-nemo:latest".to_string();
+            config.ollama.embedding_model = "nomic-embed-text".to_string();
+            config.entities.use_gleaning = true;
+            config.entities.max_gleaning_rounds = 1;
+            config.embeddings.fallback_to_hash = true;
+        },
+    }
+
+    config
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
+        )
+        .init();
+
+    let args = Args::parse();
+    let queries: Vec<&str> = args.queries.split('|').map(str::trim).collect();
+
+    if matches!(args.mode, Mode::Ollama) {
+        println!(
+            "ℹ Ollama mode: chat synthesis + LLM entity extraction use Ollama, but \
+             retrieval embeddings remain hash-based until graphrag-rs#91 wires the \
+             configured embedder into RetrievalSystem."
+        );
+    }
+
+    println!(
+        "▶ ingesting transcripts from {} (mode: {:?})",
+        args.transcripts.display(),
+        args.mode
+    );
+    let started = std::time::Instant::now();
+    let mut session = run_pipeline(&args.transcripts, build_config(args.mode)).await?;
+    println!(
+        "✔ ingested {} transcript(s) and built graph in {:.2}s\n",
+        session.docs_loaded(),
+        started.elapsed().as_secs_f32()
+    );
+
+    for (i, query) in queries.iter().enumerate() {
+        println!("─── query {} ───────────────────────────────", i + 1);
+        println!("Q: {query}");
+        let answer = session.ask(query).await?;
+        println!("A: {}", answer.answer);
+        println!("confidence: {:.0}%", answer.confidence * 100.0);
+        println!("sources ({}):", answer.sources.len());
+        for src in answer.sources.iter().take(3) {
+            let snippet: String = src.excerpt.chars().take(120).collect();
+            println!(
+                "  • [{:?} {} · {:.2}] {snippet}",
+                src.source_type, src.id, src.relevance_score
+            );
+        }
+        println!();
+    }
+
+    Ok(())
+}

--- a/examples/sales-transcripts-demo/src/bin/to_text.rs
+++ b/examples/sales-transcripts-demo/src/bin/to_text.rs
@@ -1,0 +1,125 @@
+use std::fs::{self, File};
+use std::path::PathBuf;
+
+use anyhow::{anyhow, Context, Result};
+use arrow::array::{Array, StringArray};
+use clap::Parser;
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+
+const DEFAULT_INPUT: &str = "examples/sales-transcripts-demo/data/raw/0000.parquet";
+const DEFAULT_OUTPUT: &str = "examples/sales-transcripts-demo/data/txt";
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "sales-to-text",
+    about = "Flatten gwenshap/sales-transcripts parquet into per-transcript .txt files"
+)]
+struct Args {
+    /// Path to the parquet shard downloaded from HuggingFace.
+    #[arg(short, long, default_value = DEFAULT_INPUT)]
+    input: PathBuf,
+
+    /// Directory where transcript_NNNN.txt files are written.
+    #[arg(short, long, default_value = DEFAULT_OUTPUT)]
+    output: PathBuf,
+
+    /// Optional cap on the number of transcripts emitted (useful for demos).
+    #[arg(long)]
+    limit: Option<usize>,
+
+    /// Name of the parquet column containing transcript text.
+    #[arg(long, default_value = "text")]
+    column: String,
+}
+
+// Remove every transcript_*.txt under `dir` so a re-run with a smaller --limit
+// doesn't leave stale rows in the corpus that `run_pipeline` would still ingest.
+fn purge_existing_transcripts(dir: &std::path::Path) -> Result<usize> {
+    if !dir.exists() {
+        return Ok(0);
+    }
+    let mut removed = 0usize;
+    for entry in fs::read_dir(dir).with_context(|| format!("read_dir({})", dir.display()))? {
+        let entry = entry?;
+        let path = entry.path();
+        let is_transcript = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.starts_with("transcript_") && n.ends_with(".txt"));
+        if is_transcript {
+            fs::remove_file(&path).with_context(|| format!("remove {}", path.display()))?;
+            removed += 1;
+        }
+    }
+    Ok(removed)
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+
+    if !args.input.exists() {
+        return Err(anyhow!(
+            "input parquet not found at {} — run `cargo run -p sales-transcripts-demo --bin sales-fetch` first",
+            args.input.display()
+        ));
+    }
+    fs::create_dir_all(&args.output)
+        .with_context(|| format!("create_dir_all({})", args.output.display()))?;
+
+    let removed = purge_existing_transcripts(&args.output)?;
+    if removed > 0 {
+        println!(
+            "removed {removed} stale transcript_*.txt file(s) from {}",
+            args.output.display()
+        );
+    }
+
+    let file = File::open(&args.input).with_context(|| format!("open {}", args.input.display()))?;
+    let reader = ParquetRecordBatchReaderBuilder::try_new(file)?
+        .build()
+        .context("build parquet reader")?;
+
+    let mut written = 0usize;
+    'batches: for batch in reader {
+        let batch = batch.context("decode parquet batch")?;
+        let col = batch.column_by_name(&args.column).ok_or_else(|| {
+            anyhow!(
+                "column '{}' not found — available: {:?}",
+                args.column,
+                batch
+                    .schema()
+                    .fields()
+                    .iter()
+                    .map(|f| f.name().clone())
+                    .collect::<Vec<_>>()
+            )
+        })?;
+        let strings = col
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .ok_or_else(|| anyhow!("column '{}' is not Utf8/StringArray", args.column))?;
+
+        for i in 0..strings.len() {
+            if strings.is_null(i) {
+                continue;
+            }
+            let text = strings.value(i);
+            if text.trim().is_empty() {
+                continue;
+            }
+            let out_path = args.output.join(format!("transcript_{written:04}.txt"));
+            fs::write(&out_path, text).with_context(|| format!("write {}", out_path.display()))?;
+            written += 1;
+            if args.limit.is_some_and(|cap| written >= cap) {
+                break 'batches;
+            }
+        }
+    }
+
+    println!(
+        "wrote {} transcript file(s) to {}",
+        written,
+        args.output.display()
+    );
+    Ok(())
+}

--- a/examples/sales-transcripts-demo/src/lib.rs
+++ b/examples/sales-transcripts-demo/src/lib.rs
@@ -1,0 +1,107 @@
+// End-to-end demo of ingest → index → query against the gwenshap/sales-transcripts
+// HuggingFace dataset. Public surface is `run_pipeline`, which the bins and the
+// integration smoke test both go through.
+
+use std::path::Path;
+
+use anyhow::{anyhow, Context, Result};
+use graphrag_core::retrieval::ExplainedAnswer;
+use tokio::fs;
+
+/// Minimal handle returned by [`run_pipeline`]. Owns the live `GraphRAG`
+/// instance so callers can keep asking follow-up questions without rebuilding
+/// the graph.
+pub struct DemoSession {
+    inner: graphrag_core::GraphRAG,
+    docs_loaded: usize,
+}
+
+impl DemoSession {
+    /// Number of transcript files ingested into this session.
+    pub fn docs_loaded(&self) -> usize {
+        self.docs_loaded
+    }
+
+    /// Run a follow-up query against the already-built graph.
+    pub async fn ask(&mut self, query: &str) -> Result<ExplainedAnswer> {
+        let answer = self
+            .inner
+            .ask_explained(query)
+            .await
+            .map_err(|e| anyhow!("ask_explained failed: {e}"))?;
+        Ok(answer)
+    }
+}
+
+/// Ingest every `*.txt` file under `transcripts_dir` (one transcript per file),
+/// build the knowledge graph using the supplied [`graphrag_core::Config`], and
+/// return a session ready to answer queries.
+///
+/// This is the single integration point exercised by the smoke test. Bins layer
+/// fetch + parquet→txt conversion on top of it.
+pub async fn run_pipeline(
+    transcripts_dir: &Path,
+    config: graphrag_core::Config,
+) -> Result<DemoSession> {
+    let metadata = fs::metadata(transcripts_dir)
+        .await
+        .with_context(|| format!("metadata({})", transcripts_dir.display()))?;
+    if !metadata.is_dir() {
+        return Err(anyhow!(
+            "transcripts_dir is not a directory: {}",
+            transcripts_dir.display()
+        ));
+    }
+
+    let mut paths = Vec::new();
+    let mut entries = fs::read_dir(transcripts_dir)
+        .await
+        .with_context(|| format!("read_dir({})", transcripts_dir.display()))?;
+    while let Some(entry) = entries
+        .next_entry()
+        .await
+        .with_context(|| format!("next_entry({})", transcripts_dir.display()))?
+    {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) == Some("txt") {
+            paths.push(path);
+        }
+    }
+    paths.sort();
+    if paths.is_empty() {
+        return Err(anyhow!(
+            "no .txt transcripts found under {}",
+            transcripts_dir.display()
+        ));
+    }
+
+    let mut graphrag =
+        graphrag_core::GraphRAG::new(config).map_err(|e| anyhow!("GraphRAG::new failed: {e}"))?;
+    graphrag
+        .initialize()
+        .map_err(|e| anyhow!("GraphRAG::initialize failed: {e}"))?;
+
+    let mut docs_loaded = 0usize;
+    for path in &paths {
+        let content = fs::read_to_string(path)
+            .await
+            .with_context(|| format!("read {}", path.display()))?;
+        if content.trim().is_empty() {
+            continue;
+        }
+        graphrag
+            .add_document_from_text(&content)
+            .map_err(|e| anyhow!("add_document_from_text({}): {e}", path.display()))?;
+        docs_loaded += 1;
+    }
+
+    graphrag
+        .build_graph()
+        .await
+        .map_err(|e| anyhow!("build_graph failed: {e}"))?;
+
+    Ok(DemoSession {
+        inner: graphrag,
+        docs_loaded,
+    })
+}

--- a/examples/sales-transcripts-demo/tests/fixtures/sample_transcripts/transcript_0001.txt
+++ b/examples/sales-transcripts-demo/tests/fixtures/sample_transcripts/transcript_0001.txt
@@ -1,0 +1,5 @@
+**Sales Rep**: Hi Jordan, thanks for taking my call. I wanted to walk you through how Helio Analytics could help your team cut reporting time.
+**Customer**: Sure, but pricing is going to be the deciding factor for us this quarter.
+**Sales Rep**: Understood. Our standard tier starts at four thousand a month, and we can talk about discounts for an annual commit.
+**Customer**: That's higher than I expected. Can you send a one-pager I can share with finance?
+**Sales Rep**: Absolutely, I'll have it in your inbox by end of day.

--- a/examples/sales-transcripts-demo/tests/fixtures/sample_transcripts/transcript_0002.txt
+++ b/examples/sales-transcripts-demo/tests/fixtures/sample_transcripts/transcript_0002.txt
@@ -1,0 +1,4 @@
+**Sales Rep**: Morning Priya. Following up on the Helio Analytics demo last week — what's resonating with your team?
+**Customer**: The dashboards looked great. Honestly, the blocker is integration. We're on a custom Postgres setup and migrations scare us.
+**Sales Rep**: That's fair. We have a connector library for Postgres and a solutions engineer can scope the migration on a thirty-minute call.
+**Customer**: Set that up. If integration is clean, budget conversations get easier.

--- a/examples/sales-transcripts-demo/tests/fixtures/sample_transcripts/transcript_0003.txt
+++ b/examples/sales-transcripts-demo/tests/fixtures/sample_transcripts/transcript_0003.txt
@@ -1,0 +1,4 @@
+**Sales Rep**: Hi Marcus. I know Northwind Logistics is evaluating a few options. What's the timeline pressure look like on your end?
+**Customer**: We need a vendor signed by end of quarter, otherwise the whole rollout slips to next year.
+**Sales Rep**: Got it. Helio Analytics can stand up a pilot tenant in under a week. Would that buy you the timeline cushion you need?
+**Customer**: A pilot would help, but procurement still takes three weeks no matter what.

--- a/examples/sales-transcripts-demo/tests/fixtures/sample_transcripts/transcript_0004.txt
+++ b/examples/sales-transcripts-demo/tests/fixtures/sample_transcripts/transcript_0004.txt
@@ -1,0 +1,4 @@
+**Sales Rep**: Hi Priya, circling back on the Helio Analytics pilot. Has the solutions engineer reached out about the Postgres connector?
+**Customer**: Yes, we mapped the schema yesterday. Integration looks doable. Now I'm back to the pricing question.
+**Sales Rep**: We can offer fifteen percent off for an annual contract signed before quarter end.
+**Customer**: That's enough to get this past finance. Send the redlined contract.

--- a/examples/sales-transcripts-demo/tests/fixtures/sample_transcripts/transcript_0005.txt
+++ b/examples/sales-transcripts-demo/tests/fixtures/sample_transcripts/transcript_0005.txt
@@ -1,0 +1,4 @@
+**Sales Rep**: Hey Marcus, quick check-in. Any progress on procurement for the Northwind Logistics deal?
+**Customer**: Legal flagged the data residency clause. Helio Analytics needs to confirm EU hosting before we can move.
+**Sales Rep**: Good catch. We host EU customers in Frankfurt with full GDPR coverage. I'll have legal send the data processing addendum today.
+**Customer**: Send it. If that lands, we can sign by Friday.

--- a/examples/sales-transcripts-demo/tests/fixtures/sample_transcripts/transcript_0006.txt
+++ b/examples/sales-transcripts-demo/tests/fixtures/sample_transcripts/transcript_0006.txt
@@ -1,0 +1,4 @@
+**Sales Rep**: Hi Jordan, I noticed Helio Analytics hasn't heard back from you in two weeks. Is the project still active?
+**Customer**: It's active, but priorities shifted. Our CFO wants to delay all new vendor spend until next quarter.
+**Sales Rep**: I appreciate the candor. Can we schedule a fifteen-minute call once the new quarter starts so we're ready to move?
+**Customer**: That works. Put it on my calendar for the first week of the new quarter.

--- a/examples/sales-transcripts-demo/tests/pipeline_smoke.rs
+++ b/examples/sales-transcripts-demo/tests/pipeline_smoke.rs
@@ -1,0 +1,74 @@
+use std::path::PathBuf;
+
+use graphrag_core::Config;
+use sales_transcripts_demo::run_pipeline;
+
+fn fixtures_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("sample_transcripts")
+}
+
+#[allow(clippy::field_reassign_with_default)]
+fn hash_only_config() -> Config {
+    let mut config = Config::default();
+    config.chunk_size = 256;
+    config.chunk_overlap = 40;
+    config.top_k_results = Some(5);
+    // Force the Ollama LLM call off so the test runs offline; the retrieval
+    // surface is what the smoke test validates, not LLM synthesis.
+    config.ollama.enabled = false;
+    config.embeddings.fallback_to_hash = true;
+    config
+}
+
+// End-to-end ingest → index → query against six committed sample transcripts:
+// run_pipeline must build a graph from per-transcript .txt files and surface
+// the recurring "Helio Analytics" entity in retrieval sources.
+#[tokio::test]
+async fn smoke_ingest_index_query_returns_sources() {
+    let dir = fixtures_dir();
+    assert!(
+        dir.is_dir(),
+        "fixtures dir missing at {} — committed sample transcripts required",
+        dir.display()
+    );
+    let txt_count = std::fs::read_dir(&dir)
+        .expect("read fixtures dir")
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().and_then(|s| s.to_str()) == Some("txt"))
+        .count();
+    assert!(
+        txt_count >= 5,
+        "expected at least 5 fixture transcripts, found {txt_count}"
+    );
+
+    let mut session = run_pipeline(&dir, hash_only_config())
+        .await
+        .expect("run_pipeline should succeed on committed fixtures");
+
+    let answer = session
+        .ask("What is Helio Analytics and what objections do customers raise?")
+        .await
+        .expect("ask should return an explained answer");
+
+    assert!(
+        !answer.sources.is_empty(),
+        "expected at least one retrieved source for a query about Helio Analytics"
+    );
+
+    let any_source_mentions_helio = answer
+        .sources
+        .iter()
+        .any(|s| s.excerpt.to_lowercase().contains("helio"));
+    let answer_mentions_helio = answer.answer.to_lowercase().contains("helio");
+    assert!(
+        any_source_mentions_helio || answer_mentions_helio,
+        "neither answer nor any source excerpt mentioned 'helio' — retrieval likely broken.\n\
+         answer: {}\n\
+         sources: {:#?}",
+        answer.answer,
+        answer.sources
+    );
+}


### PR DESCRIPTION
## Summary

Adds a self-contained demo crate (`examples/sales-transcripts-demo`) that walks
through the full **ingest → index → query** loop against the public
[`gwenshap/sales-transcripts`](https://huggingface.co/datasets/gwenshap/sales-transcripts)
Hugging Face dataset.

The crate exposes a small library entry point (`run_pipeline`) plus three
thin binaries:

- `sales-fetch` — downloads the HF auto-converted parquet shard via `ureq`
  with an atomic `.tmp` + `fs::rename` to avoid corrupt resumes.
- `sales-to-text` — flattens parquet → per-transcript `.txt` via the
  `arrow` / `parquet` crates; purges existing `transcript_*.txt` so a re-run
  with a smaller `--limit` doesn't leave stale rows.
- `sales-pipeline` — builds a `graphrag_core::Config` programmatically and
  runs `ask_explained` over a curated sales-domain query set, printing
  answers, confidence, and source excerpts.

Two JSON5 configs (`sales_hash_only.json5`, `sales_ollama.json5`) drive the
existing `graphrag-cli` `bench` and `tui` flows. A TDD-first integration
smoke test (`tests/pipeline_smoke.rs`) runs in CI without API keys against
six committed sample transcripts.

## Why

The repo had no end-to-end example showing how to embed `graphrag-core` in
a downstream project against a real public dataset. This crate fills that
gap and doubles as a reproducible benchmark surface.

## Honesty about current limitations

- Cloud-embeddings hybrid mode is **not yet end-to-end**: `RetrievalSystem`
  ignores `config.embeddings.backend` and always uses the dimension-
  parameterized hash embedder. Tracked in #91.
- Native Anthropic / OpenAI **chat** backend doesn't exist yet — only
  Ollama and a mock are wired through `ChatBackend`. Tracked in #90.
- `--mode ollama` in the pipeline binary prints a runtime caveat noting
  that retrieval embeddings remain hash-based until #91 lands.
- The README explains why the auto-converted parquet shard reports
  995 rows / ~140 KB while the dataset card reports 1,935 / 34 MB
  (the larger artifact bundles pre-computed OpenAI embeddings).

## Test plan

- [x] `cargo nextest run -p sales-transcripts-demo --tests` — smoke test
      passes in ~50ms with no API keys.
- [x] `cargo fmt -p sales-transcripts-demo --check`
- [x] `cargo clippy -p sales-transcripts-demo --lib --bins --tests
      --no-deps -- -D warnings`
- [x] End-to-end real-data run from workspace root: `sales-fetch`
      (139 KB) → `sales-to-text --limit 200` → re-run with `--limit 50`
      (purges 200, writes 50) → `sales-pipeline` (50 transcripts ingested
      and answered in ~30ms).
- [ ] Reviewer: try `cargo run -p graphrag-cli -- bench` against
      `sales_hash_only.json5` and confirm output matches expectations.
- [ ] Reviewer: with Ollama running, try
      `cargo run -p graphrag-cli -- tui --config
      examples/sales-transcripts-demo/configs/sales_ollama.json5`.

## Follow-ups (filed)

- #90 — native Anthropic + OpenAI chat backend
- #91 — wire configured embedder (OpenAI/Ollama/HF) into the retrieval
  hot path