### PR TITLE
fix(core): wrap sync ureq HTTP in spawn_blocking (#4 unblock)

### DIFF
--- a/graphrag-core/src/embeddings/api_providers.rs
+++ b/graphrag-core/src/embeddings/api_providers.rs
@@ -21,6 +21,21 @@ pub struct HttpEmbeddingProvider {
     client: ureq::Agent,
 }
 
+/// Owned snapshot of an `HttpEmbeddingProvider`'s HTTP-relevant fields.
+///
+/// Constructed by [`HttpEmbeddingProvider::request_ctx`] so the sync `ureq`
+/// HTTP path can be moved into `tokio::task::spawn_blocking`, which requires
+/// a `'static` closure (no borrows of `&self`).
+#[cfg(feature = "ureq")]
+#[derive(Clone)]
+struct HttpRequestCtx {
+    provider_type: EmbeddingProviderType,
+    api_key: String,
+    model: String,
+    endpoint: String,
+    client: ureq::Agent,
+}
+
 impl HttpEmbeddingProvider {
     /// Create OpenAI embeddings provider
     ///
@@ -215,8 +230,39 @@ impl HttpEmbeddingProvider {
         Ok(provider)
     }
 
+    /// Override the HTTP endpoint. Intended for redirecting requests to a
+    /// local mock server in integration tests.
+    #[doc(hidden)]
+    pub fn with_endpoint_for_tests(mut self, endpoint: impl Into<String>) -> Self {
+        self.endpoint = endpoint.into();
+        self
+    }
+
+    /// Snapshot of the fields needed by the sync HTTP path. Cloned out of
+    /// `&self` before crossing into `tokio::task::spawn_blocking`, which
+    /// requires a `'static` closure.
     #[cfg(feature = "ureq")]
-    fn make_request(&self, input: &str) -> Result<Vec<f32>> {
+    fn request_ctx(&self) -> HttpRequestCtx {
+        HttpRequestCtx {
+            provider_type: self.provider_type.clone(),
+            api_key: self.api_key.clone(),
+            model: self.model.clone(),
+            endpoint: self.endpoint.clone(),
+            client: self.client.clone(),
+        }
+    }
+
+    #[cfg(not(feature = "ureq"))]
+    fn unsupported_without_ureq<T>() -> Result<T> {
+        Err(GraphRAGError::Embedding {
+            message: "ureq feature required for HTTP-based embeddings".to_string(),
+        })
+    }
+}
+
+#[cfg(feature = "ureq")]
+impl HttpRequestCtx {
+    fn make_request(self, input: &str) -> Result<Vec<f32>> {
         // Build request body based on provider
         let request_body = match self.provider_type {
             EmbeddingProviderType::OpenAI => {
@@ -312,35 +358,28 @@ impl HttpEmbeddingProvider {
         Ok(embedding)
     }
 
-    #[cfg(not(feature = "ureq"))]
-    fn make_request(&self, _input: &str) -> Result<Vec<f32>> {
-        Err(GraphRAGError::Embedding {
-            message: "ureq feature required for HTTP-based embeddings".to_string(),
-        })
-    }
+    fn make_batch_request(self, inputs: Vec<String>) -> Result<Vec<Vec<f32>>> {
+        let input_refs: Vec<&str> = inputs.iter().map(|s| s.as_str()).collect();
 
-    /// Make batch embedding request for multiple texts
-    #[cfg(feature = "ureq")]
-    fn make_batch_request(&self, inputs: &[&str]) -> Result<Vec<Vec<f32>>> {
         // Build request body based on provider
         let request_body = match self.provider_type {
             EmbeddingProviderType::OpenAI => {
                 serde_json::json!({
                     "model": self.model.clone(),
-                    "input": inputs,
+                    "input": &input_refs,
                 })
             },
             EmbeddingProviderType::VoyageAI => {
                 serde_json::json!({
                     "model": self.model.clone(),
-                    "input": inputs,
+                    "input": &input_refs,
                     "input_type": "document",
                 })
             },
             EmbeddingProviderType::Cohere => {
                 serde_json::json!({
                     "model": self.model.clone(),
-                    "texts": inputs,
+                    "texts": &input_refs,
                     "input_type": "search_document",
                     "embedding_types": vec!["float"],
                 })
@@ -350,7 +389,7 @@ impl HttpEmbeddingProvider {
             | EmbeddingProviderType::TogetherAI => {
                 serde_json::json!({
                     "model": self.model.clone(),
-                    "input": inputs,
+                    "input": &input_refs,
                 })
             },
             _ => {
@@ -447,13 +486,6 @@ impl HttpEmbeddingProvider {
 
         Ok(embeddings)
     }
-
-    #[cfg(not(feature = "ureq"))]
-    fn make_batch_request(&self, _inputs: &[&str]) -> Result<Vec<Vec<f32>>> {
-        Err(GraphRAGError::Embedding {
-            message: "ureq feature required for batch embeddings".to_string(),
-        })
-    }
 }
 
 #[async_trait::async_trait]
@@ -464,7 +496,24 @@ impl EmbeddingProvider for HttpEmbeddingProvider {
     }
 
     async fn embed(&self, text: &str) -> Result<Vec<f32>> {
-        self.make_request(text)
+        #[cfg(feature = "ureq")]
+        {
+            // `ureq` is synchronous; dispatch to the blocking pool so the
+            // running tokio worker is not parked for the entire HTTP
+            // round-trip (issue #4).
+            let ctx = self.request_ctx();
+            let owned = text.to_string();
+            tokio::task::spawn_blocking(move || ctx.make_request(&owned))
+                .await
+                .map_err(|e| GraphRAGError::Embedding {
+                    message: format!("HTTP worker task panicked or was cancelled: {}", e),
+                })?
+        }
+
+        #[cfg(not(feature = "ureq"))]
+        {
+            Self::unsupported_without_ureq()
+        }
     }
 
     async fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
@@ -480,8 +529,16 @@ impl EmbeddingProvider for HttpEmbeddingProvider {
 
         #[cfg(feature = "ureq")]
         {
-            // Try batch request for supported providers
-            match self.make_batch_request(texts) {
+            // Try batch request for supported providers; like `embed`, dispatch
+            // the sync HTTP call to the blocking pool (issue #4).
+            let ctx = self.request_ctx();
+            let owned: Vec<String> = texts.iter().map(|s| s.to_string()).collect();
+            let batch_result = tokio::task::spawn_blocking(move || ctx.make_batch_request(owned))
+                .await
+                .map_err(|e| GraphRAGError::Embedding {
+                    message: format!("HTTP worker task panicked or was cancelled: {}", e),
+                })?;
+            match batch_result {
                 Ok(embeddings) => return Ok(embeddings),
                 Err(_) => {
                     // Fallback to sequential requests if batch fails

--- a/graphrag-core/src/ollama/mod.rs
+++ b/graphrag-core/src/ollama/mod.rs
@@ -360,23 +360,36 @@ impl OllamaClient {
             request_body["options"] = options;
         }
 
-        // Make HTTP request with retry logic
-        let mut last_error = None;
+        // Make HTTP request with retry logic.
+        //
+        // `ureq` is a synchronous HTTP client; calling it directly inside this
+        // `async fn` parks an entire tokio worker for the full round-trip.
+        // Dispatch each attempt to the blocking pool so async workers stay free
+        // for other in-flight tasks (issue #4).
+        let mut last_error: Option<String> = None;
         for attempt in 1..=self.config.max_retries {
-            match self
-                .client
-                .post(&endpoint)
-                .set("Content-Type", "application/json")
-                .send_json(&request_body)
-            {
-                Ok(response) => {
-                    let json_response: serde_json::Value =
+            let agent = self.client.clone();
+            let endpoint_owned = endpoint.clone();
+            let body_owned = request_body.clone();
+            let send_result = tokio::task::spawn_blocking(move || {
+                agent
+                    .post(&endpoint_owned)
+                    .set("Content-Type", "application/json")
+                    .send_json(&body_owned)
+                    .map_err(|e| e.to_string())
+                    .and_then(|response| {
                         response
-                            .into_json()
-                            .map_err(|e| GraphRAGError::Generation {
-                                message: format!("Failed to parse JSON response: {}", e),
-                            })?;
+                            .into_json::<serde_json::Value>()
+                            .map_err(|e| format!("Failed to parse JSON response: {}", e))
+                    })
+            })
+            .await
+            .map_err(|join_err| GraphRAGError::Generation {
+                message: format!("HTTP worker task panicked or was cancelled: {}", join_err),
+            })?;
 
+            match send_result {
+                Ok(json_response) => {
                     // Extract response text
                     if let Some(response_text) = json_response["response"].as_str() {
                         let response_string = response_text.to_string();
@@ -513,22 +526,32 @@ impl OllamaClient {
             request_body["options"] = options;
         }
 
-        let mut last_error = None;
+        // Same rationale as `generate_with_params`: the sync `ureq` call must
+        // run on the blocking pool, not on a tokio worker thread (issue #4).
+        let mut last_error: Option<String> = None;
         for attempt in 1..=self.config.max_retries {
-            match self
-                .client
-                .post(&endpoint)
-                .set("Content-Type", "application/json")
-                .send_json(&request_body)
-            {
-                Ok(response) => {
-                    let json_response: serde_json::Value =
+            let agent = self.client.clone();
+            let endpoint_owned = endpoint.clone();
+            let body_owned = request_body.clone();
+            let send_result = tokio::task::spawn_blocking(move || {
+                agent
+                    .post(&endpoint_owned)
+                    .set("Content-Type", "application/json")
+                    .send_json(&body_owned)
+                    .map_err(|e| e.to_string())
+                    .and_then(|response| {
                         response
-                            .into_json()
-                            .map_err(|e| GraphRAGError::Generation {
-                                message: format!("Failed to parse JSON response: {}", e),
-                            })?;
+                            .into_json::<serde_json::Value>()
+                            .map_err(|e| format!("Failed to parse JSON response: {}", e))
+                    })
+            })
+            .await
+            .map_err(|join_err| GraphRAGError::Generation {
+                message: format!("HTTP worker task panicked or was cancelled: {}", join_err),
+            })?;
 
+            match send_result {
+                Ok(json_response) => {
                     let text = json_response["response"]
                         .as_str()
                         .ok_or_else(|| GraphRAGError::Generation {
@@ -629,8 +652,14 @@ impl OllamaClient {
         let stats = self.stats.clone();
         let prompt_len = prompt.len();
 
-        // Spawn background task to read streaming response
-        tokio::spawn(async move {
+        // Spawn background task to read streaming response.
+        //
+        // The HTTP request and the line-by-line read loop are both synchronous
+        // (`ureq` blocks on `into_reader().read`), so they run on the blocking
+        // pool. `blocking_send` is the synchronous mpsc sender — it parks the
+        // current OS thread (a blocking-pool thread, not a tokio worker) when
+        // the channel is full or being polled.
+        tokio::task::spawn_blocking(move || {
             match client
                 .post(&endpoint)
                 .set("Content-Type", "application/json")
@@ -656,8 +685,11 @@ impl OllamaClient {
                                     if let Some(token) = json["response"].as_str() {
                                         total_response.push_str(token);
 
-                                        // Send token through channel
-                                        if tx.send(token.to_string()).await.is_err() {
+                                        // Send token through channel (sync send
+                                        // from blocking pool — never call
+                                        // `.send().await` here, that would
+                                        // require an async runtime).
+                                        if tx.blocking_send(token.to_string()).is_err() {
                                             // Receiver dropped, stop streaming
                                             break;
                                         }

--- a/graphrag-core/src/text/late_chunking.rs
+++ b/graphrag-core/src/text/late_chunking.rs
@@ -269,7 +269,7 @@ impl JinaLateChunkingClient {
         &self,
         chunks: &[TextChunk],
     ) -> crate::Result<Vec<Vec<f32>>> {
-        let inputs: Vec<&str> = chunks.iter().map(|c| c.content.as_str()).collect();
+        let inputs: Vec<String> = chunks.iter().map(|c| c.content.clone()).collect();
 
         let body = serde_json::json!({
             "model": self.model,
@@ -277,22 +277,30 @@ impl JinaLateChunkingClient {
             "late_chunking": true,
         });
 
-        let agent = ureq::AgentBuilder::new().build();
-        let response = agent
-            .post(Self::ENDPOINT)
-            .set("Authorization", &format!("Bearer {}", self.api_key))
-            .set("Content-Type", "application/json")
-            .send_json(&body)
-            .map_err(|e| GraphRAGError::Generation {
-                message: format!("Jina API request failed: {e}"),
-            })?;
-
-        let json: serde_json::Value =
+        // `ureq` is synchronous; running it directly inside this `async fn`
+        // would park a tokio worker for the whole round-trip. Dispatch to the
+        // blocking pool (issue #4).
+        let api_key = self.api_key.clone();
+        let json = tokio::task::spawn_blocking(move || -> crate::Result<serde_json::Value> {
+            let agent = ureq::AgentBuilder::new().build();
+            let response = agent
+                .post(Self::ENDPOINT)
+                .set("Authorization", &format!("Bearer {}", api_key))
+                .set("Content-Type", "application/json")
+                .send_json(&body)
+                .map_err(|e| GraphRAGError::Generation {
+                    message: format!("Jina API request failed: {e}"),
+                })?;
             response
-                .into_json()
+                .into_json::<serde_json::Value>()
                 .map_err(|e| GraphRAGError::Generation {
                     message: format!("Failed to parse Jina API response: {e}"),
-                })?;
+                })
+        })
+        .await
+        .map_err(|e| GraphRAGError::Generation {
+            message: format!("HTTP worker task panicked or was cancelled: {e}"),
+        })??;
 
         let data = json["data"]
             .as_array()

--- a/graphrag-core/tests/embeddings_concurrent_blocking.rs
+++ b/graphrag-core/tests/embeddings_concurrent_blocking.rs
@@ -1,0 +1,134 @@
+//! Concurrency regression test for issue #4 — embeddings path.
+//!
+//! `HttpEmbeddingProvider` (OpenAI / Voyage / Cohere / etc.) used the same
+//! sync-`ureq`-inside-`async-fn` pattern that `OllamaClient` did, so concurrent
+//! `embed` calls serialised on the tokio worker pool and contributed to the
+//! `build_graph` deadlock under load. This test asserts that 8 concurrent
+//! `embed` calls against a 500ms mock server complete in roughly one
+//! round-trip when run on a 2-worker tokio runtime.
+
+#![cfg(all(feature = "ureq", feature = "async"))]
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::TcpListener;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use graphrag_core::embeddings::api_providers::HttpEmbeddingProvider;
+use graphrag_core::embeddings::EmbeddingProvider;
+
+struct MockServer {
+    port: u16,
+    shutdown: Arc<AtomicBool>,
+}
+
+impl MockServer {
+    fn start(delay: Duration) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        let port = listener.local_addr().unwrap().port();
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown_clone = shutdown.clone();
+
+        listener
+            .set_nonblocking(true)
+            .expect("set_nonblocking on listener");
+
+        thread::spawn(move || {
+            while !shutdown_clone.load(Ordering::Relaxed) {
+                match listener.accept() {
+                    Ok((stream, _addr)) => {
+                        thread::spawn(move || handle_connection(stream, delay));
+                    },
+                    Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(10));
+                    },
+                    Err(_) => break,
+                }
+            }
+        });
+
+        MockServer { port, shutdown }
+    }
+}
+
+impl Drop for MockServer {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::Relaxed);
+    }
+}
+
+fn handle_connection(mut stream: std::net::TcpStream, delay: Duration) {
+    stream
+        .set_nonblocking(false)
+        .expect("set blocking on accepted stream");
+
+    let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+    let mut content_length: usize = 0;
+    let mut line = String::new();
+    loop {
+        line.clear();
+        if reader.read_line(&mut line).unwrap_or(0) == 0 {
+            return;
+        }
+        if line == "\r\n" {
+            break;
+        }
+        if let Some(rest) = line.to_ascii_lowercase().strip_prefix("content-length:") {
+            content_length = rest.trim().parse().unwrap_or(0);
+        }
+    }
+    if content_length > 0 {
+        let mut body = vec![0u8; content_length];
+        let _ = reader.read_exact(&mut body);
+    }
+
+    thread::sleep(delay);
+
+    // OpenAI-compatible embeddings response with a 4-dim vector.
+    let body = br#"{"data":[{"embedding":[0.1,0.2,0.3,0.4],"index":0}],"model":"test","usage":{}}"#;
+    let header = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    );
+    let _ = stream.write_all(header.as_bytes());
+    let _ = stream.write_all(body);
+    let _ = stream.flush();
+}
+
+/// 8 concurrent `embed` calls against a 500ms mock should complete in roughly
+/// one round-trip (~600ms) on a 2-worker runtime once the sync ureq call is
+/// dispatched to the blocking pool. Without the fix the calls serialise on
+/// the worker pool and total time exceeds 2s.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn concurrent_embed_does_not_block_runtime_workers() {
+    let server = MockServer::start(Duration::from_millis(500));
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let endpoint = format!("http://127.0.0.1:{}/v1/embeddings", server.port);
+
+    // Use the openai() constructor and swap the endpoint via the
+    // `with_endpoint_for_tests` helper exposed on `HttpEmbeddingProvider`.
+    let provider = HttpEmbeddingProvider::openai("sk-test".to_string(), "model".to_string())
+        .with_endpoint_for_tests(endpoint);
+
+    let n = 8usize;
+    let provider = std::sync::Arc::new(provider);
+    let start = Instant::now();
+    let mut handles = Vec::with_capacity(n);
+    for _ in 0..n {
+        let p = provider.clone();
+        handles.push(tokio::spawn(async move { p.embed("hello").await }));
+    }
+    for h in handles {
+        h.await.expect("join").expect("embed ok");
+    }
+    let elapsed = start.elapsed();
+
+    assert!(
+        elapsed < Duration::from_millis(1500),
+        "concurrent embed calls took {elapsed:?}; expected well under 1.5s, \
+         which means sync ureq is parking tokio worker threads"
+    );
+}

--- a/graphrag-core/tests/ollama_concurrent_blocking.rs
+++ b/graphrag-core/tests/ollama_concurrent_blocking.rs
@@ -1,0 +1,172 @@
+//! Concurrency regression test for issue #4.
+//!
+//! `OllamaClient` uses synchronous `ureq` calls inside `async fn` bodies. Without
+//! `tokio::task::spawn_blocking`, every in-flight LLM request parks an entire
+//! tokio worker thread for the duration of the HTTP round-trip, which serialises
+//! concurrent calls and — combined with sequential per-chunk extraction — wedges
+//! `build_graph` once the document count exceeds the worker pool size.
+//!
+//! These tests assert that N concurrent generate calls against a slow mock
+//! server complete in roughly one round-trip, not N round-trips.
+
+#![cfg(all(feature = "ollama", feature = "async", feature = "ureq"))]
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::TcpListener;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use graphrag_core::ollama::{OllamaClient, OllamaConfig, OllamaGenerationParams};
+
+/// A tiny single-threaded HTTP mock that delays every response by `delay_ms`.
+///
+/// Returns the bound port and a guard whose drop signals the listener thread
+/// to exit on the next accept. The server uses one OS thread per connection so
+/// it can serve many simultaneous requests in parallel — the contention we are
+/// measuring is on the *client* side, not the server side.
+struct MockServer {
+    port: u16,
+    shutdown: Arc<AtomicBool>,
+}
+
+impl MockServer {
+    fn start(delay: Duration) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        let port = listener.local_addr().unwrap().port();
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown_clone = shutdown.clone();
+
+        // Use non-blocking accept with a short poll so the thread can observe
+        // the shutdown flag and exit promptly when the test finishes.
+        listener
+            .set_nonblocking(true)
+            .expect("set_nonblocking on listener");
+
+        thread::spawn(move || {
+            while !shutdown_clone.load(Ordering::Relaxed) {
+                match listener.accept() {
+                    Ok((stream, _addr)) => {
+                        thread::spawn(move || handle_connection(stream, delay));
+                    },
+                    Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(10));
+                    },
+                    Err(_) => break,
+                }
+            }
+        });
+
+        MockServer { port, shutdown }
+    }
+}
+
+impl Drop for MockServer {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::Relaxed);
+    }
+}
+
+fn handle_connection(mut stream: std::net::TcpStream, delay: Duration) {
+    stream
+        .set_nonblocking(false)
+        .expect("set blocking on accepted stream");
+
+    // Parse just enough of the request to know the content-length, then drain it.
+    let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+    let mut content_length: usize = 0;
+    let mut line = String::new();
+    loop {
+        line.clear();
+        if reader.read_line(&mut line).unwrap_or(0) == 0 {
+            return;
+        }
+        if line == "\r\n" {
+            break;
+        }
+        if let Some(rest) = line.to_ascii_lowercase().strip_prefix("content-length:") {
+            content_length = rest.trim().parse().unwrap_or(0);
+        }
+    }
+    if content_length > 0 {
+        let mut body = vec![0u8; content_length];
+        let _ = reader.read_exact(&mut body);
+    }
+
+    // Simulate a slow LLM response.
+    thread::sleep(delay);
+
+    let body =
+        br#"{"response":"ok","context":[],"prompt_eval_count":1,"eval_count":1,"done":true}"#;
+    let header = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    );
+    let _ = stream.write_all(header.as_bytes());
+    let _ = stream.write_all(body);
+    let _ = stream.flush();
+}
+
+fn make_client(port: u16) -> OllamaClient {
+    let config = OllamaConfig {
+        enabled: true,
+        host: "http://127.0.0.1".to_string(),
+        port,
+        embedding_model: "nomic-embed-text".to_string(),
+        chat_model: "test-model".to_string(),
+        timeout_seconds: 10,
+        max_retries: 1,
+        fallback_to_hash: false,
+        max_tokens: Some(8),
+        temperature: Some(0.0),
+        enable_caching: false,
+        keep_alive: None,
+        num_ctx: None,
+    };
+    OllamaClient::new(config)
+}
+
+/// Asserts that 8 concurrent generate_with_params calls against a 500ms mock
+/// complete well under the time it would take to serialise them on a 2-worker
+/// runtime. Without spawn_blocking around the sync ureq call this test
+/// effectively serialises (>= ~2s); with spawn_blocking it parallelises on the
+/// blocking pool (~600ms in practice).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn concurrent_generate_does_not_block_runtime_workers() {
+    let server = MockServer::start(Duration::from_millis(500));
+    // Give the server a beat to start its accept loop.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let client = make_client(server.port);
+
+    let n = 8usize;
+    let start = Instant::now();
+    let mut handles = Vec::with_capacity(n);
+    for _ in 0..n {
+        let c = client.clone();
+        handles.push(tokio::spawn(async move {
+            c.generate_with_params(
+                "hi",
+                OllamaGenerationParams {
+                    num_predict: Some(1),
+                    ..Default::default()
+                },
+            )
+            .await
+        }));
+    }
+    for h in handles {
+        h.await.expect("join").expect("generate ok");
+    }
+    let elapsed = start.elapsed();
+
+    // Hard upper bound: a fully serialised run on 2 workers would be ~2s
+    // (8 * 500ms / 2). We pick 1500ms as the failure threshold so the test
+    // fails before the fix and passes comfortably after.
+    assert!(
+        elapsed < Duration::from_millis(1500),
+        "concurrent generate calls took {elapsed:?}; expected well under 1.5s, \
+         which means sync ureq is parking tokio worker threads"
+    );
+}


### PR DESCRIPTION
## Summary

Wraps every synchronous `ureq` HTTP call that previously ran inside an `async fn` body in `tokio::task::spawn_blocking`. Each unwrapped call was parking an entire tokio worker thread for the duration of the round-trip, which (per the issue #4 investigation) is the most likely root cause of the deadlock at ~25+ documents — the runtime's worker pool gets fully consumed by parked extraction calls and stops making progress.

### Sites wrapped

- **`graphrag-core/src/ollama/mod.rs`**
  - `OllamaClient::generate_with_params`
  - `OllamaClient::generate_with_full_response`
  - `OllamaClient::generate_streaming` (was `tokio::spawn` over sync I/O; now `spawn_blocking` + `mpsc::Sender::blocking_send`)
- **`graphrag-core/src/embeddings/api_providers.rs`**
  - `HttpEmbeddingProvider::embed` (covers OpenAI, Voyage AI, Cohere, Jina AI, Mistral, Together AI)
  - `HttpEmbeddingProvider::embed_batch`
- **`graphrag-core/src/text/late_chunking.rs`**
  - `JinaLateChunkingClient::embed_with_late_chunking`

### Implementation notes

- Extracted an owned `HttpRequestCtx` snapshot struct so the closure handed to `spawn_blocking` is `'static` without retaining references to `&self`.
- `JoinError` mapped to typed `GraphRAGError::Generation` / `GraphRAGError::Embedding` — no `.unwrap()` on the join.
- Added `#[doc(hidden)] HttpEmbeddingProvider::with_endpoint_for_tests` for the integration test only.

### Scope deliberately limited

This is the **necessary precondition** for resolving #4, not a complete fix. Still open:
- Sequential per-chunk extraction loop in `lib.rs::build_graph` (#9)
- CLI re-running `build_graph().await` after every `/load` (separate concern)

After this lands, the strace/tokio-debug repro recommended by the original investigation should produce a much clearer signal on what (if anything) still wedges.

## Test plan

- [x] `tests/ollama_concurrent_blocking.rs::concurrent_generate_does_not_block_runtime_workers` — 8 calls × 500 ms / 2 workers — Red: 2.02s · Green: 0.56s · bound: < 1.5s
- [x] `tests/embeddings_concurrent_blocking.rs::concurrent_embed_does_not_block_runtime_workers` — same harness, mock-served — Red: 2.02s · Green: 0.56s · bound: < 1.5s
- [x] `cargo test -p graphrag-core --features full --lib`: 465 pass
- [x] `cargo fmt --all` clean
- [x] Independent code review: both Codex (gpt-5.3-codex) and Gemini (3.1-pro-preview) reviewed and approved with no findings