### PR TITLE
fix(ci): green the clippy and wasm advisory jobs

### DIFF
--- a/graphrag-core/Cargo.toml
+++ b/graphrag-core/Cargo.toml
@@ -204,7 +204,10 @@ wasm = [
     "js-sys",
     "serde-wasm-bindgen",
     "getrandom",
-] # Browser WASM compatibility
+    "tracing",
+] # Browser WASM compatibility. `tracing` is included because graphrag-core
+  # uses `tracing::*` macros unconditionally throughout the crate; without it
+  # wasm builds fail with E0433.
 cuda = ["neural-embeddings", "candle-core/cuda"] # NVIDIA GPU acceleration
 metal = [
     "neural-embeddings",

--- a/graphrag-core/src/lib.rs
+++ b/graphrag-core/src/lib.rs
@@ -1174,6 +1174,10 @@ impl GraphRAG {
                         relation_type: relation_type.clone(),
                         confidence: self.config.graph.relationship_confidence_threshold,
                         context: vec![chunk.id.clone()],
+                        embedding: None,
+                        temporal_type: None,
+                        temporal_range: None,
+                        causal_strength: None,
                     };
 
                     if let Err(_e) = graph.add_relationship(relationship) {
@@ -1346,6 +1350,10 @@ impl GraphRAG {
     }
 
     /// Query the system for relevant information (synchronous version)
+    ///
+    /// The hybrid retrieval pipeline is async-only, so this fallback delegates
+    /// to `RetrievalSystem::query`, which performs a placeholder lookup. Builds
+    /// that need real retrieval should enable the `async` feature.
     #[cfg(not(feature = "async"))]
     pub fn ask(&mut self, query: &str) -> Result<String> {
         self.ensure_initialized()?;
@@ -1354,7 +1362,13 @@ impl GraphRAG {
             self.build_graph()?;
         }
 
-        let results = self.query_internal(query)?;
+        let retrieval = self
+            .retrieval_system
+            .as_ref()
+            .ok_or_else(|| GraphRAGError::Config {
+                message: "Retrieval system not initialized".to_string(),
+            })?;
+        let results = retrieval.query(query)?;
         Ok(results.join("\n"))
     }
 

--- a/graphrag-core/src/text/chunking_strategies.rs
+++ b/graphrag-core/src/text/chunking_strategies.rs
@@ -535,6 +535,11 @@ impl BoundaryAwareChunkingStrategy {
     }
 }
 
+// The sync trait impl below bridges into async coherence scoring via a tokio
+// runtime, so it is only available when the `async` feature is enabled. On
+// targets without async (e.g. wasm32) `BoundaryAwareChunkingStrategy` is still
+// constructible, but cannot be used through the `ChunkingStrategy` trait.
+#[cfg(feature = "async")]
 impl ChunkingStrategy for BoundaryAwareChunkingStrategy {
     fn chunk(&self, text: &str) -> Vec<TextChunk> {
         // The sync trait impl needs to drive async coherence scoring. Pick the

--- a/graphrag-core/tests/incremental_integration.rs
+++ b/graphrag-core/tests/incremental_integration.rs
@@ -48,10 +48,6 @@ fn test_incremental_manager_with_lazy_propagation() {
     // Force propagate pending updates
     let result = manager.force_propagate_updates().unwrap();
     assert_eq!(result.updates_failed, 0);
-
-    // Get propagation statistics
-    let propagation_stats = manager.get_propagation_stats();
-    assert!(propagation_stats.total_propagated >= 0);
 }
 
 #[test]
@@ -236,12 +232,6 @@ fn test_lazy_propagation_auto_trigger() {
             })
             .unwrap();
     }
-
-    // Check that auto-propagation occurred
-    let stats = manager.get_propagation_stats();
-    // With threshold of 3, we should have at least 1 auto-propagation
-    // (5 nodes / 3 threshold = 1+ propagations)
-    assert!(stats.auto_propagations >= 0); // May or may not have triggered depending on timing
 }
 
 #[test]
@@ -307,9 +297,6 @@ fn test_combined_lazy_and_delta() {
     // Verify both features worked
     let stats = manager.stats();
     assert_eq!(stats.node_count, 5);
-
-    let prop_stats = manager.get_propagation_stats();
-    assert!(prop_stats.total_propagated >= 0);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Both advisory CI jobs (`Clippy (advisory)` and `WASM build (advisory)` in `.github/workflows/ci.yml`) have been red on `main`. Top-level CI is green only because each job sets `continue-on-error: true`. This PR makes both jobs pass.

- **Clippy**: 3 errors → 0. Three `assert!(x >= 0)` calls in `graphrag-core/tests/incremental_integration.rs` compared `usize` counters against `0`, which clippy's correctness-group lint `absurd_extreme_comparisons` rejects. Removed.
- **WASM build**: 67 errors → 0. Three independent root causes:
  1. `graphrag-core` uses `tracing::*` macros unconditionally throughout the crate, but the `wasm` feature combo did not pull in `tracing` (65 × `E0433`). Added `tracing` to the `wasm` feature.
  2. The sync `GraphRAG::build_graph` (gated `#[cfg(not(feature = \"async\"))]`) constructed `Relationship` literals without the four optional fields added later (`embedding`, `temporal_type`, `temporal_range`, `causal_strength`) — `E0063`. Added the missing fields.
  3. The sync `GraphRAG::ask` (same cfg) called the `async fn query_internal` with `?`, which is an `E0277` (cannot `?` a future from a non-async fn). Rerouted to `RetrievalSystem::query`, the only sync retrieval entry point. The async retrieval pipeline still requires `feature = \"async\"`; this is documented in the doc comment.
  4. (Bonus, found while fixing the above.) `BoundaryAwareChunkingStrategy::chunk` bridges into async coherence scoring through a tokio runtime, so its `ChunkingStrategy` impl is now gated on `feature = \"async\"`. The struct itself remains constructible on wasm; only the sync trait method is gone.

The advisory `continue-on-error: true` flags are intentionally **not** flipped in this PR — let one green CI cycle land first, then a tiny follow-up can promote both jobs to required gates.

## Commits
1. `fix(graphrag-core): drop tautological usize >= 0 asserts in tests`
2. `build(graphrag-core): include tracing in the wasm feature`
3. `fix(graphrag-core): repair non-async build paths for wasm`

## Test plan
- [x] `cargo clippy --workspace --all-targets --exclude graphrag_py --exclude graphrag-wasm` exits 0
- [x] `cargo build -p graphrag-wasm --lib --target wasm32-unknown-unknown` finishes cleanly (0 errors, 19 pre-existing warnings)
- [x] `cargo build --workspace --exclude graphrag_py --exclude graphrag-wasm` finishes cleanly
- [x] `cargo nextest run --workspace --tests --exclude graphrag_py --exclude graphrag-wasm` → 722 passed, 40 skipped
- [x] `cargo fmt --all -- --check` clean
- [ ] Confirm both advisory jobs run green in this PR's CI
- [ ] Follow-up PR: drop `continue-on-error: true` and add `-- -D warnings` on clippy

## Out of scope
- 19 pre-existing dead-code / unused-import warnings in `graphrag-core` (visible during the wasm build) are untouched.
- README updates: none — no user-visible behavior, commands, or APIs change. Sync `GraphRAG::ask` has zero callers in the workspace; only the placeholder behind it changed.