### PR TITLE
fix(server): security & robustness hardening (#31 #32 #37 #45 #46)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4047,6 +4047,7 @@ dependencies = [
  "arrow-array 56.2.0",
  "arrow-schema 56.2.0",
  "async-trait",
+ "axum",
  "bcrypt",
  "bincode",
  "chrono",

--- a/graphrag-server/Cargo.toml
+++ b/graphrag-server/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 default = ["qdrant"] # , "auth"]
 qdrant = ["qdrant-client"]
 lancedb = ["dep:lancedb", "arrow-array", "arrow-schema"]
-auth = ["jsonwebtoken", "bcrypt"]
+auth = ["jsonwebtoken", "bcrypt", "dep:axum"]
 ollama = ["ollama-rs"]
 
 [dependencies]
@@ -51,6 +51,10 @@ arrow-schema = { version = "56", optional = true }
 # Authentication (optional)
 jsonwebtoken = { workspace = true, optional = true }
 bcrypt = { workspace = true, optional = true }
+# axum is still imported by `auth.rs` (issue #40 — not yet ported to actix-web).
+# Pulled in only when the `auth` feature is enabled so the module can compile
+# while the port is in flight; the routes are not wired into main.rs yet.
+axum = { workspace = true, optional = true }
 thiserror = { workspace = true }
 futures = { workspace = true }
 

--- a/graphrag-server/README.md
+++ b/graphrag-server/README.md
@@ -644,6 +644,20 @@ upsert at a time.
 2. Use a different `COLLECTION_NAME` to start fresh.
 3. Drop and recreate the collection if its data is no longer needed.
 
+### "Could not determine if Qdrant collection '...' exists"
+
+**Cause:** The `CollectionExists` RPC failed (transport error, auth
+denied, server unreachable, etc.). Startup refuses to continue rather
+than coerce the failure to "does not exist", which would route to the
+create-collection path and skip the dimension check above.
+
+**Solutions:**
+1. Verify `QDRANT_URL` is reachable from the server host.
+2. If Qdrant requires authentication, ensure the client can authenticate
+   (check tokens / TLS config).
+3. Inspect Qdrant logs for the failing RPC and retry once the server is
+   healthy.
+
 ### Slow query performance
 
 **Cause:** Large dataset without proper indexing.

--- a/graphrag-server/README.md
+++ b/graphrag-server/README.md
@@ -109,7 +109,9 @@ cargo run --bin graphrag-server --features "lancedb,ollama"
 # Minimal (hash-based embeddings, in-memory storage)
 cargo run --bin graphrag-server --no-default-features
 
-# With authentication
+# With authentication (requires JWT_SECRET >= 32 bytes; server refuses
+# to start otherwise — see #31)
+JWT_SECRET="$(openssl rand -hex 32)" \
 cargo run --bin graphrag-server --features "qdrant,ollama,auth"
 ```
 

--- a/graphrag-server/README.md
+++ b/graphrag-server/README.md
@@ -629,6 +629,19 @@ curl http://localhost:6333/healthz
 cargo run --bin graphrag-server 2>&1 | grep collection
 ```
 
+### "Qdrant collection dimension check failed"
+
+**Cause:** `EMBEDDING_DIM` (default `384`) disagrees with the vector
+dimension of the existing Qdrant collection. The server now refuses to
+start in that case to avoid silently corrupting the collection one
+upsert at a time.
+
+**Solutions:**
+1. Set `EMBEDDING_DIM` to match the existing collection (e.g. `768` or
+   `1024` if you previously created one with a different model).
+2. Use a different `COLLECTION_NAME` to start fresh.
+3. Drop and recreate the collection if its data is no longer needed.
+
 ### Slow query performance
 
 **Cause:** Large dataset without proper indexing.

--- a/graphrag-server/src/auth.rs
+++ b/graphrag-server/src/auth.rs
@@ -117,10 +117,7 @@ impl AuthState {
         role: UserRole,
         duration_hours: u64,
     ) -> Result<String, AuthError> {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
+        let now = unix_secs(std::time::SystemTime::now())?;
 
         let claims = Claims {
             sub: user_id.to_string(),
@@ -192,10 +189,7 @@ impl AuthState {
         user_id: &str,
         limit: &RateLimit,
     ) -> Result<(), AuthError> {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
+        let now = unix_secs(std::time::SystemTime::now())?;
 
         let mut rate_limits = self.rate_limits.write().await;
 
@@ -220,6 +214,18 @@ impl AuthState {
 
         Ok(())
     }
+}
+
+/// Convert a `SystemTime` to seconds since the UNIX epoch.
+///
+/// Returns `AuthError::TokenGenerationFailed` instead of panicking when
+/// the clock is set before 1970 — both `generate_token` and
+/// `check_rate_limit` previously called `.unwrap()` on the result and
+/// would crash the worker thread (#45).
+fn unix_secs(t: std::time::SystemTime) -> Result<u64, AuthError> {
+    t.duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .map_err(|e| AuthError::TokenGenerationFailed(format!("system clock before UNIX epoch: {e}")))
 }
 
 /// Authentication errors
@@ -395,6 +401,26 @@ mod tests {
 
         assert_eq!(api_key.user_id, "user123");
         assert_eq!(api_key.role, UserRole::User);
+    }
+
+    // Pre-UNIX-epoch SystemTime values must surface as TokenGenerationFailed
+    // instead of panicking via .unwrap() (regression for #45).
+    #[test]
+    fn unix_secs_returns_err_on_pre_epoch_clock() {
+        let before_epoch = std::time::UNIX_EPOCH - std::time::Duration::from_secs(1);
+        let result = unix_secs(before_epoch);
+        assert!(
+            matches!(result, Err(AuthError::TokenGenerationFailed(_))),
+            "expected TokenGenerationFailed, got {result:?}"
+        );
+    }
+
+    // Sanity check: a normal post-epoch SystemTime returns the seconds value.
+    #[test]
+    fn unix_secs_returns_seconds_for_post_epoch_clock() {
+        let t = std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000);
+        let result = unix_secs(t).expect("post-epoch time must succeed");
+        assert_eq!(result, 1_700_000_000);
     }
 
     #[tokio::test]

--- a/graphrag-server/src/auth.rs
+++ b/graphrag-server/src/auth.rs
@@ -39,7 +39,15 @@ pub struct Claims {
 }
 
 /// User roles for RBAC
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+///
+/// Ordering encodes the privilege hierarchy `Admin > User > Readonly >
+/// Guest`, so `actual >= minimum` is the canonical permission check
+/// (see `require_role`). `PartialOrd`/`Ord` are implemented manually
+/// instead of derived because the `#[derive]` order would put `Admin`
+/// at the bottom — and the variant declaration order is part of the
+/// public surface (it's also serialized via `#[serde(rename_all)]`,
+/// which we don't want to reshuffle just to satisfy a derive).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "lowercase")]
 pub enum UserRole {
     /// Administrator with full access
@@ -50,6 +58,31 @@ pub enum UserRole {
     Readonly,
     /// Guest with limited access
     Guest,
+}
+
+impl UserRole {
+    /// Numeric privilege rank. Higher == more privileged. Used by
+    /// `PartialOrd`/`Ord` so callers can write `actual >= minimum`.
+    fn rank(self) -> u8 {
+        match self {
+            UserRole::Admin => 3,
+            UserRole::User => 2,
+            UserRole::Readonly => 1,
+            UserRole::Guest => 0,
+        }
+    }
+}
+
+impl PartialOrd for UserRole {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for UserRole {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.rank().cmp(&other.rank())
+    }
 }
 
 /// API key structure
@@ -349,21 +382,12 @@ pub async fn require_role(
     Next,
 ) -> futures::future::BoxFuture<'static, Result<Response, AuthError>> {
     move |Extension(user): axum::extract::Extension<AuthUser>, request: Request, next: Next| {
-        let minimum_role = minimum_role.clone();
+        let minimum_role = minimum_role;
         Box::pin(async move {
-            // Check role hierarchy: Admin > User > Readonly > Guest
-            let has_permission = match (&user.role, &minimum_role) {
-                (UserRole::Admin, _) => true,
-                (UserRole::User, UserRole::User) => true,
-                (UserRole::User, UserRole::Readonly) => true,
-                (UserRole::User, UserRole::Guest) => true,
-                (UserRole::Readonly, UserRole::Readonly) => true,
-                (UserRole::Readonly, UserRole::Guest) => true,
-                (UserRole::Guest, UserRole::Guest) => true,
-                _ => false,
-            };
-
-            if !has_permission {
+            // Hierarchy: Admin > User > Readonly > Guest. `UserRole`'s
+            // `Ord` impl encodes this directly, so the brittle 7-arm
+            // match with a `_ => false` catch-all (#46) is gone.
+            if user.role < minimum_role {
                 return Err(AuthError::InsufficientPermissions);
             }
 
@@ -421,6 +445,43 @@ mod tests {
         let t = std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000);
         let result = unix_secs(t).expect("post-epoch time must succeed");
         assert_eq!(result, 1_700_000_000);
+    }
+
+    // Exhaustive role-hierarchy check (#46): every (actual, minimum) pair
+    // must satisfy `actual >= minimum` iff actual's privilege level is at
+    // least minimum's. Hierarchy: Admin > User > Readonly > Guest.
+    #[test]
+    fn user_role_ord_covers_every_pair() {
+        use UserRole::*;
+        let all = [Admin, User, Readonly, Guest];
+        // (actual, minimum, expected has_permission)
+        let cases: &[(UserRole, UserRole, bool)] = &[
+            (Admin, Admin, true),
+            (Admin, User, true),
+            (Admin, Readonly, true),
+            (Admin, Guest, true),
+            (User, Admin, false),
+            (User, User, true),
+            (User, Readonly, true),
+            (User, Guest, true),
+            (Readonly, Admin, false),
+            (Readonly, User, false),
+            (Readonly, Readonly, true),
+            (Readonly, Guest, true),
+            (Guest, Admin, false),
+            (Guest, User, false),
+            (Guest, Readonly, false),
+            (Guest, Guest, true),
+        ];
+        // Sanity: we covered every (actual, minimum) pair.
+        assert_eq!(cases.len(), all.len() * all.len());
+        for (actual, minimum, expected) in cases {
+            let got = actual >= minimum;
+            assert_eq!(
+                got, *expected,
+                "role hierarchy mismatch: actual={actual:?}, minimum={minimum:?}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/graphrag-server/src/auth.rs
+++ b/graphrag-server/src/auth.rs
@@ -16,11 +16,27 @@ use axum::{
     middleware::Next,
     response::{IntoResponse, Response},
 };
-use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
+use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, Validation};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
+
+/// Canonical `iss` claim placed on every JWT we mint and required on
+/// every JWT we accept (#31). Pinning a fixed issuer keeps tokens
+/// minted by other services that happen to share our HS256 secret out
+/// of our trust boundary.
+pub const JWT_ISSUER: &str = "graphrag-server";
+
+/// Canonical `aud` claim. Keeps tokens issued for a different API
+/// (e.g. an admin console reusing the same secret) from being accepted
+/// here (#31).
+pub const JWT_AUDIENCE: &str = "graphrag-api";
+
+/// Minimum acceptable JWT secret length, in bytes. HS256 signatures
+/// are only as strong as the shared secret; sub-32-byte secrets are
+/// brute-forceable with commodity hardware (#31).
+pub const JWT_SECRET_MIN_BYTES: usize = 32;
 
 /// JWT claims structure
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -31,6 +47,12 @@ pub struct Claims {
     pub iat: u64,
     /// Expiration time (timestamp)
     pub exp: u64,
+    /// Issuer — pinned to `JWT_ISSUER` on mint, required on validate (#31).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub iss: Option<String>,
+    /// Audience — pinned to `JWT_AUDIENCE` on mint, required on validate (#31).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub aud: Option<String>,
     /// User role
     pub role: UserRole,
     /// Custom claims
@@ -136,6 +158,10 @@ impl AuthState {
     ///
     /// # Arguments
     /// * `jwt_secret` - Secret key for JWT signing (should be 32+ characters)
+    ///
+    /// Prefer [`AuthState::try_new`] in production wiring; this
+    /// constructor is kept for backwards compatibility and accepts any
+    /// length, including the empty string. Tests still use it.
     pub fn new(jwt_secret: String) -> Self {
         Self {
             jwt_secret,
@@ -143,6 +169,20 @@ impl AuthState {
             rate_limits: Arc::new(RwLock::new(HashMap::new())),
             jwt_rate_limits: HashMap::new(),
         }
+    }
+
+    /// Construct an `AuthState` while enforcing the minimum JWT secret
+    /// length (`JWT_SECRET_MIN_BYTES`). Returns
+    /// `AuthError::TokenGenerationFailed` with an operator-facing
+    /// message that *does not* include the secret value (#31).
+    pub fn try_new(jwt_secret: String) -> Result<Self, AuthError> {
+        let len = jwt_secret.len();
+        if len < JWT_SECRET_MIN_BYTES {
+            return Err(AuthError::TokenGenerationFailed(format!(
+                "JWT secret too short: {len} bytes; minimum is {JWT_SECRET_MIN_BYTES}"
+            )));
+        }
+        Ok(Self::new(jwt_secret))
     }
 
     /// Override the JWT-path rate limit for a specific role.
@@ -157,10 +197,7 @@ impl AuthState {
     /// Look up the JWT-path rate limit for a role, falling back to the
     /// global `RateLimit::default()` (1000 req/hr).
     fn jwt_rate_limit_for(&self, role: UserRole) -> RateLimit {
-        self.jwt_rate_limits
-            .get(&role)
-            .cloned()
-            .unwrap_or_default()
+        self.jwt_rate_limits.get(&role).cloned().unwrap_or_default()
     }
 
     /// Generate a JWT token
@@ -181,24 +218,32 @@ impl AuthState {
             sub: user_id.to_string(),
             iat: now,
             exp: now + (duration_hours * 3600),
+            iss: Some(JWT_ISSUER.to_string()),
+            aud: Some(JWT_AUDIENCE.to_string()),
             role,
             custom: HashMap::new(),
         };
 
         encode(
-            &Header::default(),
+            &Header::new(Algorithm::HS256),
             &claims,
             &EncodingKey::from_secret(self.jwt_secret.as_bytes()),
         )
         .map_err(|e| AuthError::TokenGenerationFailed(e.to_string()))
     }
 
-    /// Validate a JWT token
+    /// Validate a JWT token. Requires `exp`, `iss`, `aud` and pins
+    /// `iss == JWT_ISSUER`, `aud == JWT_AUDIENCE` (#31).
     pub fn validate_token(&self, token: &str) -> Result<Claims, AuthError> {
+        let mut validation = Validation::new(Algorithm::HS256);
+        validation.set_required_spec_claims(&["exp", "iss", "aud"]);
+        validation.set_issuer(&[JWT_ISSUER]);
+        validation.set_audience(&[JWT_AUDIENCE]);
+
         decode::<Claims>(
             token,
             &DecodingKey::from_secret(self.jwt_secret.as_bytes()),
-            &Validation::default(),
+            &validation,
         )
         .map(|data| data.claims)
         .map_err(|e| AuthError::InvalidToken(e.to_string()))
@@ -283,7 +328,9 @@ impl AuthState {
 fn unix_secs(t: std::time::SystemTime) -> Result<u64, AuthError> {
     t.duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs())
-        .map_err(|e| AuthError::TokenGenerationFailed(format!("system clock before UNIX epoch: {e}")))
+        .map_err(|e| {
+            AuthError::TokenGenerationFailed(format!("system clock before UNIX epoch: {e}"))
+        })
 }
 
 /// Authentication errors
@@ -538,6 +585,112 @@ mod tests {
         assert!(matches!(result, Err(AuthError::RateLimitExceeded { .. })));
     }
 
+    // AuthState::try_new must reject a missing or under-32-byte JWT secret
+    // (#31). Anything weaker than 32 bytes is brute-forceable for HS256 and
+    // makes the previous hardcoded "graphrag_secret_key_change_in_production"
+    // default a security landmine.
+    #[test]
+    fn try_new_rejects_short_secret() {
+        // Use a distinctive non-English value so we can assert the secret
+        // bytes don't leak into the operator-facing error.
+        let secret = "xq8z!".to_string();
+        let result = AuthState::try_new(secret.clone());
+        let msg = match result {
+            Err(AuthError::TokenGenerationFailed(s)) => s,
+            Err(other) => panic!("expected TokenGenerationFailed, got {other:?}"),
+            Ok(_) => panic!("short secret must reject"),
+        };
+        // Length and threshold should appear in the operator-facing message,
+        // but the secret itself must NOT be logged.
+        assert!(msg.contains("32"), "msg should cite the threshold: {msg}");
+        assert!(!msg.contains(&secret), "secret value must not leak: {msg}");
+    }
+
+    // Empty secrets are also rejected, with no panic.
+    #[test]
+    fn try_new_rejects_empty_secret() {
+        let result = AuthState::try_new(String::new());
+        assert!(matches!(result, Err(AuthError::TokenGenerationFailed(_))));
+    }
+
+    // try_new accepts an exactly-32-byte secret.
+    #[test]
+    fn try_new_accepts_secret_at_threshold() {
+        let secret = "a".repeat(32);
+        assert!(
+            AuthState::try_new(secret).is_ok(),
+            "32-byte secret must be accepted"
+        );
+    }
+
+    // Issued tokens carry the canonical iss/aud claims and validate end-to-end.
+    #[test]
+    fn generate_and_validate_token_round_trip_with_iss_aud() {
+        let auth_state = AuthState::try_new("a".repeat(32)).expect("state");
+        let token = auth_state
+            .generate_token("u1", UserRole::User, 1)
+            .expect("token");
+        let claims = auth_state.validate_token(&token).expect("validate");
+        assert_eq!(claims.iss.as_deref(), Some(JWT_ISSUER));
+        assert_eq!(claims.aud.as_deref(), Some(JWT_AUDIENCE));
+    }
+
+    // A token with the wrong issuer must be rejected even if the signature
+    // verifies — protects against same-secret tokens minted by another
+    // service in the same trust boundary (#31).
+    #[test]
+    fn validate_token_rejects_wrong_issuer() {
+        let auth_state = AuthState::try_new("a".repeat(32)).expect("state");
+        // Hand-roll a token with a foreign `iss` but the right secret.
+        let now = unix_secs(std::time::SystemTime::now()).unwrap();
+        let claims = Claims {
+            sub: "u1".into(),
+            iat: now,
+            exp: now + 3600,
+            iss: Some("other-service".into()),
+            aud: Some(JWT_AUDIENCE.into()),
+            role: UserRole::User,
+            custom: HashMap::new(),
+        };
+        let token = encode(
+            &Header::default(),
+            &claims,
+            &EncodingKey::from_secret("a".repeat(32).as_bytes()),
+        )
+        .unwrap();
+        let err = auth_state
+            .validate_token(&token)
+            .expect_err("foreign iss must reject");
+        assert!(matches!(err, AuthError::InvalidToken(_)));
+    }
+
+    // A token with the wrong audience must be rejected even if the
+    // signature verifies (#31).
+    #[test]
+    fn validate_token_rejects_wrong_audience() {
+        let auth_state = AuthState::try_new("a".repeat(32)).expect("state");
+        let now = unix_secs(std::time::SystemTime::now()).unwrap();
+        let claims = Claims {
+            sub: "u1".into(),
+            iat: now,
+            exp: now + 3600,
+            iss: Some(JWT_ISSUER.into()),
+            aud: Some("other-api".into()),
+            role: UserRole::User,
+            custom: HashMap::new(),
+        };
+        let token = encode(
+            &Header::default(),
+            &claims,
+            &EncodingKey::from_secret("a".repeat(32).as_bytes()),
+        )
+        .unwrap();
+        let err = auth_state
+            .validate_token(&token)
+            .expect_err("foreign aud must reject");
+        assert!(matches!(err, AuthError::InvalidToken(_)));
+    }
+
     // JWT-authenticated callers must be rate-limited too (#32). The Bearer
     // branch of `extract_auth_user` previously returned the user without
     // ever calling `check_rate_limit`, so a stolen JWT had no per-user
@@ -560,10 +713,7 @@ mod tests {
             .expect("token");
 
         let mut headers = axum::http::HeaderMap::new();
-        headers.insert(
-            "Authorization",
-            format!("Bearer {token}").parse().unwrap(),
-        );
+        headers.insert("Authorization", format!("Bearer {token}").parse().unwrap());
 
         // First two extractions succeed.
         extract_auth_user(&auth_state, &headers).await.expect("1st");

--- a/graphrag-server/src/auth.rs
+++ b/graphrag-server/src/auth.rs
@@ -1,23 +1,14 @@
 //! Authentication and Authorization Middleware
 //!
-//! **STATUS: Not yet ported to actix-web (issue #40).** This module
-//! still imports from `axum::{extract, http, middleware, response}`
-//! while the rest of the server is built on `actix-web`. The `auth`
-//! Cargo feature is currently disabled in `default = ["qdrant"]` for
-//! exactly this reason — turning it on produces ~30 unrelated-looking
-//! compile errors about an unresolved `axum` crate.
-//!
-//! The `compile_error!` below makes that failure mode loud: anyone
-//! enabling `--features auth` gets one clear message instead of a wall
-//! of "use of unresolved module or unlinked crate `axum`" errors.
-//! Remove it once auth.rs is ported to `actix-web-httpauth`-style
-//! middleware (or, alternatively, once `axum` is added as a dep and
-//! the Apistos integration is reworked).
-
-compile_error!(
-    "the `auth` Cargo feature is not yet ported to actix-web — see issue #40. \
-     Disable the feature (it is off by default) until the port lands."
-);
+//! **STATUS: Not yet ported to actix-web (issue #40).** The HTTP-glue
+//! parts of this module still import from `axum::{extract, http,
+//! middleware, response}` while the rest of the server is on actix-web.
+//! The `auth` Cargo feature pulls `axum` in as an optional dep so the
+//! module compiles and its security-critical logic (JWT issuance/
+//! validation, RBAC, rate limiting, secret loading) can be unit-tested
+//! ahead of the port. The auth routes are still NOT wired into
+//! `main.rs` (`/auth/*` is commented out), so toggling the feature
+//! does not expose any new HTTP surface.
 
 use axum::{
     extract::{Extension, Request, State},

--- a/graphrag-server/src/auth.rs
+++ b/graphrag-server/src/auth.rs
@@ -123,6 +123,12 @@ pub struct AuthState {
     api_keys: Arc<RwLock<HashMap<String, ApiKey>>>,
     /// Rate limiting state: (user_id, (count, window_start))
     rate_limits: Arc<RwLock<HashMap<String, (usize, u64)>>>,
+    /// Per-role rate limits applied on the JWT (Bearer) auth path.
+    /// API-key callers carry their own `RateLimit`; JWT callers do not,
+    /// so without this table the Bearer branch had no per-user ceiling
+    /// at all (#32). Roles missing from the map fall back to
+    /// `RateLimit::default()`.
+    jwt_rate_limits: HashMap<UserRole, RateLimit>,
 }
 
 impl AuthState {
@@ -135,7 +141,26 @@ impl AuthState {
             jwt_secret,
             api_keys: Arc::new(RwLock::new(HashMap::new())),
             rate_limits: Arc::new(RwLock::new(HashMap::new())),
+            jwt_rate_limits: HashMap::new(),
         }
+    }
+
+    /// Override the JWT-path rate limit for a specific role.
+    ///
+    /// Used at startup (and in tests) to install per-role ceilings; the
+    /// JWT branch of `extract_auth_user` consults this table.
+    #[allow(dead_code)]
+    pub fn set_jwt_rate_limit(&mut self, role: UserRole, limit: RateLimit) {
+        self.jwt_rate_limits.insert(role, limit);
+    }
+
+    /// Look up the JWT-path rate limit for a role, falling back to the
+    /// global `RateLimit::default()` (1000 req/hr).
+    fn jwt_rate_limit_for(&self, role: UserRole) -> RateLimit {
+        self.jwt_rate_limits
+            .get(&role)
+            .cloned()
+            .unwrap_or_default()
     }
 
     /// Generate a JWT token
@@ -328,6 +353,11 @@ pub async fn extract_auth_user(
     // Check for Bearer token (JWT)
     if let Some(token) = auth_header.strip_prefix("Bearer ") {
         let claims = auth_state.validate_token(token)?;
+        // Apply per-role JWT rate limit (#32). Previously the Bearer
+        // branch returned without ever counting the request, so a JWT
+        // had no per-user ceiling — only API-key callers were limited.
+        let limit = auth_state.jwt_rate_limit_for(claims.role);
+        auth_state.check_rate_limit(&claims.sub, &limit).await?;
         return Ok(AuthUser {
             user_id: claims.sub,
             role: claims.role,
@@ -506,5 +536,45 @@ mod tests {
         // Third should fail
         let result = auth_state.check_rate_limit("user123", &limit).await;
         assert!(matches!(result, Err(AuthError::RateLimitExceeded { .. })));
+    }
+
+    // JWT-authenticated callers must be rate-limited too (#32). The Bearer
+    // branch of `extract_auth_user` previously returned the user without
+    // ever calling `check_rate_limit`, so a stolen JWT had no per-user
+    // ceiling at all.
+    #[tokio::test]
+    async fn extract_auth_user_rate_limits_jwt_path() {
+        let mut auth_state = AuthState::new("test_secret_key_32_characters_long".to_string());
+        // Tighten the per-role JWT ceiling so the test doesn't have to
+        // burn the default 1000 requests.
+        auth_state.set_jwt_rate_limit(
+            UserRole::User,
+            RateLimit {
+                max_requests: 2,
+                window_seconds: 60,
+            },
+        );
+
+        let token = auth_state
+            .generate_token("jwt_user", UserRole::User, 1)
+            .expect("token");
+
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(
+            "Authorization",
+            format!("Bearer {token}").parse().unwrap(),
+        );
+
+        // First two extractions succeed.
+        extract_auth_user(&auth_state, &headers).await.expect("1st");
+        extract_auth_user(&auth_state, &headers).await.expect("2nd");
+
+        // Third must be rejected as RateLimitExceeded — not panic, not
+        // silently pass.
+        let result = extract_auth_user(&auth_state, &headers).await;
+        assert!(
+            matches!(result, Err(AuthError::RateLimitExceeded { .. })),
+            "expected RateLimitExceeded, got {result:?}"
+        );
     }
 }

--- a/graphrag-server/src/main.rs
+++ b/graphrag-server/src/main.rs
@@ -892,14 +892,13 @@ async fn graph_stats(state: Data<AppState>) -> Json<GraphStatsResponse> {
 // Authentication Endpoints (feature-gated)
 // ============================================================================
 
+// Note: `#[api_operation]` deliberately omitted on the auth handlers. The
+// `error_code` arm of the macro doesn't currently resolve against
+// `ApiError`'s `ApiErrorComponent` schema, and these routes are not
+// mounted (see the commented-out `/auth/*` block in `main()`). Re-add
+// the macro alongside the actix port (issue #40).
 #[cfg(feature = "auth")]
-#[api_operation(
-    tag = "auth",
-    summary = "User login",
-    description = "Authenticate user and receive JWT token",
-    error_code = 401,
-    error_code = 500
-)]
+#[allow(dead_code)]
 async fn login(
     _state: Data<AppState>,
     body: Json<LoginRequest>,
@@ -925,12 +924,7 @@ async fn login(
 }
 
 #[cfg(feature = "auth")]
-#[api_operation(
-    tag = "auth",
-    summary = "Create API key",
-    description = "Generate an API key for programmatic access",
-    error_code = 500
-)]
+#[allow(dead_code)]
 async fn create_api_key(
     state: Data<AppState>,
     body: Json<ApiKeyRequest>,

--- a/graphrag-server/src/main.rs
+++ b/graphrag-server/src/main.rs
@@ -155,9 +155,26 @@ impl AppState {
                             },
                         }
                     } else {
+                        // Refuse to start if EMBEDDING_DIM disagrees with the
+                        // collection's stored vector size (#37). A silent
+                        // mismatch otherwise corrupts the index one upsert
+                        // at a time. Mirrors the LanceDB per-row dim check.
+                        if let Err(e) =
+                            store.verify_collection_dimension(embedding_dim as u64).await
+                        {
+                            tracing::error!(
+                                "❌ Qdrant collection dimension check failed: {}. \
+                                 Set EMBEDDING_DIM to match the existing collection, \
+                                 use a different COLLECTION_NAME, or recreate the \
+                                 collection.",
+                                e
+                            );
+                            std::process::exit(1);
+                        }
                         tracing::info!(
-                            "✅ Connected to existing Qdrant collection: {}",
-                            collection_name
+                            "✅ Connected to existing Qdrant collection: {} ({} dims)",
+                            collection_name,
+                            embedding_dim
                         );
                     }
 

--- a/graphrag-server/src/main.rs
+++ b/graphrag-server/src/main.rs
@@ -49,7 +49,9 @@ use models::*;
 #[cfg(feature = "qdrant")]
 mod qdrant_store;
 #[cfg(feature = "qdrant")]
-use qdrant_store::{DocumentMetadata, QdrantStore};
+use qdrant_store::{
+    classify_collection_existence, CollectionStartupAction, DocumentMetadata, QdrantStore,
+};
 
 #[cfg(feature = "auth")]
 mod auth;
@@ -174,39 +176,60 @@ impl AppState {
 
             match QdrantStore::new(&qdrant_url, &collection_name).await {
                 Ok(store) => {
-                    // Check if collection exists, create if not
-                    if !store.collection_exists().await.unwrap_or(false) {
-                        match store.create_collection(embedding_dim as u64).await {
-                            Ok(_) => {
-                                tracing::info!("✅ Created Qdrant collection: {}", collection_name);
-                            },
-                            Err(e) => {
-                                tracing::warn!("⚠️  Could not create collection: {}", e);
-                            },
-                        }
-                    } else {
-                        // Refuse to start if EMBEDDING_DIM disagrees with the
-                        // collection's stored vector size (#37). A silent
-                        // mismatch otherwise corrupts the index one upsert
-                        // at a time. Mirrors the LanceDB per-row dim check.
-                        if let Err(e) = store
-                            .verify_collection_dimension(embedding_dim as u64)
-                            .await
-                        {
+                    // Probe whether the collection exists. A probe failure
+                    // (transport, permission, etc.) MUST abort startup —
+                    // treating it as "does not exist" would route to the
+                    // create-collection branch and bypass the #37
+                    // dimension check on the existing collection.
+                    match classify_collection_existence(store.collection_exists().await) {
+                        CollectionStartupAction::Create => {
+                            match store.create_collection(embedding_dim as u64).await {
+                                Ok(_) => {
+                                    tracing::info!(
+                                        "✅ Created Qdrant collection: {}",
+                                        collection_name
+                                    );
+                                },
+                                Err(e) => {
+                                    tracing::warn!("⚠️  Could not create collection: {}", e);
+                                },
+                            }
+                        },
+                        CollectionStartupAction::VerifyExisting => {
+                            // Refuse to start if EMBEDDING_DIM disagrees with the
+                            // collection's stored vector size (#37). A silent
+                            // mismatch otherwise corrupts the index one upsert
+                            // at a time. Mirrors the LanceDB per-row dim check.
+                            if let Err(e) = store
+                                .verify_collection_dimension(embedding_dim as u64)
+                                .await
+                            {
+                                tracing::error!(
+                                    "❌ Qdrant collection dimension check failed: {}. \
+                                     Set EMBEDDING_DIM to match the existing collection, \
+                                     use a different COLLECTION_NAME, or recreate the \
+                                     collection.",
+                                    e
+                                );
+                                std::process::exit(1);
+                            }
+                            tracing::info!(
+                                "✅ Connected to existing Qdrant collection: {} ({} dims)",
+                                collection_name,
+                                embedding_dim
+                            );
+                        },
+                        CollectionStartupAction::Abort(e) => {
                             tracing::error!(
-                                "❌ Qdrant collection dimension check failed: {}. \
-                                 Set EMBEDDING_DIM to match the existing collection, \
-                                 use a different COLLECTION_NAME, or recreate the \
-                                 collection.",
+                                "❌ Could not determine if Qdrant collection '{}' exists: {}. \
+                                 Refusing to start: a probe failure could otherwise route to \
+                                 the create-collection path and skip the EMBEDDING_DIM check \
+                                 against an existing collection (#37).",
+                                collection_name,
                                 e
                             );
                             std::process::exit(1);
-                        }
-                        tracing::info!(
-                            "✅ Connected to existing Qdrant collection: {} ({} dims)",
-                            collection_name,
-                            embedding_dim
-                        );
+                        },
                     }
 
                     tracing::info!("🗄️  Using Qdrant at: {}", qdrant_url);

--- a/graphrag-server/src/main.rs
+++ b/graphrag-server/src/main.rs
@@ -97,6 +97,36 @@ struct AppState {
     query_count: Arc<RwLock<usize>>,
 }
 
+/// Build an `AuthState` from `JWT_SECRET`, exiting the process if the
+/// env var is missing or the value is shorter than the HS256 minimum
+/// (#31). Centralised so all three `AppState::new` arms — Qdrant
+/// connected, Qdrant unavailable, Qdrant feature off — share one rule
+/// and can't drift out of sync.
+#[cfg(feature = "auth")]
+fn load_auth_state() -> AuthState {
+    let secret = match std::env::var("JWT_SECRET") {
+        Ok(s) => s,
+        Err(_) => {
+            tracing::error!(
+                "❌ JWT_SECRET is not set. Refusing to start the auth-enabled \
+                 server with a default secret. Set JWT_SECRET to a value of \
+                 at least {} bytes.",
+                auth::JWT_SECRET_MIN_BYTES
+            );
+            std::process::exit(1);
+        },
+    };
+    match AuthState::try_new(secret) {
+        Ok(state) => state,
+        Err(e) => {
+            // `try_new`'s error message names the threshold and the
+            // observed length — never the secret value itself (#31).
+            tracing::error!("❌ JWT_SECRET rejected: {}. Refusing to start.", e);
+            std::process::exit(1);
+        },
+    }
+}
+
 impl AppState {
     async fn new() -> Self {
         // Initialize embedding service
@@ -159,8 +189,9 @@ impl AppState {
                         // collection's stored vector size (#37). A silent
                         // mismatch otherwise corrupts the index one upsert
                         // at a time. Mirrors the LanceDB per-row dim check.
-                        if let Err(e) =
-                            store.verify_collection_dimension(embedding_dim as u64).await
+                        if let Err(e) = store
+                            .verify_collection_dimension(embedding_dim as u64)
+                            .await
                         {
                             tracing::error!(
                                 "❌ Qdrant collection dimension check failed: {}. \
@@ -186,9 +217,7 @@ impl AppState {
                         graphrag: Arc::new(RwLock::new(None)),
                         config_manager: Arc::new(ConfigManager::new()),
                         #[cfg(feature = "auth")]
-                        auth: Arc::new(AuthState::new(std::env::var("JWT_SECRET").unwrap_or_else(
-                            |_| "graphrag_secret_key_change_in_production_32chars".to_string(),
-                        ))),
+                        auth: Arc::new(load_auth_state()),
                         documents: Arc::new(RwLock::new(Vec::new())),
                         graph_built: Arc::new(RwLock::new(false)),
                         query_count: Arc::new(RwLock::new(0)),
@@ -205,9 +234,7 @@ impl AppState {
                         graphrag: Arc::new(RwLock::new(None)),
                         config_manager: Arc::new(ConfigManager::new()),
                         #[cfg(feature = "auth")]
-                        auth: Arc::new(AuthState::new(std::env::var("JWT_SECRET").unwrap_or_else(
-                            |_| "graphrag_secret_key_change_in_production_32chars".to_string(),
-                        ))),
+                        auth: Arc::new(load_auth_state()),
                         documents: Arc::new(RwLock::new(Vec::new())),
                         graph_built: Arc::new(RwLock::new(false)),
                         query_count: Arc::new(RwLock::new(0)),
@@ -224,9 +251,7 @@ impl AppState {
                 graphrag: Arc::new(RwLock::new(None)),
                 config_manager: Arc::new(ConfigManager::new()),
                 #[cfg(feature = "auth")]
-                auth: Arc::new(AuthState::new(std::env::var("JWT_SECRET").unwrap_or_else(
-                    |_| "graphrag_secret_key_change_in_production_32chars".to_string(),
-                ))),
+                auth: Arc::new(load_auth_state()),
                 documents: Arc::new(RwLock::new(Vec::new())),
                 graph_built: Arc::new(RwLock::new(false)),
                 query_count: Arc::new(RwLock::new(0)),
@@ -1119,13 +1144,10 @@ async fn main() -> std::io::Result<()> {
         ..Default::default()
     };
 
-    // JWT secret warning (item 3.4)
-    #[cfg(feature = "auth")]
-    if std::env::var("JWT_SECRET").is_err() {
-        tracing::warn!(
-            "⚠️  JWT_SECRET not set! Using insecure default. Set JWT_SECRET env var in production."
-        );
-    }
+    // JWT_SECRET is now validated up front in `load_auth_state`, which
+    // exits the process if the var is missing or under
+    // `JWT_SECRET_MIN_BYTES` bytes (#31). The previous "using insecure
+    // default" warning is gone because there is no longer a default.
 
     tracing::info!("🚀 GraphRAG Server starting...");
     tracing::info!("📡 Listening on http://0.0.0.0:8080");

--- a/graphrag-server/src/qdrant_store.rs
+++ b/graphrag-server/src/qdrant_store.rs
@@ -127,12 +127,22 @@ impl QdrantStore {
         Ok(())
     }
 
-    /// Check if collection exists
+    /// Check if the collection exists.
+    ///
+    /// Delegates to `qdrant_client::Qdrant::collection_exists`, which uses
+    /// the dedicated `CollectionExists` RPC and reports presence/absence
+    /// without conflating it with transport, permission, or other RPC
+    /// failures. Errors are propagated as `CollectionError` so callers
+    /// can fail fast instead of silently treating a transient/permission
+    /// failure as "collection does not exist" — that misclassification
+    /// would route startup through the create-collection branch and
+    /// bypass `verify_collection_dimension` (#37 follow-up from the
+    /// Codex review).
     pub async fn collection_exists(&self) -> Result<bool, QdrantError> {
-        match self.client.collection_info(&self.collection_name).await {
-            Ok(_) => Ok(true),
-            Err(_) => Ok(false),
-        }
+        self.client
+            .collection_exists(self.collection_name.clone())
+            .await
+            .map_err(|e| QdrantError::CollectionError(e.to_string()))
     }
 
     /// Fetch the configured vector dimension of the existing collection.
@@ -359,6 +369,39 @@ impl QdrantStore {
     #[allow(dead_code)]
     pub fn collection_name(&self) -> &str {
         &self.collection_name
+    }
+}
+
+/// What startup should do after probing whether the target Qdrant
+/// collection already exists.
+///
+/// Returned by `classify_collection_existence` so the decision can be
+/// unit-tested without a live Qdrant server. Aborting on probe failure
+/// is the whole point — a swallowed error would skip
+/// `verify_collection_dimension` (#37 follow-up).
+#[derive(Debug)]
+pub(crate) enum CollectionStartupAction {
+    /// Probe returned `Ok(false)`: create the collection.
+    Create,
+    /// Probe returned `Ok(true)`: run the dimension check against the
+    /// existing collection before serving traffic.
+    VerifyExisting,
+    /// Probe failed: refuse to start. Treating this as "does not exist"
+    /// would route to `Create` and bypass the dimension verification.
+    Abort(QdrantError),
+}
+
+/// Map a `collection_exists` probe result to the startup action.
+///
+/// Pure helper so the regression test for the Codex-reported bug
+/// (existence-probe errors silently bypassing #37) can be a unit test.
+pub(crate) fn classify_collection_existence(
+    probe: Result<bool, QdrantError>,
+) -> CollectionStartupAction {
+    match probe {
+        Ok(true) => CollectionStartupAction::VerifyExisting,
+        Ok(false) => CollectionStartupAction::Create,
+        Err(e) => CollectionStartupAction::Abort(e),
     }
 }
 
@@ -594,6 +637,48 @@ mod tests {
             msg.contains("768"),
             "msg should include expected dim: {msg}"
         );
+    }
+
+    // classify_collection_existence reports Create when the existence
+    // probe returns Ok(false), so startup takes the create-collection
+    // branch.
+    #[test]
+    fn classify_returns_create_when_collection_absent() {
+        match classify_collection_existence(Ok(false)) {
+            CollectionStartupAction::Create => {},
+            other => panic!("expected Create, got {other:?}"),
+        }
+    }
+
+    // classify_collection_existence reports VerifyExisting when the
+    // existence probe returns Ok(true), so startup runs the dimension
+    // check against the live collection (#37).
+    #[test]
+    fn classify_returns_verify_when_collection_present() {
+        match classify_collection_existence(Ok(true)) {
+            CollectionStartupAction::VerifyExisting => {},
+            other => panic!("expected VerifyExisting, got {other:?}"),
+        }
+    }
+
+    // Regression: a transient/permission failure on the existence probe
+    // must abort startup instead of being coerced to "collection does
+    // not exist". Previously `collection_exists` returned `Ok(false)` on
+    // any error, so `main.rs` took the create-collection branch and
+    // skipped `verify_collection_dimension` — silently bypassing the
+    // #37 fail-fast dimension check (Codex review follow-up).
+    #[test]
+    fn classify_aborts_on_existence_probe_error() {
+        let err = QdrantError::CollectionError("rpc unavailable".into());
+        match classify_collection_existence(Err(err)) {
+            CollectionStartupAction::Abort(QdrantError::CollectionError(msg)) => {
+                assert!(
+                    msg.contains("rpc unavailable"),
+                    "abort should preserve underlying error: {msg}"
+                );
+            },
+            other => panic!("expected Abort(CollectionError), got {other:?}"),
+        }
     }
 
     // metadata_to_payload round-trips a normal DocumentMetadata.

--- a/graphrag-server/src/qdrant_store.rs
+++ b/graphrag-server/src/qdrant_store.rs
@@ -135,6 +135,67 @@ impl QdrantStore {
         }
     }
 
+    /// Fetch the configured vector dimension of the existing collection.
+    ///
+    /// Returns `CollectionError` if the collection cannot be inspected or
+    /// its `vectors_config` is missing the expected single-vector
+    /// `params.size` field. Used by `verify_collection_dimension` so we
+    /// can refuse to start a server whose `EMBEDDING_DIM` doesn't match
+    /// the persisted collection (#37).
+    pub async fn collection_vector_dim(&self) -> Result<u64, QdrantError> {
+        use qdrant_client::qdrant::{vectors_config::Config, VectorsConfig};
+
+        let info = self
+            .client
+            .collection_info(&self.collection_name)
+            .await
+            .map_err(|e| QdrantError::CollectionError(e.to_string()))?;
+
+        let params = info
+            .result
+            .and_then(|r| r.config)
+            .and_then(|c| c.params)
+            .ok_or_else(|| {
+                QdrantError::CollectionError(format!(
+                    "collection '{}' has no params",
+                    self.collection_name
+                ))
+            })?;
+
+        let cfg: VectorsConfig = params.vectors_config.ok_or_else(|| {
+            QdrantError::CollectionError(format!(
+                "collection '{}' has no vectors_config",
+                self.collection_name
+            ))
+        })?;
+
+        match cfg.config {
+            Some(Config::Params(p)) => Ok(p.size),
+            Some(Config::ParamsMap(_)) => Err(QdrantError::CollectionError(format!(
+                "collection '{}' uses named-vector ParamsMap; \
+                 dimension check expects a single unnamed vector",
+                self.collection_name
+            ))),
+            None => Err(QdrantError::CollectionError(format!(
+                "collection '{}' vectors_config is empty",
+                self.collection_name
+            ))),
+        }
+    }
+
+    /// Refuse to use the collection if its persisted vector dimension
+    /// disagrees with `expected` (#37).
+    ///
+    /// Mirrors `LanceDBStore::add_document`'s per-row dimension check
+    /// (`graphrag-server/src/lancedb_store.rs:153`), but is invoked once
+    /// at startup so a misconfigured `EMBEDDING_DIM` produces a clear
+    /// fatal log instead of silently corrupting the collection one
+    /// upsert at a time.
+    pub async fn verify_collection_dimension(&self, expected: u64) -> Result<(), QdrantError> {
+        let actual = self.collection_vector_dim().await?;
+        check_collection_dimension(expected, actual, &self.collection_name)
+    }
+
     /// Delete the collection
     #[allow(dead_code)]
     pub async fn delete_collection(&self) -> Result<(), QdrantError> {
@@ -298,6 +359,25 @@ impl QdrantStore {
     #[allow(dead_code)]
     pub fn collection_name(&self) -> &str {
         &self.collection_name
+    }
+}
+
+/// Pure dimension-mismatch check, factored out of
+/// `verify_collection_dimension` so it can be unit-tested without a
+/// live Qdrant server (#37).
+fn check_collection_dimension(
+    expected: u64,
+    actual: u64,
+    collection: &str,
+) -> Result<(), QdrantError> {
+    if expected == actual {
+        Ok(())
+    } else {
+        Err(QdrantError::CollectionError(format!(
+            "vector dimension mismatch on collection '{collection}': \
+             EMBEDDING_DIM={expected} but stored vectors are {actual}-dim. \
+             Refuse to start to avoid corrupting the collection."
+        )))
     }
 }
 
@@ -484,6 +564,30 @@ mod tests {
         );
         let err = try_decode_search_result(point).expect_err("should fail, not panic");
         assert!(matches!(err, QdrantError::OperationError(_)));
+    }
+
+    // check_collection_dimension passes when expected == actual (#37).
+    #[test]
+    fn check_collection_dimension_accepts_match() {
+        check_collection_dimension(384, 384, "graphrag").expect("matching dims must pass");
+    }
+
+    // check_collection_dimension surfaces a CollectionError when the
+    // configured EMBEDDING_DIM differs from the live collection's stored
+    // vector size, with the actual/expected values in the message so the
+    // operator can act on it. (#37 — previously a 768-dim embedding shipped
+    // against a 384-dim collection silently corrupted the index.)
+    #[test]
+    fn check_collection_dimension_errors_on_mismatch() {
+        let err = check_collection_dimension(768, 384, "graphrag")
+            .expect_err("mismatched dims must error");
+        let msg = match err {
+            QdrantError::CollectionError(s) => s,
+            other => panic!("expected CollectionError, got {other:?}"),
+        };
+        assert!(msg.contains("graphrag"), "msg should name collection: {msg}");
+        assert!(msg.contains("384"), "msg should include actual dim: {msg}");
+        assert!(msg.contains("768"), "msg should include expected dim: {msg}");
     }
 
     // metadata_to_payload round-trips a normal DocumentMetadata.

--- a/graphrag-server/src/qdrant_store.rs
+++ b/graphrag-server/src/qdrant_store.rs
@@ -585,9 +585,15 @@ mod tests {
             QdrantError::CollectionError(s) => s,
             other => panic!("expected CollectionError, got {other:?}"),
         };
-        assert!(msg.contains("graphrag"), "msg should name collection: {msg}");
+        assert!(
+            msg.contains("graphrag"),
+            "msg should name collection: {msg}"
+        );
         assert!(msg.contains("384"), "msg should include actual dim: {msg}");
-        assert!(msg.contains("768"), "msg should include expected dim: {msg}");
+        assert!(
+            msg.contains("768"),
+            "msg should include expected dim: {msg}"
+        );
     }
 
     // metadata_to_payload round-trips a normal DocumentMetadata.


### PR DESCRIPTION
## Summary

Bundles five graphrag-server hardening fixes flagged in code review, plus one preliminary build-unblock and one follow-up fix from a second-opinion review. Every fix landed via Red-Green TDD.

- **#31** (`fix(server): mandate JWT_SECRET, pin iss/aud, validate`): refuse to start when `JWT_SECRET` is missing/short under `--features auth`. Encode/decode with `iss="graphrag-server"` and a pinned `aud`. **Deferred**: `kid`/rotation map (needs schema design — open follow-up).
- **#32** (`fix(server): rate-limit JWT auth path in extract_auth_user`): JWT branch now calls `check_rate_limit` before returning `AuthUser`. Closed an auth-scheme rate-limit bypass.
- **#37** (`fix(server): refuse startup on Qdrant vector dim mismatch` + `fix(server): abort Qdrant startup when existence probe fails`): on startup, fetch `collection_info` and assert `params.size == embedding_dim`. Existence probe now uses `Qdrant::collection_exists` and propagates errors instead of coercing to `Ok(false)` (caught by Codex review).
- **#45** (`fix(server): return error for pre-epoch clock in auth`): replaced `SystemTime::now().duration_since(UNIX_EPOCH).unwrap()` with `Result` propagation via `AuthError::TokenGenerationFailed` at both call sites.
- **#46** (`fix(server): replace brittle role match with Ord on UserRole`): `impl PartialOrd for UserRole` + `if actual >= minimum`. Exhaustive `(actual, minimum)` test added.
- **Preliminary** (`build(server): unblock auth feature for security TDD`): removed a `compile_error!` gate on the `auth` feature so tests could run. Auth routes remain commented in `main()` — no new HTTP surface exposed. **Issue #40 (axum→actix port) is still open and tracked separately.**

## Test plan

- [x] `cargo test -p graphrag-server --lib` (no features): 26 pass
- [x] `cargo test -p graphrag-server --features auth --lib`: 42 pass
- [x] `cargo fmt --all` clean
- [ ] Manual: bring up against real Qdrant with `EMBEDDING_DIM` mismatch and confirm fail-fast (covered by `#[ignore]`-gated integration test)
- [ ] Manual: start without `JWT_SECRET` and confirm fatal exit