### PR TITLE
fix(core): prevent block_in_place panic on current_thread runtime (#16)

### DIFF
--- a/graphrag-core/src/caching/client.rs
+++ b/graphrag-core/src/caching/client.rs
@@ -15,18 +15,28 @@ use tokio::sync::RwLock;
 
 /// Drive an async future from a sync trait method.
 ///
-/// Inside an existing tokio runtime we use `block_in_place` + `Handle::block_on`
-/// (the only safe way; constructing a fresh `Runtime` from inside one panics).
-/// Outside any runtime we build an ad-hoc one. `block_in_place` requires the
-/// multi-threaded scheduler — calling this from a `current_thread` runtime
-/// would still panic, but we now report ad-hoc runtime construction failures
-/// as a `Generation` error rather than the previous `unwrap`/`expect` panics.
+/// Bridge strategy by tokio runtime context:
+/// * `MultiThread` runtime: `block_in_place` + `Handle::block_on`.
+/// * `CurrentThread` runtime: returns `Generation` error — `block_in_place`
+///   would panic and `Handle::block_on` on `CurrentThread` deadlocks.
+/// * No runtime: builds an ad-hoc `Runtime`; surfaces construction failure as
+///   `Generation` rather than panicking.
 fn run_sync<F, T>(work: F) -> Result<T>
 where
     F: Future<Output = Result<T>>,
 {
     match tokio::runtime::Handle::try_current() {
-        Ok(handle) => tokio::task::block_in_place(|| handle.block_on(work)),
+        Ok(handle) => match handle.runtime_flavor() {
+            tokio::runtime::RuntimeFlavor::MultiThread => {
+                tokio::task::block_in_place(|| handle.block_on(work))
+            },
+            _ => Err(crate::core::GraphRAGError::Generation {
+                message: "CachedLLMClient sync trait methods require a multi-thread \
+                          tokio runtime when called from inside an async context; \
+                          use the *_async variants or switch to a multi_thread runtime"
+                    .to_string(),
+            }),
+        },
         Err(_) => match tokio::runtime::Runtime::new() {
             Ok(rt) => rt.block_on(work),
             Err(e) => Err(crate::core::GraphRAGError::Generation {
@@ -615,6 +625,31 @@ mod tests {
 
             let response = client.complete("Test prompt").unwrap();
             assert!(!response.is_empty());
+        });
+    }
+
+    // Sync `complete` returns a typed Generation error (not a panic) when
+    // invoked from inside a tokio current_thread runtime. Regression for #16.
+    #[test]
+    fn complete_returns_error_on_current_thread_runtime() {
+        let mock_llm = MockLLM::new().unwrap();
+        let config = CacheConfig::development();
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        rt.block_on(async {
+            let client = CachedLLMClient::new(mock_llm, config).await.unwrap();
+            let err = client
+                .complete("Test prompt")
+                .expect_err("expected typed error on current_thread runtime");
+            let msg = err.to_string();
+            assert!(
+                msg.contains("current_thread") || msg.contains("multi-thread"),
+                "error should mention runtime flavor mismatch, got: {msg}"
+            );
         });
     }
 }

--- a/graphrag-core/src/generation/async_mock_llm.rs
+++ b/graphrag-core/src/generation/async_mock_llm.rs
@@ -512,36 +512,48 @@ impl Clone for AsyncMockLLM {
     }
 }
 
+/// Drive an async future from a sync `LLMInterface` method.
+///
+/// Bridge strategy by tokio runtime context:
+/// * `MultiThread` runtime: `block_in_place` + `Handle::block_on`.
+/// * `CurrentThread` runtime: returns a `Generation` error — `block_in_place`
+///   would panic and `Handle::block_on` on `CurrentThread` deadlocks.
+/// * No runtime: builds an ad-hoc `Runtime` and surfaces construction
+///   failure as a `Generation` error.
+fn run_sync_llm<F>(work: F) -> Result<String>
+where
+    F: std::future::Future<Output = Result<String>>,
+{
+    match tokio::runtime::Handle::try_current() {
+        Ok(handle) => match handle.runtime_flavor() {
+            tokio::runtime::RuntimeFlavor::MultiThread => {
+                tokio::task::block_in_place(|| handle.block_on(work))
+            },
+            _ => Err(GraphRAGError::Generation {
+                message: "AsyncMockLLM sync LLMInterface methods require a multi-thread \
+                          tokio runtime when called from inside an async context; \
+                          call the async API directly or switch to a multi_thread runtime"
+                    .to_string(),
+            }),
+        },
+        Err(_) => match tokio::runtime::Runtime::new() {
+            Ok(rt) => rt.block_on(work),
+            Err(e) => Err(GraphRAGError::Generation {
+                message: format!("Failed to construct ad-hoc tokio runtime: {e}"),
+            }),
+        },
+    }
+}
+
 /// Synchronous LLMInterface implementation for backward compatibility
 #[async_trait]
 impl LLMInterface for AsyncMockLLM {
     fn generate_response(&self, prompt: &str) -> Result<String> {
-        // For sync compatibility, use tokio's block_in_place if we're in a tokio context
-        if tokio::runtime::Handle::try_current().is_ok() {
-            tokio::task::block_in_place(|| {
-                tokio::runtime::Handle::current().block_on(self.complete(prompt))
-            })
-        } else {
-            // If not in async context, create a new runtime
-            let rt = tokio::runtime::Runtime::new().map_err(|e| GraphRAGError::Generation {
-                message: format!("Failed to create async runtime: {e}"),
-            })?;
-            rt.block_on(self.complete(prompt))
-        }
+        run_sync_llm(self.complete(prompt))
     }
 
     fn generate_summary(&self, content: &str, max_length: usize) -> Result<String> {
-        if tokio::runtime::Handle::try_current().is_ok() {
-            tokio::task::block_in_place(|| {
-                tokio::runtime::Handle::current()
-                    .block_on(self.generate_summary_async(content, max_length))
-            })
-        } else {
-            let rt = tokio::runtime::Runtime::new().map_err(|e| GraphRAGError::Generation {
-                message: format!("Failed to create async runtime: {e}"),
-            })?;
-            rt.block_on(self.generate_summary_async(content, max_length))
-        }
+        run_sync_llm(self.generate_summary_async(content, max_length))
     }
 
     fn extract_key_points(&self, content: &str, num_points: usize) -> Result<Vec<String>> {
@@ -627,5 +639,51 @@ mod tests {
         let llm = AsyncMockLLM::new().await.unwrap();
         let tokens = llm.estimate_tokens("This is a test prompt").await.unwrap();
         assert!(tokens > 0);
+    }
+
+    // Sync `LLMInterface::generate_response` returns a typed error (not a
+    // panic) when invoked from a tokio current_thread runtime. Regression
+    // for #16.
+    #[test]
+    fn generate_response_returns_error_on_current_thread_runtime() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        rt.block_on(async {
+            let llm = AsyncMockLLM::new().await.unwrap();
+            let err = llm
+                .generate_response("Hello")
+                .expect_err("expected typed error on current_thread runtime");
+            let msg = err.to_string();
+            assert!(
+                msg.contains("current_thread") || msg.contains("multi-thread"),
+                "error should mention runtime flavor mismatch, got: {msg}"
+            );
+        });
+    }
+
+    // Sync `LLMInterface::generate_summary` returns a typed error (not a
+    // panic) when invoked from a tokio current_thread runtime. Regression
+    // for #16.
+    #[test]
+    fn generate_summary_returns_error_on_current_thread_runtime() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        rt.block_on(async {
+            let llm = AsyncMockLLM::new().await.unwrap();
+            let err = llm
+                .generate_summary("Some content for the model.", 32)
+                .expect_err("expected typed error on current_thread runtime");
+            let msg = err.to_string();
+            assert!(
+                msg.contains("current_thread") || msg.contains("multi-thread"),
+                "error should mention runtime flavor mismatch, got: {msg}"
+            );
+        });
     }
 }

--- a/graphrag-core/src/text/chunking_strategies.rs
+++ b/graphrag-core/src/text/chunking_strategies.rs
@@ -654,10 +654,7 @@ mod tests {
                 Ok(v)
             }
 
-            async fn embed_batch(
-                &self,
-                texts: &[&str],
-            ) -> crate::core::Result<Vec<Vec<f32>>> {
+            async fn embed_batch(&self, texts: &[&str]) -> crate::core::Result<Vec<Vec<f32>>> {
                 let mut out = Vec::with_capacity(texts.len());
                 for t in texts {
                     out.push(self.embed(t).await?);

--- a/graphrag-core/src/text/chunking_strategies.rs
+++ b/graphrag-core/src/text/chunking_strategies.rs
@@ -333,8 +333,12 @@ impl BoundaryAwareChunkingStrategy {
         )
     }
 
-    /// Chunk text asynchronously (helper for async contexts)
-    async fn chunk_async(&self, text: &str) -> Vec<TextChunk> {
+    /// Chunk text asynchronously.
+    ///
+    /// Prefer this over the sync `ChunkingStrategy::chunk` impl when calling
+    /// from inside a tokio runtime; `chunk` only works on the multi_thread
+    /// flavor and returns an empty `Vec` on `current_thread`.
+    pub async fn chunk_async(&self, text: &str) -> Vec<TextChunk> {
         // 1. Detect all semantic boundaries
         let boundaries = self.boundary_detector.detect_boundaries(text);
 
@@ -537,21 +541,31 @@ impl BoundaryAwareChunkingStrategy {
 
 impl ChunkingStrategy for BoundaryAwareChunkingStrategy {
     fn chunk(&self, text: &str) -> Vec<TextChunk> {
-        // The sync trait impl needs to drive async coherence scoring. Pick the
-        // bridging strategy by inspecting the calling context:
+        // The sync trait must drive async coherence scoring. Bridge by
+        // tokio runtime context:
         //
-        //   * If we're inside an existing tokio runtime, `block_in_place` +
-        //     `Handle::block_on` is the only safe path. Constructing a fresh
-        //     `Runtime` from inside another runtime panics with
-        //     "Cannot start a runtime from within a runtime."
-        //   * If we're not in any runtime, build one ad-hoc.
-        //
-        // `block_in_place` requires the multi-threaded scheduler. Callers on
-        // a `current_thread` runtime will panic — that's a runtime-flavor
-        // contract we can't surface through the infallible trait signature,
-        // so the constraint is documented on the trait.
+        //   * MultiThread runtime: `block_in_place` + `Handle::block_on`.
+        //   * CurrentThread runtime: `block_in_place` would panic and
+        //     `Handle::block_on` would deadlock. The trait signature is
+        //     infallible, so we log and return an empty `Vec` — callers
+        //     needing chunks from a current_thread context must drive
+        //     `chunk_async` directly.
+        //   * No runtime: build one ad-hoc; on construction failure, log
+        //     and return an empty `Vec`.
         match tokio::runtime::Handle::try_current() {
-            Ok(handle) => tokio::task::block_in_place(|| handle.block_on(self.chunk_async(text))),
+            Ok(handle) => match handle.runtime_flavor() {
+                tokio::runtime::RuntimeFlavor::MultiThread => {
+                    tokio::task::block_in_place(|| handle.block_on(self.chunk_async(text)))
+                },
+                _ => {
+                    tracing::warn!(
+                        "BoundaryAwareChunkingStrategy::chunk called from a tokio \
+                         current_thread runtime; the sync trait requires multi_thread. \
+                         Returning empty chunk list — call chunk_async directly instead."
+                    );
+                    Vec::new()
+                },
+            },
             Err(_) => match tokio::runtime::Runtime::new() {
                 Ok(rt) => rt.block_on(self.chunk_async(text)),
                 Err(e) => {
@@ -602,6 +616,83 @@ mod tests {
         // for chunk in &chunks {
         //     assert!(!chunk.content.is_empty());
         // }
+    }
+
+    // BoundaryAwareChunkingStrategy::chunk does not panic when invoked from
+    // inside a tokio current_thread runtime. Regression for #16 (block_in_place
+    // would otherwise panic with "can call blocking only when running on the
+    // multi-threaded runtime").
+    #[test]
+    fn boundary_aware_chunk_does_not_panic_on_current_thread_runtime() {
+        use crate::embeddings::EmbeddingProvider;
+        use crate::text::BoundaryAwareChunkingStrategy;
+        use async_trait::async_trait;
+        use std::sync::Arc;
+
+        struct MockEmbedder {
+            dimension: usize,
+        }
+
+        #[async_trait]
+        impl EmbeddingProvider for MockEmbedder {
+            async fn initialize(&mut self) -> crate::core::Result<()> {
+                Ok(())
+            }
+
+            async fn embed(&self, text: &str) -> crate::core::Result<Vec<f32>> {
+                let mut v = vec![0.0; self.dimension];
+                let h = text.len() as f32;
+                for (i, x) in v.iter_mut().enumerate() {
+                    *x = ((h + i as f32) * 0.1).sin();
+                }
+                let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+                if norm > 0.0 {
+                    for x in &mut v {
+                        *x /= norm;
+                    }
+                }
+                Ok(v)
+            }
+
+            async fn embed_batch(
+                &self,
+                texts: &[&str],
+            ) -> crate::core::Result<Vec<Vec<f32>>> {
+                let mut out = Vec::with_capacity(texts.len());
+                for t in texts {
+                    out.push(self.embed(t).await?);
+                }
+                Ok(out)
+            }
+
+            fn dimensions(&self) -> usize {
+                self.dimension
+            }
+
+            fn is_available(&self) -> bool {
+                true
+            }
+
+            fn provider_name(&self) -> &str {
+                "mock"
+            }
+        }
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        rt.block_on(async {
+            let provider = Arc::new(MockEmbedder { dimension: 16 });
+            let document_id = DocumentId::new("ct_test".to_string());
+            let strategy = BoundaryAwareChunkingStrategy::with_defaults(provider, document_id);
+
+            // The previous implementation would panic here via `block_in_place`
+            // on the current_thread runtime. We assert the call returns
+            // (any Vec, even empty, is acceptable — non-panic is the contract).
+            let _chunks = strategy.chunk("Paragraph one.\n\nParagraph two with more content.");
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes issue #16 — three sites where sync trait impls bridge to async via `block_on`/`block_in_place` and would panic on `current_thread` tokio runtimes (or when constructing a runtime inside an existing one).

All three sites use the same approach: detect runtime via `Handle::try_current()` + `runtime_flavor()`. On `MultiThread`, keep `block_in_place + Handle::block_on`. On `CurrentThread`, return a typed error (or empty `Vec` for the infallible chunking trait). With no runtime, build an ephemeral `Runtime` and map construction failure to a typed error.

- **`fix(core): return error on current_thread runtime in cached LLM bridge`** — `caching/client.rs`. Returns `GraphRAGError::Generation { .. }`.
- **`fix(core): return error on current_thread runtime in AsyncMockLLM bridge`** — `generation/async_mock_llm.rs`. New `run_sync_llm` helper.
- **`fix(core): handle current_thread runtime in BoundaryAware sync chunker`** — `text/chunking_strategies.rs`. Promotes `chunk_async` to `pub` so async callers have a recourse; sync path warns and returns empty `Vec`.

## Notes for reviewers

- **No breaking changes** — return types unchanged. The infallible `ChunkingStrategy::chunk` had to fall back to empty `Vec` because the trait can't return `Result`; flagged in the doc comment.
- A second-opinion review (Codex gpt-5.3-codex) noted that `block_in_place` can also panic in `LocalSet` tasks even on `MultiThread`. That edge case is **pre-existing** (not introduced by this patch) and is out of scope here. Worth a follow-up issue if anyone uses `LocalSet` in production paths.

## Test plan

- [x] Each site has a regression test that confirmed the panic before the fix and passes after
- [x] `cargo test -p graphrag-core --features full --lib`: 469 pass
- [x] `cargo test -p graphrag-core --features full --test bar_rag_integration`: 17 pass
- [x] `cargo fmt --all` clean