### PR TITLE
fix(graphrag-core): make sync ask return an explicit error

### DIFF
--- a/graphrag-core/src/lib.rs
+++ b/graphrag-core/src/lib.rs
@@ -1351,25 +1351,17 @@ impl GraphRAG {
 
     /// Query the system for relevant information (synchronous version)
     ///
-    /// The hybrid retrieval pipeline is async-only, so this fallback delegates
-    /// to `RetrievalSystem::query`, which performs a placeholder lookup. Builds
-    /// that need real retrieval should enable the `async` feature.
+    /// The hybrid retrieval pipeline is async-only. This sync fallback exists
+    /// only to keep the `GraphRAG::ask` symbol present on builds without the
+    /// `async` feature; calling it returns an error rather than fabricating
+    /// stub answers. Enable the `async` feature for real retrieval.
     #[cfg(not(feature = "async"))]
-    pub fn ask(&mut self, query: &str) -> Result<String> {
-        self.ensure_initialized()?;
-
-        if self.has_documents() && !self.has_graph() {
-            self.build_graph()?;
-        }
-
-        let retrieval = self
-            .retrieval_system
-            .as_ref()
-            .ok_or_else(|| GraphRAGError::Config {
-                message: "Retrieval system not initialized".to_string(),
-            })?;
-        let results = retrieval.query(query)?;
-        Ok(results.join("\n"))
+    pub fn ask(&mut self, _query: &str) -> Result<String> {
+        Err(GraphRAGError::Config {
+            message: "GraphRAG::ask requires the `async` feature; the sync \
+                fallback cannot drive hybrid retrieval"
+                .to_string(),
+        })
     }
 
     /// Query the system and return an explained answer with reasoning trace


### PR DESCRIPTION
## Summary
Follow-up to #113. The advisory CI bringup added a sync fallback for `GraphRAG::ask` that routed through `RetrievalSystem::query` — which is a placeholder returning `\"Results for query: ...\"` rather than performing real retrieval. External code review (Codex) flagged it: the path looks successful but lies to the caller.

There is no sync hybrid retrieval pipeline today. This change makes the sync `ask` return a `GraphRAGError::Config` explaining that the `async` feature is required for real retrieval, instead of fabricating stub answers.

## Why this is safe
- `GraphRAG::ask` has zero non-async callers in the workspace (verified across graphrag-cli, graphrag-server, graphrag-wasm, examples, benches — every caller goes through the async `pub async fn ask`, gated on `feature = \"async\"`).
- The sync overload only exists at all to keep the symbol present on builds without the `async` feature (notably wasm). Those callers now get a clear error rather than a hallucinated success.

## Test plan
- [x] `cargo build -p graphrag-wasm --lib --target wasm32-unknown-unknown` clean
- [x] `cargo build --workspace --exclude graphrag_py --exclude graphrag-wasm` clean
- [x] `cargo nextest run --workspace --tests --exclude graphrag_py --exclude graphrag-wasm` — 722 passed
- [x] `cargo fmt --all -- --check` clean
- [ ] Confirm both advisory jobs stay green in this PR's CI