### PR TITLE
fix(core): persistence robustness for workspaces & cache (#23 #24)

### DIFF
--- a/graphrag-core/src/caching/distributed.rs
+++ b/graphrag-core/src/caching/distributed.rs
@@ -306,20 +306,58 @@ where
         // Try L2 (Redis) if available
         #[cfg(feature = "redis_storage")]
         if let Some(l2) = &self.l2 {
-            if let Ok(Some(bytes)) = l2.get(&key.to_string()) {
-                if let Ok(value) = bincode::deserialize::<V>(&bytes) {
-                    self.stats.write().l2_hits += 1;
-
-                    // Populate L1 cache
-                    self.l1.put(key.clone(), value.clone());
-
-                    return Some(value);
-                }
+            match l2.get(&key.to_string()) {
+                Ok(Some(bytes)) => {
+                    // Bytes present — distinguish a successful deserialize
+                    // (true L2 hit) from a deserialize failure (corrupt
+                    // payload / serialization-format drift). The previous
+                    // `if let Ok(value) = ...` collapsed these into a plain
+                    // miss, masking format drift in metrics. (#23)
+                    match Self::try_deserialize(&bytes) {
+                        Ok(value) => {
+                            self.stats.write().l2_hits += 1;
+                            self.l1.put(key.clone(), value.clone());
+                            return Some(value);
+                        },
+                        Err(_e) => {
+                            self.stats.write().l2_deserialize_failures += 1;
+                            #[cfg(feature = "tracing")]
+                            tracing::warn!(
+                                key = %key.to_string(),
+                                error = %_e,
+                                "L2 cache: bytes present but deserialize failed — \
+                                 treating as miss. Likely format drift or corruption."
+                            );
+                        },
+                    }
+                },
+                Ok(None) => {
+                    self.stats.write().l2_misses += 1;
+                },
+                Err(_e) => {
+                    // Connection / transport error against Redis. Count as
+                    // a miss but log so the operator sees it.
+                    self.stats.write().l2_misses += 1;
+                    #[cfg(feature = "tracing")]
+                    tracing::warn!(
+                        key = %key.to_string(),
+                        error = %_e,
+                        "L2 cache GET failed (Redis transport error)"
+                    );
+                },
             }
-            self.stats.write().l2_misses += 1;
         }
 
         None
+    }
+
+    /// Attempt to deserialize a bincode-encoded cache payload.
+    ///
+    /// Extracted so tests can exercise the deserialize-failure path
+    /// without spinning up Redis.
+    #[cfg(feature = "redis_storage")]
+    fn try_deserialize(bytes: &[u8]) -> std::result::Result<V, bincode::Error> {
+        bincode::deserialize::<V>(bytes)
     }
 
     /// Put value into cache (writes to both L1 and L2)
@@ -397,8 +435,12 @@ pub struct DistributedCacheStats {
     pub l1_capacity: usize,
     /// Number of cache hits in L2 (Redis) cache
     pub l2_hits: u64,
-    /// Number of cache misses in L2 (Redis) cache
+    /// Number of cache misses in L2 (Redis) cache (key absent)
     pub l2_misses: u64,
+    /// L2 lookups that returned bytes but failed to deserialize. Counted
+    /// separately from `l2_misses` so format drift / corruption shows up
+    /// in metrics instead of disguised as a normal miss. (#23)
+    pub l2_deserialize_failures: u64,
 }
 
 impl DistributedCacheStats {
@@ -452,5 +494,29 @@ mod tests {
 
         std::thread::sleep(Duration::from_millis(15));
         assert!(entry.is_expired());
+    }
+
+    // Regression for #23: bincode garbage in the L2 byte stream must surface
+    // as a deserialize failure (caller can count it separately from miss).
+    #[cfg(feature = "redis_storage")]
+    #[test]
+    fn try_deserialize_returns_err_on_garbage_bytes() {
+        // We never deserialize an `i32` from a single 0xff byte successfully.
+        let result: std::result::Result<i32, _> =
+            DistributedCache::<String, i32>::try_deserialize(&[0xff]);
+        assert!(
+            result.is_err(),
+            "deserialize must fail loudly on corrupt bytes so callers can \
+             distinguish miss from format drift"
+        );
+    }
+
+    // The new `l2_deserialize_failures` counter starts at zero and is
+    // distinct from `l2_misses` so dashboards can split the two signals.
+    #[test]
+    fn distributed_cache_stats_separates_misses_from_deserialize_failures() {
+        let stats = DistributedCacheStats::default();
+        assert_eq!(stats.l2_misses, 0);
+        assert_eq!(stats.l2_deserialize_failures, 0);
     }
 }

--- a/graphrag-core/src/caching/distributed.rs
+++ b/graphrag-core/src/caching/distributed.rs
@@ -444,10 +444,16 @@ pub struct DistributedCacheStats {
 }
 
 impl DistributedCacheStats {
-    /// Calculate the overall cache hit rate across both L1 and L2
+    /// Calculate the overall cache hit rate across both L1 and L2.
+    ///
+    /// `l2_deserialize_failures` count toward the denominator: a deserialize
+    /// failure is a request that did not return cached data, so excluding it
+    /// would inflate the reported hit rate and mask cache-health regressions
+    /// caused by format drift or corruption (#23).
     pub fn hit_rate(&self) -> f64 {
         let total_hits = self.l1_hits + self.l2_hits;
-        let total_requests = total_hits + self.l1_misses + self.l2_misses;
+        let total_requests =
+            total_hits + self.l1_misses + self.l2_misses + self.l2_deserialize_failures;
         if total_requests == 0 {
             0.0
         } else {
@@ -518,5 +524,34 @@ mod tests {
         let stats = DistributedCacheStats::default();
         assert_eq!(stats.l2_misses, 0);
         assert_eq!(stats.l2_deserialize_failures, 0);
+    }
+
+    // hit_rate() must count L2 deserialize failures as non-hits in its
+    // denominator; otherwise a wave of corruption-induced failures would
+    // leave the reported hit rate unchanged and hide the regression (#23).
+    #[test]
+    fn hit_rate_counts_deserialize_failures_as_non_hits() {
+        let baseline = DistributedCacheStats {
+            l1_hits: 1,
+            l1_misses: 0,
+            l1_size: 0,
+            l1_capacity: 0,
+            l2_hits: 0,
+            l2_misses: 1,
+            l2_deserialize_failures: 0,
+        };
+        let with_failure = DistributedCacheStats {
+            l2_deserialize_failures: 1,
+            ..baseline.clone()
+        };
+
+        assert!(
+            with_failure.hit_rate() < baseline.hit_rate(),
+            "deserialize failures must lower the hit rate (baseline {}, with failure {})",
+            baseline.hit_rate(),
+            with_failure.hit_rate()
+        );
+        // 1 hit / (1 hit + 1 miss + 1 deserialize failure) = 1/3.
+        assert!((with_failure.hit_rate() - (1.0 / 3.0)).abs() < f64::EPSILON);
     }
 }

--- a/graphrag-core/src/core/mod.rs
+++ b/graphrag-core/src/core/mod.rs
@@ -518,18 +518,11 @@ impl KnowledgeGraph {
 
         // Helper: pull a required non-empty string field from a json::JsonValue
         // and surface DataCorruption rather than silently substituting "".
-        fn required_str(
-            obj: &json::JsonValue,
-            field: &str,
-            kind: &str,
-        ) -> Result<String> {
+        fn required_str(obj: &json::JsonValue, field: &str, kind: &str) -> Result<String> {
             match obj[field].as_str() {
                 Some(s) if !s.is_empty() => Ok(s.to_string()),
                 _ => Err(GraphRAGError::DataCorruption {
-                    message: format!(
-                        "{} record missing required string field '{}'",
-                        kind, field
-                    ),
+                    message: format!("{} record missing required string field '{}'", kind, field),
                 }),
             }
         }
@@ -580,10 +573,8 @@ impl KnowledgeGraph {
         let mut dropped_relationships: usize = 0;
         if json_data["relationships"].is_array() {
             for rel_obj in json_data["relationships"].members() {
-                let source =
-                    EntityId::new(required_str(rel_obj, "source_id", "relationship")?);
-                let target =
-                    EntityId::new(required_str(rel_obj, "target_id", "relationship")?);
+                let source = EntityId::new(required_str(rel_obj, "source_id", "relationship")?);
+                let target = EntityId::new(required_str(rel_obj, "target_id", "relationship")?);
                 let relation_type = rel_obj["relation_type"].as_str().unwrap_or("").to_string();
                 let confidence = rel_obj["confidence"].as_f32().unwrap_or(0.0);
 
@@ -596,9 +587,8 @@ impl KnowledgeGraph {
                     }
                 }
 
-                let relationship =
-                    Relationship::new(source, target, relation_type, confidence)
-                        .with_context(context);
+                let relationship = Relationship::new(source, target, relation_type, confidence)
+                    .with_context(context);
 
                 // A relationship can fail to attach if its endpoints reference
                 // entities that aren't in the graph (schema drift, partial
@@ -622,8 +612,7 @@ impl KnowledgeGraph {
         if json_data["chunks"].is_array() {
             for chunk_obj in json_data["chunks"].members() {
                 let id = ChunkId::new(required_str(chunk_obj, "id", "chunk")?);
-                let document_id =
-                    DocumentId::new(required_str(chunk_obj, "document_id", "chunk")?);
+                let document_id = DocumentId::new(required_str(chunk_obj, "document_id", "chunk")?);
                 let start_offset = chunk_obj["start_offset"].as_usize().unwrap_or(0);
                 let end_offset = chunk_obj["end_offset"].as_usize().unwrap_or(0);
 

--- a/graphrag-core/src/core/mod.rs
+++ b/graphrag-core/src/core/mod.rs
@@ -498,7 +498,15 @@ impl KnowledgeGraph {
         self.graph.edge_weights().collect()
     }
 
-    /// Load knowledge graph from JSON file
+    /// Load knowledge graph from JSON file.
+    ///
+    /// Required identifier fields (`entities[].id`, `chunks[].id`,
+    /// `chunks[].document_id`, `documents[].id`) are validated up front:
+    /// missing or non-string values produce a typed
+    /// [`GraphRAGError::DataCorruption`] instead of being silently
+    /// substituted with empty strings (which collide). Dangling
+    /// relationships (endpoints not in the loaded entity set) are skipped
+    /// and counted; the count is logged as a warning. See issue #23.
     pub fn load_from_json(file_path: &str) -> Result<Self> {
         use std::fs;
 
@@ -508,12 +516,30 @@ impl KnowledgeGraph {
             message: format!("Failed to parse JSON: {}", e),
         })?;
 
+        // Helper: pull a required non-empty string field from a json::JsonValue
+        // and surface DataCorruption rather than silently substituting "".
+        fn required_str(
+            obj: &json::JsonValue,
+            field: &str,
+            kind: &str,
+        ) -> Result<String> {
+            match obj[field].as_str() {
+                Some(s) if !s.is_empty() => Ok(s.to_string()),
+                _ => Err(GraphRAGError::DataCorruption {
+                    message: format!(
+                        "{} record missing required string field '{}'",
+                        kind, field
+                    ),
+                }),
+            }
+        }
+
         let mut kg = KnowledgeGraph::new();
 
         // Load entities
         if json_data["entities"].is_array() {
             for entity_obj in json_data["entities"].members() {
-                let id = EntityId::new(entity_obj["id"].as_str().unwrap_or("").to_string());
+                let id = EntityId::new(required_str(entity_obj, "id", "entity")?);
                 let name = entity_obj["name"].as_str().unwrap_or("").to_string();
                 let entity_type = entity_obj["type"].as_str().unwrap_or("").to_string();
                 let confidence = entity_obj["confidence"].as_f32().unwrap_or(0.0);
@@ -551,10 +577,13 @@ impl KnowledgeGraph {
         }
 
         // Load relationships
+        let mut dropped_relationships: usize = 0;
         if json_data["relationships"].is_array() {
             for rel_obj in json_data["relationships"].members() {
-                let source = EntityId::new(rel_obj["source_id"].as_str().unwrap_or("").to_string());
-                let target = EntityId::new(rel_obj["target_id"].as_str().unwrap_or("").to_string());
+                let source =
+                    EntityId::new(required_str(rel_obj, "source_id", "relationship")?);
+                let target =
+                    EntityId::new(required_str(rel_obj, "target_id", "relationship")?);
                 let relation_type = rel_obj["relation_type"].as_str().unwrap_or("").to_string();
                 let confidence = rel_obj["confidence"].as_f32().unwrap_or(0.0);
 
@@ -567,29 +596,34 @@ impl KnowledgeGraph {
                     }
                 }
 
-                let relationship = Relationship {
-                    source,
-                    target,
-                    relation_type,
-                    confidence,
-                    context,
-                    embedding: None,
-                    temporal_type: None,
-                    temporal_range: None,
-                    causal_strength: None,
-                };
+                let relationship =
+                    Relationship::new(source, target, relation_type, confidence)
+                        .with_context(context);
 
-                // Ignore errors if entities don't exist
-                let _ = kg.add_relationship(relationship);
+                // A relationship can fail to attach if its endpoints reference
+                // entities that aren't in the graph (schema drift, partial
+                // corruption). Don't crash the load — but don't silently
+                // ignore either: count and log so users see a signal (#23).
+                if kg.add_relationship(relationship).is_err() {
+                    dropped_relationships += 1;
+                }
             }
+        }
+        if dropped_relationships > 0 {
+            #[cfg(feature = "tracing")]
+            tracing::warn!(
+                "JSON load: dropped {} relationship(s) whose endpoints are not present \
+                 in the loaded entity set (possible schema drift or partial corruption)",
+                dropped_relationships
+            );
         }
 
         // Load chunks with full content
         if json_data["chunks"].is_array() {
             for chunk_obj in json_data["chunks"].members() {
-                let id = ChunkId::new(chunk_obj["id"].as_str().unwrap_or("").to_string());
+                let id = ChunkId::new(required_str(chunk_obj, "id", "chunk")?);
                 let document_id =
-                    DocumentId::new(chunk_obj["document_id"].as_str().unwrap_or("").to_string());
+                    DocumentId::new(required_str(chunk_obj, "document_id", "chunk")?);
                 let start_offset = chunk_obj["start_offset"].as_usize().unwrap_or(0);
                 let end_offset = chunk_obj["end_offset"].as_usize().unwrap_or(0);
 
@@ -623,7 +657,7 @@ impl KnowledgeGraph {
         // Load documents with full content
         if json_data["documents"].is_array() {
             for doc_obj in json_data["documents"].members() {
-                let id = DocumentId::new(doc_obj["id"].as_str().unwrap_or("").to_string());
+                let id = DocumentId::new(required_str(doc_obj, "id", "document")?);
                 let title = doc_obj["title"].as_str().unwrap_or("").to_string();
                 let content = doc_obj["content"].as_str().unwrap_or("").to_string();
 
@@ -1462,5 +1496,105 @@ mod temporal_tests {
         assert!(!json.contains("temporal_type"));
         assert!(!json.contains("temporal_range"));
         assert!(!json.contains("causal_strength"));
+    }
+}
+
+#[cfg(test)]
+mod json_load_robustness_tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn write_json(value: &serde_json::Value) -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(value.to_string().as_bytes()).unwrap();
+        f
+    }
+
+    // Regression for #23: load_from_json must reject entity records that are
+    // missing the `id` field instead of silently substituting an empty string
+    // (which collides across all such entities).
+    #[test]
+    fn load_from_json_rejects_entity_without_id() {
+        let payload = serde_json::json!({
+            "entities": [
+                { "name": "ghost", "type": "PERSON", "confidence": 0.5 }
+            ],
+            "relationships": [],
+            "chunks": [],
+            "documents": [],
+        });
+        let f = write_json(&payload);
+        let result = KnowledgeGraph::load_from_json(f.path().to_str().unwrap());
+        assert!(
+            result.is_err(),
+            "missing entity id must surface as an error, not synthesize \"\""
+        );
+    }
+
+    // Regression for #23: load_from_json must reject chunk records that are
+    // missing the `id` field instead of silently substituting an empty string.
+    #[test]
+    fn load_from_json_rejects_chunk_without_id() {
+        let payload = serde_json::json!({
+            "entities": [],
+            "relationships": [],
+            "chunks": [
+                { "document_id": "doc-1", "content": "text", "start_offset": 0, "end_offset": 4 }
+            ],
+            "documents": [],
+        });
+        let f = write_json(&payload);
+        let result = KnowledgeGraph::load_from_json(f.path().to_str().unwrap());
+        assert!(result.is_err(), "missing chunk id must surface as an error");
+    }
+
+    // Regression for #23: load_from_json must reject document records that
+    // are missing the `id` field.
+    #[test]
+    fn load_from_json_rejects_document_without_id() {
+        let payload = serde_json::json!({
+            "entities": [],
+            "relationships": [],
+            "chunks": [],
+            "documents": [
+                { "title": "t", "content": "c" }
+            ],
+        });
+        let f = write_json(&payload);
+        let result = KnowledgeGraph::load_from_json(f.path().to_str().unwrap());
+        assert!(
+            result.is_err(),
+            "missing document id must surface as an error"
+        );
+    }
+
+    // Regression for #23: load_from_json must succeed (and not crash) when
+    // a relationship references an entity that isn't in the graph. The
+    // dangling relationship is dropped, but its drop should be visible
+    // (counted via tracing) rather than silenced via `let _ = ...`.
+    #[test]
+    fn load_from_json_tolerates_dangling_relationship() {
+        let payload = serde_json::json!({
+            "entities": [
+                { "id": "ent-1", "name": "Alice", "type": "PERSON", "confidence": 0.9 }
+            ],
+            "relationships": [
+                {
+                    "source_id": "ent-1",
+                    "target_id": "missing-target",
+                    "relation_type": "knows",
+                    "confidence": 0.8,
+                    "context_chunks": [],
+                }
+            ],
+            "chunks": [],
+            "documents": [],
+        });
+        let f = write_json(&payload);
+        let kg = KnowledgeGraph::load_from_json(f.path().to_str().unwrap()).unwrap();
+        // 1 entity loaded, 0 relationships attached (dangling skipped).
+        assert_eq!(kg.entities().count(), 1);
+        assert_eq!(kg.get_all_relationships().len(), 0);
     }
 }

--- a/graphrag-core/src/persistence/parquet.rs
+++ b/graphrag-core/src/persistence/parquet.rs
@@ -425,15 +425,14 @@ impl ParquetPersistence {
                     None
                 };
 
-                let entity = Entity {
-                    id: EntityId::new(ids.value(i).to_string()),
-                    name: names.value(i).to_string(),
-                    entity_type: types.value(i).to_string(),
-                    confidence: confidences.value(i),
-                    mentions: Vec::new(), // Will be populated later if needed
-                    embedding,
-                };
-
+                let mut entity = Entity::new(
+                    EntityId::new(ids.value(i).to_string()),
+                    names.value(i).to_string(),
+                    types.value(i).to_string(),
+                    confidences.value(i),
+                );
+                entity.embedding = embedding;
+                // mentions are not yet persisted (see issue #24).
                 entities.push(entity);
             }
         }
@@ -627,13 +626,13 @@ impl ParquetPersistence {
                     }
                 }
 
-                let relationship = Relationship {
-                    source: EntityId::new(sources.value(i).to_string()),
-                    target: EntityId::new(targets.value(i).to_string()),
-                    relation_type: types.value(i).to_string(),
-                    confidence: confidences.value(i),
-                    context,
-                };
+                let relationship = Relationship::new(
+                    EntityId::new(sources.value(i).to_string()),
+                    EntityId::new(targets.value(i).to_string()),
+                    types.value(i).to_string(),
+                    confidences.value(i),
+                )
+                .with_context(context);
 
                 relationships.push(relationship);
             }

--- a/graphrag-core/src/persistence/parquet.rs
+++ b/graphrag-core/src/persistence/parquet.rs
@@ -8,6 +8,7 @@
 //! ```text
 //! workspace/
 //! ├── entities.parquet          # Entity nodes
+//! ├── entity_mentions.parquet   # EntityMention rows joined by entity_id
 //! ├── relationships.parquet     # Relationship edges
 //! ├── chunks.parquet            # Text chunks
 //! └── documents.parquet         # Document metadata
@@ -221,14 +222,12 @@ impl ParquetPersistence {
 
     /// Save entities to Parquet.
     ///
-    /// **Lossy round-trip warning:** the current schema persists only
-    /// `mention_count` (a `usize`), not the `EntityMention` payload itself.
-    /// On load, entities are reconstructed with `mentions: Vec::new()`. The
-    /// entity-to-chunk provenance used by retrieval (`source_chunks`) is
-    /// derived from mentions and is therefore lost across save+load. A
-    /// warning is logged at save time when any entity has non-empty mentions
-    /// so users see the signal. Persisting full mentions in a separate
-    /// `entity_mentions.parquet` is tracked in #24.
+    /// Entity rows go to `entities.parquet`. The `EntityMention` payload
+    /// (chunk id + offsets + per-mention confidence) is written to a
+    /// sidecar `entity_mentions.parquet` keyed by entity id, so that
+    /// entity-to-chunk provenance (`source_chunks`) survives a save/load
+    /// round trip. See `load_entities`/`load_entity_mentions` for the read
+    /// side. Fixes #24.
     #[cfg(feature = "persistent-storage")]
     fn save_entities(&self, graph: &KnowledgeGraph) -> Result<()> {
         let entities: Vec<_> = graph.entities().collect();
@@ -237,18 +236,6 @@ impl ParquetPersistence {
             #[cfg(feature = "tracing")]
             tracing::warn!("No entities to save");
             return Ok(());
-        }
-
-        let entities_with_mentions = entities.iter().filter(|e| !e.mentions.is_empty()).count();
-        if entities_with_mentions > 0 {
-            #[cfg(feature = "tracing")]
-            tracing::warn!(
-                "Parquet save: {} of {} entities have mentions, but the current schema \
-                 persists only `mention_count` — full mention payloads will be lost on \
-                 reload. See issue #24.",
-                entities_with_mentions,
-                entities.len()
-            );
         }
 
         // Build Arrow schema for entities
@@ -332,10 +319,97 @@ impl ParquetPersistence {
         #[cfg(feature = "tracing")]
         tracing::info!("Saved {} entities to {:?}", entities.len(), file_path);
 
+        // Persist the mention payload separately so retrieval has provenance
+        // back to source chunks after reload (#24).
+        self.save_entity_mentions(&entities)?;
+
         Ok(())
     }
 
-    /// Load entities from Parquet
+    /// Save entity mentions to a sidecar `entity_mentions.parquet`.
+    ///
+    /// One row per mention; entity_id is the join key back to entities.parquet.
+    /// Always (re)written — including as an empty file — so a stale sidecar
+    /// from a previous save with mentions doesn't get re-attached to a fresh
+    /// graph that has none.
+    #[cfg(feature = "persistent-storage")]
+    fn save_entity_mentions(&self, entities: &[&Entity]) -> Result<()> {
+        let file_path = self.base_dir.join("entity_mentions.parquet");
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("entity_id", DataType::Utf8, false),
+            Field::new("chunk_id", DataType::Utf8, false),
+            Field::new("start_offset", DataType::UInt64, false),
+            Field::new("end_offset", DataType::UInt64, false),
+            Field::new("confidence", DataType::Float32, false),
+        ]));
+
+        let total_mentions: usize = entities.iter().map(|e| e.mentions.len()).sum();
+
+        let mut entity_ids: Vec<&str> = Vec::with_capacity(total_mentions);
+        let mut chunk_ids: Vec<&str> = Vec::with_capacity(total_mentions);
+        let mut starts: Vec<u64> = Vec::with_capacity(total_mentions);
+        let mut ends: Vec<u64> = Vec::with_capacity(total_mentions);
+        let mut confidences: Vec<f32> = Vec::with_capacity(total_mentions);
+
+        for entity in entities {
+            for mention in &entity.mentions {
+                entity_ids.push(entity.id.0.as_str());
+                chunk_ids.push(mention.chunk_id.0.as_str());
+                starts.push(mention.start_offset as u64);
+                ends.push(mention.end_offset as u64);
+                confidences.push(mention.confidence);
+            }
+        }
+
+        let entity_id_arr: StringArray = entity_ids.into_iter().map(Some).collect();
+        let chunk_id_arr: StringArray = chunk_ids.into_iter().map(Some).collect();
+        let start_arr: UInt64Array = starts.into_iter().map(Some).collect();
+        let end_arr: UInt64Array = ends.into_iter().map(Some).collect();
+        let confidence_arr: Float32Array = confidences.into_iter().map(Some).collect();
+
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(entity_id_arr),
+                Arc::new(chunk_id_arr),
+                Arc::new(start_arr),
+                Arc::new(end_arr),
+                Arc::new(confidence_arr),
+            ],
+        )
+        .map_err(|e| GraphRAGError::Config {
+            message: format!("Failed to create mentions RecordBatch: {}", e),
+        })?;
+
+        let file = std::fs::File::create(&file_path)?;
+        let props = WriterProperties::builder()
+            .set_compression(self.get_compression())
+            .build();
+        let mut writer =
+            ArrowWriter::try_new(file, schema, Some(props)).map_err(|e| GraphRAGError::Config {
+                message: format!("Failed to create ArrowWriter: {}", e),
+            })?;
+
+        writer.write(&batch).map_err(|e| GraphRAGError::Config {
+            message: format!("Failed to write mentions batch: {}", e),
+        })?;
+
+        writer.close().map_err(|e| GraphRAGError::Config {
+            message: format!("Failed to close mentions writer: {}", e),
+        })?;
+
+        #[cfg(feature = "tracing")]
+        tracing::info!(
+            "Saved {} entity mentions to {:?}",
+            total_mentions,
+            file_path
+        );
+
+        Ok(())
+    }
+
+    /// Load entities from Parquet (rejoins mentions from the sidecar file).
     #[cfg(feature = "persistent-storage")]
     fn load_entities(&self) -> Result<Vec<Entity>> {
         let file_path = self.base_dir.join("entities.parquet");
@@ -432,8 +506,19 @@ impl ParquetPersistence {
                     confidences.value(i),
                 );
                 entity.embedding = embedding;
-                // mentions are not yet persisted (see issue #24).
                 entities.push(entity);
+            }
+        }
+
+        // Reattach mentions from the sidecar so retrieval has provenance back
+        // to source chunks (#24). Tolerate a missing sidecar file (legacy
+        // workspaces written before this fix).
+        let mentions_by_entity = self.load_entity_mentions()?;
+        if !mentions_by_entity.is_empty() {
+            for entity in entities.iter_mut() {
+                if let Some(mentions) = mentions_by_entity.get(&entity.id) {
+                    entity.mentions = mentions.clone();
+                }
             }
         }
 
@@ -441,6 +526,103 @@ impl ParquetPersistence {
         tracing::info!("Loaded {} entities from {:?}", entities.len(), file_path);
 
         Ok(entities)
+    }
+
+    /// Load entity mentions from `entity_mentions.parquet`, grouped by
+    /// entity id. Returns an empty map if the file is missing — legacy
+    /// workspaces written before issue #24 don't have it.
+    #[cfg(feature = "persistent-storage")]
+    fn load_entity_mentions(
+        &self,
+    ) -> Result<std::collections::HashMap<EntityId, Vec<crate::core::EntityMention>>> {
+        use crate::core::EntityMention;
+
+        let file_path = self.base_dir.join("entity_mentions.parquet");
+        let mut by_entity: std::collections::HashMap<EntityId, Vec<EntityMention>> =
+            std::collections::HashMap::new();
+
+        if !file_path.exists() {
+            #[cfg(feature = "tracing")]
+            tracing::debug!(
+                "No entity_mentions.parquet found — mentions will be empty (legacy workspace)"
+            );
+            return Ok(by_entity);
+        }
+
+        let file = std::fs::File::open(&file_path)?;
+        let reader = ParquetRecordBatchReaderBuilder::try_new(file)
+            .map_err(|e| GraphRAGError::Config {
+                message: format!("Failed to create mentions Parquet reader: {}", e),
+            })?
+            .build()
+            .map_err(|e| GraphRAGError::Config {
+                message: format!("Failed to build mentions reader: {}", e),
+            })?;
+
+        for batch in reader {
+            let batch = batch.map_err(|e| GraphRAGError::Config {
+                message: format!("Failed to read mentions batch: {}", e),
+            })?;
+
+            let entity_ids = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .ok_or_else(|| GraphRAGError::Config {
+                    message: "Invalid entity_id column type in entity_mentions.parquet".to_string(),
+                })?;
+            let chunk_ids = batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .ok_or_else(|| GraphRAGError::Config {
+                    message: "Invalid chunk_id column type in entity_mentions.parquet".to_string(),
+                })?;
+            let starts = batch
+                .column(2)
+                .as_any()
+                .downcast_ref::<UInt64Array>()
+                .ok_or_else(|| GraphRAGError::Config {
+                    message: "Invalid start_offset column type in entity_mentions.parquet"
+                        .to_string(),
+                })?;
+            let ends = batch
+                .column(3)
+                .as_any()
+                .downcast_ref::<UInt64Array>()
+                .ok_or_else(|| GraphRAGError::Config {
+                    message: "Invalid end_offset column type in entity_mentions.parquet"
+                        .to_string(),
+                })?;
+            let confidences = batch
+                .column(4)
+                .as_any()
+                .downcast_ref::<Float32Array>()
+                .ok_or_else(|| GraphRAGError::Config {
+                    message: "Invalid confidence column type in entity_mentions.parquet"
+                        .to_string(),
+                })?;
+
+            for i in 0..batch.num_rows() {
+                let entity_id = EntityId::new(entity_ids.value(i).to_string());
+                let mention = EntityMention {
+                    chunk_id: ChunkId::new(chunk_ids.value(i).to_string()),
+                    start_offset: starts.value(i) as usize,
+                    end_offset: ends.value(i) as usize,
+                    confidence: confidences.value(i),
+                };
+                by_entity.entry(entity_id).or_default().push(mention);
+            }
+        }
+
+        #[cfg(feature = "tracing")]
+        tracing::info!(
+            "Loaded mentions for {} entities from {:?}",
+            by_entity.len(),
+            file_path
+        );
+
+        Ok(by_entity)
     }
 
     /// Placeholder implementations for relationships, chunks, and documents
@@ -1310,5 +1492,77 @@ mod tests {
         let entities = persistence.load_entities().unwrap();
         assert_eq!(entities.len(), 1);
         assert_eq!(entities[0].name, "Test Entity");
+    }
+
+    // Regression for #24: entity mentions must survive a save/load round
+    // trip so entity-to-chunk provenance is preserved for retrieval.
+    #[test]
+    #[cfg(feature = "persistent-storage")]
+    fn entity_mentions_survive_save_and_load_round_trip() {
+        use crate::core::EntityMention;
+
+        let temp_dir = TempDir::new().unwrap();
+        let persistence = ParquetPersistence::new(temp_dir.path().to_path_buf()).unwrap();
+
+        let mut graph = KnowledgeGraph::new();
+        let mentions = vec![
+            EntityMention {
+                chunk_id: ChunkId::new("chunk-a".to_string()),
+                start_offset: 10,
+                end_offset: 17,
+                confidence: 0.91,
+            },
+            EntityMention {
+                chunk_id: ChunkId::new("chunk-b".to_string()),
+                start_offset: 22,
+                end_offset: 29,
+                confidence: 0.42,
+            },
+        ];
+        let entity = Entity::new(
+            EntityId::new("ent-1".to_string()),
+            "Alice".to_string(),
+            "PERSON".to_string(),
+            0.9,
+        )
+        .with_mentions(mentions.clone());
+        graph.add_entity(entity).unwrap();
+
+        persistence.save_entities(&graph).unwrap();
+
+        let entities = persistence.load_entities().unwrap();
+        assert_eq!(entities.len(), 1);
+        let loaded = &entities[0];
+        assert_eq!(loaded.mentions.len(), mentions.len());
+        for (got, want) in loaded.mentions.iter().zip(mentions.iter()) {
+            assert_eq!(got.chunk_id, want.chunk_id);
+            assert_eq!(got.start_offset, want.start_offset);
+            assert_eq!(got.end_offset, want.end_offset);
+            assert!((got.confidence - want.confidence).abs() < 1e-6);
+        }
+    }
+
+    // Regression for #24: an entity with no mentions still round-trips
+    // successfully (we shouldn't write a malformed sidecar file).
+    #[test]
+    #[cfg(feature = "persistent-storage")]
+    fn entities_without_mentions_round_trip_cleanly() {
+        let temp_dir = TempDir::new().unwrap();
+        let persistence = ParquetPersistence::new(temp_dir.path().to_path_buf()).unwrap();
+
+        let mut graph = KnowledgeGraph::new();
+        graph
+            .add_entity(Entity::new(
+                EntityId::new("loner".to_string()),
+                "Loner".to_string(),
+                "THING".to_string(),
+                0.5,
+            ))
+            .unwrap();
+
+        persistence.save_entities(&graph).unwrap();
+        let entities = persistence.load_entities().unwrap();
+        assert_eq!(entities.len(), 1);
+        assert!(entities[0].mentions.is_empty());
     }
 }

--- a/graphrag-core/src/persistence/parquet.rs
+++ b/graphrag-core/src/persistence/parquet.rs
@@ -512,12 +512,13 @@ impl ParquetPersistence {
 
         // Reattach mentions from the sidecar so retrieval has provenance back
         // to source chunks (#24). Tolerate a missing sidecar file (legacy
-        // workspaces written before this fix).
-        let mentions_by_entity = self.load_entity_mentions()?;
+        // workspaces written before this fix). Use `remove` to take
+        // ownership of each `Vec<EntityMention>` rather than cloning.
+        let mut mentions_by_entity = self.load_entity_mentions()?;
         if !mentions_by_entity.is_empty() {
             for entity in entities.iter_mut() {
-                if let Some(mentions) = mentions_by_entity.get(&entity.id) {
-                    entity.mentions = mentions.clone();
+                if let Some(mentions) = mentions_by_entity.remove(&entity.id) {
+                    entity.mentions = mentions;
                 }
             }
         }

--- a/graphrag-core/src/persistence/workspace.rs
+++ b/graphrag-core/src/persistence/workspace.rs
@@ -178,10 +178,26 @@ impl WorkspaceManager {
                     .unwrap_or("unknown")
                     .to_string();
 
-                // Load metadata
-                let metadata = self
-                    .load_metadata(&workspace_name)
-                    .unwrap_or_else(|_| WorkspaceMetadata::new(workspace_name.clone()));
+                // Load metadata. If it's missing or unreadable, skip the
+                // workspace from the listing rather than synthesize fresh
+                // defaults — the previous behaviour silently surfaced
+                // corrupt or partially-initialized directories as healthy
+                // workspaces with `modified_at = now`, which then sorted to
+                // the top of the list. Surface the failure in the log so
+                // operators can investigate (#23).
+                let metadata = match self.load_metadata(&workspace_name) {
+                    Ok(m) => m,
+                    Err(_e) => {
+                        #[cfg(feature = "tracing")]
+                        tracing::warn!(
+                            workspace = %workspace_name,
+                            error = %_e,
+                            "Skipping workspace from listing: metadata unreadable. \
+                             Inspect metadata.toml or remove the directory."
+                        );
+                        continue;
+                    },
+                };
 
                 // Calculate size
                 let size_bytes = Self::calculate_dir_size(&path).unwrap_or(0);
@@ -438,5 +454,29 @@ mod tests {
     fn new_metadata_carries_current_format_version() {
         let m = WorkspaceMetadata::new("fresh".to_string());
         assert_eq!(m.format_version, CURRENT_FORMAT_VERSION);
+    }
+
+    // Regression for #23: a workspace dir whose metadata.toml is unreadable
+    // (corrupt TOML) must not be silently surfaced as a fresh, healthy
+    // workspace by list_workspaces. It should be skipped from the listing.
+    #[test]
+    fn list_workspaces_skips_workspace_with_corrupt_metadata() {
+        let temp_dir = TempDir::new().unwrap();
+        let workspace = WorkspaceManager::new(temp_dir.path()).unwrap();
+
+        workspace.create_workspace("good").unwrap();
+        workspace.create_workspace("broken").unwrap();
+
+        // Stomp on the broken workspace's metadata with garbage TOML.
+        let bad_meta_path = temp_dir.path().join("broken").join("metadata.toml");
+        fs::write(&bad_meta_path, "this is :: not :: valid :: toml @@@").unwrap();
+
+        let listed = workspace.list_workspaces().unwrap();
+        let names: Vec<&str> = listed.iter().map(|w| w.name.as_str()).collect();
+        assert!(names.contains(&"good"), "good workspace should be listed");
+        assert!(
+            !names.contains(&"broken"),
+            "broken workspace must not be silently listed with synthesized defaults"
+        );
     }
 }

--- a/graphrag-core/src/persistence/workspace.rs
+++ b/graphrag-core/src/persistence/workspace.rs
@@ -178,25 +178,39 @@ impl WorkspaceManager {
                     .unwrap_or("unknown")
                     .to_string();
 
-                // Load metadata. If it's missing or unreadable, skip the
-                // workspace from the listing rather than synthesize fresh
-                // defaults — the previous behaviour silently surfaced
-                // corrupt or partially-initialized directories as healthy
-                // workspaces with `modified_at = now`, which then sorted to
-                // the top of the list. Surface the failure in the log so
-                // operators can investigate (#23).
-                let metadata = match self.load_metadata(&workspace_name) {
-                    Ok(m) => m,
-                    Err(_e) => {
-                        #[cfg(feature = "tracing")]
-                        tracing::warn!(
-                            workspace = %workspace_name,
-                            error = %_e,
-                            "Skipping workspace from listing: metadata unreadable. \
-                             Inspect metadata.toml or remove the directory."
-                        );
-                        continue;
-                    },
+                // Load metadata. Distinguish two failure modes:
+                //   * metadata.toml missing entirely → legacy workspace
+                //     written before metadata existed. `load_graph` already
+                //     tolerates this, so synthesize defaults and surface
+                //     the workspace in the listing; otherwise UIs / CLIs
+                //     hide loadable data.
+                //   * metadata.toml present but unreadable (corrupt TOML,
+                //     unrecognized schema, IO failure) → skip and warn.
+                //     Surfacing it as healthy with `modified_at = now`
+                //     would float a corrupt directory to the top of the
+                //     list (#23).
+                let metadata_path = path.join("metadata.toml");
+                let metadata = if !metadata_path.exists() {
+                    #[cfg(feature = "tracing")]
+                    tracing::debug!(
+                        workspace = %workspace_name,
+                        "metadata.toml missing — synthesizing defaults for legacy workspace"
+                    );
+                    WorkspaceMetadata::new(workspace_name.clone())
+                } else {
+                    match self.load_metadata(&workspace_name) {
+                        Ok(m) => m,
+                        Err(_e) => {
+                            #[cfg(feature = "tracing")]
+                            tracing::warn!(
+                                workspace = %workspace_name,
+                                error = %_e,
+                                "Skipping workspace from listing: metadata unreadable. \
+                                 Inspect metadata.toml or remove the directory."
+                            );
+                            continue;
+                        },
+                    }
                 };
 
                 // Calculate size
@@ -509,6 +523,29 @@ mod tests {
             "error message should mention the version mismatch, got: {}",
             msg
         );
+    }
+
+    // Legacy workspaces written before metadata.toml existed must still
+    // appear in `list_workspaces` with synthesized defaults; otherwise
+    // they become invisible to UIs/CLIs even though `load_graph` can
+    // still read them (#23 follow-up).
+    #[test]
+    fn list_workspaces_includes_legacy_dir_with_missing_metadata() {
+        let temp_dir = TempDir::new().unwrap();
+        let workspace = WorkspaceManager::new(temp_dir.path()).unwrap();
+
+        // Create a bare legacy workspace directory with no metadata.toml.
+        let legacy_path = temp_dir.path().join("legacy");
+        fs::create_dir_all(&legacy_path).unwrap();
+
+        let listed = workspace.list_workspaces().unwrap();
+        let legacy = listed
+            .iter()
+            .find(|w| w.name == "legacy")
+            .expect("legacy workspace must appear in listing even without metadata.toml");
+        assert_eq!(legacy.metadata.name, "legacy");
+        assert_eq!(legacy.metadata.format_version, CURRENT_FORMAT_VERSION);
+        assert_eq!(legacy.metadata.entity_count, 0);
     }
 
     // Regression for #23: a workspace dir whose metadata.toml is unreadable

--- a/graphrag-core/src/persistence/workspace.rs
+++ b/graphrag-core/src/persistence/workspace.rs
@@ -251,12 +251,34 @@ impl WorkspaceManager {
         Ok(())
     }
 
-    /// Load knowledge graph from workspace
+    /// Load knowledge graph from workspace.
+    ///
+    /// Refuses to load if the workspace's `metadata.toml` declares a
+    /// `format_version` that doesn't match [`CURRENT_FORMAT_VERSION`] —
+    /// continuing would silently couple a stale on-disk schema to in-memory
+    /// types. Recreate the workspace or write a migration before retrying.
+    /// (Workspaces without metadata.toml fall through to the existing
+    /// best-effort load path.) See issue #23.
     pub fn load_graph(&self, workspace_name: &str) -> Result<KnowledgeGraph> {
         if !self.workspace_exists(workspace_name) {
             return Err(GraphRAGError::Config {
                 message: format!("Workspace '{}' does not exist", workspace_name),
             });
+        }
+
+        // Refuse on format_version mismatch. Missing metadata.toml is
+        // treated as legacy and tolerated below.
+        if let Ok(meta) = self.load_metadata(workspace_name) {
+            if meta.format_version != CURRENT_FORMAT_VERSION {
+                return Err(GraphRAGError::Config {
+                    message: format!(
+                        "Workspace '{}' has metadata format_version '{}' but this build \
+                         expects '{}'. Refusing to load: no migration is implemented. \
+                         Recreate the workspace or downgrade graphrag-core.",
+                        workspace_name, meta.format_version, CURRENT_FORMAT_VERSION
+                    ),
+                });
+            }
         }
 
         let workspace_path = self.workspace_path(workspace_name);
@@ -454,6 +476,39 @@ mod tests {
     fn new_metadata_carries_current_format_version() {
         let m = WorkspaceMetadata::new("fresh".to_string());
         assert_eq!(m.format_version, CURRENT_FORMAT_VERSION);
+    }
+
+    // Regression for #23: load_graph must refuse to load a workspace whose
+    // metadata.toml declares an unrecognized `format_version`. Continuing
+    // would silently couple stale on-disk schemas to in-memory types and is
+    // a correctness footgun; surface it as an error so callers either
+    // migrate or recreate the workspace.
+    #[test]
+    fn load_graph_refuses_on_format_version_mismatch() {
+        let temp_dir = TempDir::new().unwrap();
+        let workspace = WorkspaceManager::new(temp_dir.path()).unwrap();
+
+        let graph = KnowledgeGraph::new();
+        workspace.save_graph(&graph, "future").unwrap();
+
+        // Replace metadata with a version we don't understand.
+        let meta_path = temp_dir.path().join("future").join("metadata.toml");
+        let mut meta: WorkspaceMetadata =
+            toml::from_str(&fs::read_to_string(&meta_path).unwrap()).unwrap();
+        meta.format_version = "9.9-from-the-future".to_string();
+        fs::write(&meta_path, toml::to_string_pretty(&meta).unwrap()).unwrap();
+
+        let result = workspace.load_graph("future");
+        assert!(
+            result.is_err(),
+            "load_graph must refuse to load a workspace with an incompatible format_version"
+        );
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains("format_version") || msg.contains("9.9-from-the-future"),
+            "error message should mention the version mismatch, got: {}",
+            msg
+        );
     }
 
     // Regression for #23: a workspace dir whose metadata.toml is unreadable


### PR DESCRIPTION
## Summary

Closes issues #23 (silent error swallowing in persistence) and #24 (lossy entity round-trip in Parquet), with three follow-up fixes from a second-opinion review.

### Issue #24 — entity mentions roundtrip
- **`fix(core/persistence): persist entity mentions in sidecar parquet`** — new `entity_mentions.parquet` (one row per mention, `entity_id` join key). `save_entities` always writes; `load_entities` rejoins. Legacy workspaces without the sidecar load with empty mentions (backwards compatible).
- Sidecar layout chosen over an embedded `List<Struct<...>>` column to avoid breaking the entities table schema and to keep the file queryable from Polars/DuckDB.

### Issue #23 — silent persistence errors
- **`fix(core/persistence): refuse load on workspace format_version mismatch`** — `load_graph` returns `GraphRAGError::Config` with both versions and a remediation hint when on-disk `format_version` ≠ `CURRENT_FORMAT_VERSION`. (Strict refusal; happy to discuss softening to a migration path in a follow-up.)
- **`fix(core/persistence): skip workspaces with unreadable metadata in listing`** + **`fix(core/persistence): list_workspaces falls back on missing metadata`** — distinguish `NotFound` (legacy workspace, synthesize defaults so it stays visible) from genuine corruption (skip and warn).
- **`fix(core): make load_from_json reject missing IDs and count dropped relationships`** — replaced `unwrap_or("")` on JSON ID reads with a `required_str` helper returning `GraphRAGError::DataCorruption`. Replaced silent `let _ = kg.add_relationship(...)` with counted skips + `tracing::warn!` summary.
- **`fix(core/caching): split L2 deserialize failures from misses in metrics`** + **`fix(core/caching): include deserialize failures in cache hit rate`** — new `DistributedCacheStats::l2_deserialize_failures` counter; `hit_rate()` denominator updated so deserialize failures count as non-hits.

### Performance polish
- **`perf(core/persistence): take ownership of entity mentions during load`** — replaced `.get(&id).cloned()` with `.remove(&id)` in `load_entities`, dropping a `Vec<EntityMention>` clone per entity.

### Build prerequisite
- **`fix(core/persistence): build parquet load with full Entity/Relationship fields`** — pre-existing E0063 break under `--features persistent-storage`; switched to `Entity::new()`/`Relationship::new()` constructors.

## Test plan

- [x] `cargo test -p graphrag-core --features "persistent-storage caching default pagerank redis_storage" --lib`: 456 pass
- [x] `cargo test -p graphrag-core --lib` (default features): 403 pass
- [x] `cargo fmt --all` clean
- [x] Roundtrip test for entity mentions (entity → save → load → assert mentions preserved)
- [x] format_version mismatch refusal test (writes a future version into metadata.toml)
- [x] list_workspaces test for both missing-metadata (visible) and corrupt-metadata (skipped) cases
- [x] hit-rate test asserting deserialize failures lower the rate