### PR TITLE
perf(core): retrieval/chunking — batch embed + drain fusion inputs

### DIFF
--- a/graphrag-core/src/retrieval/hybrid.rs
+++ b/graphrag-core/src/retrieval/hybrid.rs
@@ -557,20 +557,25 @@ mod tests {
         assert!(result.is_err());
     }
 
+    // Mimic the real semantic_search content: a placeholder string derived
+    // from the id (see `semantic_search` which uses the id as content).
     fn semantic(id: &str, score: f32) -> (String, f32, String) {
-        (id.to_string(), score, format!("content of {id}"))
+        (id.to_string(), score, format!("semantic-placeholder-{id}"))
     }
 
+    // Mimic real BM25 results carrying the actual document text.
     fn keyword(id: &str, score: f32) -> BM25Result {
         BM25Result {
             doc_id: id.to_string(),
             score,
-            content: format!("content of {id}"),
+            content: format!("real-bm25-text-{id}"),
         }
     }
 
     // RRF fusion preserves expected scores and content while consuming
-    // its inputs (regression for #108: drained, not cloned).
+    // its inputs (regression for #108: drained, not cloned). For ids that
+    // appear in both inputs the keyword (BM25) content must win, since
+    // the semantic side carries only an id-derived placeholder.
     #[test]
     fn rrf_fusion_consumes_inputs_and_preserves_output() {
         let mut retriever = HybridRetriever::with_config(HybridConfig {
@@ -587,9 +592,12 @@ mod tests {
 
         let by_id: HashMap<_, _> = results.iter().map(|r| (r.id.clone(), r)).collect();
         assert_eq!(by_id.len(), 3, "expected ids a, b, c");
-        assert_eq!(by_id["a"].content, "content of a");
-        assert_eq!(by_id["b"].content, "content of b");
-        assert_eq!(by_id["c"].content, "content of c");
+        assert_eq!(by_id["a"].content, "semantic-placeholder-a");
+        assert_eq!(
+            by_id["b"].content, "real-bm25-text-b",
+            "overlapping id must keep keyword content, not semantic placeholder"
+        );
+        assert_eq!(by_id["c"].content, "real-bm25-text-c");
         assert!(
             by_id["b"].score >= by_id["a"].score,
             "b appears in both lists"
@@ -597,7 +605,8 @@ mod tests {
     }
 
     // Weighted fusion preserves expected scores and content while
-    // consuming its inputs (regression for #108).
+    // consuming its inputs (regression for #108). Keyword content must
+    // win for ids present in both input sets.
     #[test]
     fn weighted_fusion_consumes_inputs_and_preserves_output() {
         let mut retriever = HybridRetriever::with_config(HybridConfig {
@@ -615,8 +624,11 @@ mod tests {
 
         let by_id: HashMap<_, _> = results.iter().map(|r| (r.id.clone(), r)).collect();
         assert_eq!(by_id.len(), 3, "expected ids a, b, c");
-        assert_eq!(by_id["a"].content, "content of a");
-        assert_eq!(by_id["b"].content, "content of b");
-        assert_eq!(by_id["c"].content, "content of c");
+        assert_eq!(by_id["a"].content, "semantic-placeholder-a");
+        assert_eq!(
+            by_id["b"].content, "real-bm25-text-b",
+            "overlapping id must keep keyword content, not semantic placeholder"
+        );
+        assert_eq!(by_id["c"].content, "real-bm25-text-c");
     }
 }

--- a/graphrag-core/src/retrieval/hybrid.rs
+++ b/graphrag-core/src/retrieval/hybrid.rs
@@ -236,25 +236,28 @@ impl HybridRetriever {
         let mut combined_scores: HashMap<String, (f32, f32, f32)> = HashMap::new();
         let mut content_map: HashMap<String, String> = HashMap::new();
 
-        // Process semantic results
-        for (rank, (id, score, content)) in semantic_results.iter().enumerate() {
+        // Drain semantic results: each id is cloned at most once (for the
+        // score-map key) and content is moved into content_map.
+        for (rank, (id, score, content)) in semantic_results.into_iter().enumerate() {
             let rrf_score = 1.0 / (self.config.rrf_k + rank as f32 + 1.0);
-            combined_scores.insert(
-                id.clone(),
-                (rrf_score * self.config.semantic_weight, *score, 0.0),
-            );
-            content_map.insert(id.clone(), content.clone());
+            let weighted = rrf_score * self.config.semantic_weight;
+            combined_scores
+                .entry(id.clone())
+                .or_insert((0.0, score, 0.0))
+                .0 += weighted;
+            content_map.entry(id).or_insert(content);
         }
 
-        // Process keyword results
-        for (rank, result) in keyword_results.iter().enumerate() {
+        // Drain keyword results with the same single-clone, move-content pattern.
+        for (rank, result) in keyword_results.into_iter().enumerate() {
             let rrf_score = 1.0 / (self.config.rrf_k + rank as f32 + 1.0);
+            let weighted = rrf_score * self.config.keyword_weight;
             let entry = combined_scores
                 .entry(result.doc_id.clone())
                 .or_insert((0.0, 0.0, 0.0));
-            entry.0 += rrf_score * self.config.keyword_weight;
+            entry.0 += weighted;
             entry.2 = result.score;
-            content_map.insert(result.doc_id.clone(), result.content.clone());
+            content_map.entry(result.doc_id).or_insert(result.content);
         }
 
         self.create_hybrid_results(combined_scores, content_map, limit, FusionMethod::RRF)
@@ -270,43 +273,46 @@ impl HybridRetriever {
         let mut combined_scores: HashMap<String, (f32, f32, f32)> = HashMap::new();
         let mut content_map: HashMap<String, String> = HashMap::new();
 
-        // Normalize semantic scores
+        // Compute normalization factors before draining the inputs.
         let max_semantic = semantic_results
             .iter()
             .map(|(_, score, _)| *score)
             .fold(f32::NEG_INFINITY, f32::max);
-
-        for (id, score, content) in semantic_results {
-            let normalized_score = if max_semantic > 0.0 {
-                score / max_semantic
-            } else {
-                0.0
-            };
-            combined_scores.insert(
-                id.clone(),
-                (normalized_score * self.config.semantic_weight, score, 0.0),
-            );
-            content_map.insert(id, content);
-        }
-
-        // Normalize keyword scores
         let max_keyword = keyword_results
             .iter()
             .map(|r| r.score)
             .fold(f32::NEG_INFINITY, f32::max);
 
-        for result in keyword_results {
+        // Drain semantic results: id cloned once for the score-map key,
+        // content moved into the content map.
+        for (id, score, content) in semantic_results.into_iter() {
+            let normalized_score = if max_semantic > 0.0 {
+                score / max_semantic
+            } else {
+                0.0
+            };
+            let weighted = normalized_score * self.config.semantic_weight;
+            combined_scores
+                .entry(id.clone())
+                .or_insert((0.0, score, 0.0))
+                .0 += weighted;
+            content_map.entry(id).or_insert(content);
+        }
+
+        // Drain keyword results with the same single-clone, move-content pattern.
+        for result in keyword_results.into_iter() {
             let normalized_score = if max_keyword > 0.0 {
                 result.score / max_keyword
             } else {
                 0.0
             };
+            let weighted = normalized_score * self.config.keyword_weight;
             let entry = combined_scores
                 .entry(result.doc_id.clone())
                 .or_insert((0.0, 0.0, 0.0));
-            entry.0 += normalized_score * self.config.keyword_weight;
+            entry.0 += weighted;
             entry.2 = result.score;
-            content_map.insert(result.doc_id.clone(), result.content.clone());
+            content_map.entry(result.doc_id).or_insert(result.content);
         }
 
         self.create_hybrid_results(combined_scores, content_map, limit, FusionMethod::Weighted)
@@ -541,5 +547,68 @@ mod tests {
         let mut retriever = HybridRetriever::new();
         let result = retriever.search("test", 10);
         assert!(result.is_err());
+    }
+
+    fn semantic(id: &str, score: f32) -> (String, f32, String) {
+        (id.to_string(), score, format!("content of {id}"))
+    }
+
+    fn keyword(id: &str, score: f32) -> BM25Result {
+        BM25Result {
+            doc_id: id.to_string(),
+            score,
+            content: format!("content of {id}"),
+        }
+    }
+
+    // RRF fusion preserves expected scores and content while consuming
+    // its inputs (regression for #108: drained, not cloned).
+    #[test]
+    fn rrf_fusion_consumes_inputs_and_preserves_output() {
+        let mut retriever = HybridRetriever::with_config(HybridConfig {
+            min_score_threshold: 0.0,
+            ..HybridConfig::default()
+        });
+
+        let semantic_results = vec![semantic("a", 0.9), semantic("b", 0.7)];
+        let keyword_results = vec![keyword("b", 5.0), keyword("c", 3.0)];
+
+        let results = retriever
+            .reciprocal_rank_fusion(semantic_results, keyword_results, 10)
+            .expect("rrf should succeed");
+
+        let by_id: HashMap<_, _> = results.iter().map(|r| (r.id.clone(), r)).collect();
+        assert_eq!(by_id.len(), 3, "expected ids a, b, c");
+        assert_eq!(by_id["a"].content, "content of a");
+        assert_eq!(by_id["b"].content, "content of b");
+        assert_eq!(by_id["c"].content, "content of c");
+        assert!(
+            by_id["b"].score >= by_id["a"].score,
+            "b appears in both lists"
+        );
+    }
+
+    // Weighted fusion preserves expected scores and content while
+    // consuming its inputs (regression for #108).
+    #[test]
+    fn weighted_fusion_consumes_inputs_and_preserves_output() {
+        let mut retriever = HybridRetriever::with_config(HybridConfig {
+            min_score_threshold: 0.0,
+            fusion_method: FusionMethod::Weighted,
+            ..HybridConfig::default()
+        });
+
+        let semantic_results = vec![semantic("a", 0.9), semantic("b", 0.6)];
+        let keyword_results = vec![keyword("b", 4.0), keyword("c", 2.0)];
+
+        let results = retriever
+            .weighted_combination(semantic_results, keyword_results, 10)
+            .expect("weighted fusion should succeed");
+
+        let by_id: HashMap<_, _> = results.iter().map(|r| (r.id.clone(), r)).collect();
+        assert_eq!(by_id.len(), 3, "expected ids a, b, c");
+        assert_eq!(by_id["a"].content, "content of a");
+        assert_eq!(by_id["b"].content, "content of b");
+        assert_eq!(by_id["c"].content, "content of c");
     }
 }

--- a/graphrag-core/src/retrieval/hybrid.rs
+++ b/graphrag-core/src/retrieval/hybrid.rs
@@ -237,7 +237,9 @@ impl HybridRetriever {
         let mut content_map: HashMap<String, String> = HashMap::new();
 
         // Drain semantic results: each id is cloned at most once (for the
-        // score-map key) and content is moved into content_map.
+        // score-map key) and content is moved into content_map. The semantic
+        // pass runs first into an empty map, so entry/or_insert and a plain
+        // insert behave identically here.
         for (rank, (id, score, content)) in semantic_results.into_iter().enumerate() {
             let rrf_score = 1.0 / (self.config.rrf_k + rank as f32 + 1.0);
             let weighted = rrf_score * self.config.semantic_weight;
@@ -248,7 +250,10 @@ impl HybridRetriever {
             content_map.entry(id).or_insert(content);
         }
 
-        // Drain keyword results with the same single-clone, move-content pattern.
+        // Drain keyword results. Use a plain `insert` for content_map so that
+        // the real BM25 text overwrites any semantic-side placeholder for
+        // overlapping ids (semantic_search currently returns the id as
+        // content). The owned `result.content` lets us avoid a clone.
         for (rank, result) in keyword_results.into_iter().enumerate() {
             let rrf_score = 1.0 / (self.config.rrf_k + rank as f32 + 1.0);
             let weighted = rrf_score * self.config.keyword_weight;
@@ -257,7 +262,7 @@ impl HybridRetriever {
                 .or_insert((0.0, 0.0, 0.0));
             entry.0 += weighted;
             entry.2 = result.score;
-            content_map.entry(result.doc_id).or_insert(result.content);
+            content_map.insert(result.doc_id, result.content);
         }
 
         self.create_hybrid_results(combined_scores, content_map, limit, FusionMethod::RRF)
@@ -284,7 +289,8 @@ impl HybridRetriever {
             .fold(f32::NEG_INFINITY, f32::max);
 
         // Drain semantic results: id cloned once for the score-map key,
-        // content moved into the content map.
+        // content moved into the content map. Semantic pass runs first
+        // into an empty map, so entry/or_insert is fine here.
         for (id, score, content) in semantic_results.into_iter() {
             let normalized_score = if max_semantic > 0.0 {
                 score / max_semantic
@@ -299,7 +305,9 @@ impl HybridRetriever {
             content_map.entry(id).or_insert(content);
         }
 
-        // Drain keyword results with the same single-clone, move-content pattern.
+        // Drain keyword results. Use a plain `insert` for content_map so
+        // the real BM25 text overwrites any semantic-side placeholder for
+        // overlapping ids; the owned `result.content` keeps this clone-free.
         for result in keyword_results.into_iter() {
             let normalized_score = if max_keyword > 0.0 {
                 result.score / max_keyword
@@ -312,7 +320,7 @@ impl HybridRetriever {
                 .or_insert((0.0, 0.0, 0.0));
             entry.0 += weighted;
             entry.2 = result.score;
-            content_map.entry(result.doc_id).or_insert(result.content);
+            content_map.insert(result.doc_id, result.content);
         }
 
         self.create_hybrid_results(combined_scores, content_map, limit, FusionMethod::Weighted)

--- a/graphrag-core/src/text/semantic_chunking.rs
+++ b/graphrag-core/src/text/semantic_chunking.rs
@@ -163,15 +163,13 @@ impl SemanticChunker {
         sentences
     }
 
-    /// Generate embeddings for all sentences
+    /// Generate embeddings for all sentences in a single batch call.
+    ///
+    /// Issuing one batched request avoids N sequential round-trips for
+    /// remote embedders (Ollama/OpenAI), which dominated chunking latency.
     fn embed_sentences(&mut self, sentences: &[String]) -> Result<Vec<Vec<f32>>> {
-        let mut embeddings = Vec::new();
-
-        for sentence in sentences {
-            let embedding = self.embedding_generator.generate_embedding(sentence);
-            embeddings.push(embedding);
-        }
-
+        let refs: Vec<&str> = sentences.iter().map(String::as_str).collect();
+        let embeddings = self.embedding_generator.batch_generate(&refs);
         Ok(embeddings)
     }
 
@@ -446,5 +444,31 @@ mod tests {
         let chunker = SemanticChunker::new(config, embedding_gen);
         let result = chunker.calculate_std_threshold(&[]);
         assert_eq!(result, 0.0, "empty diffs should yield default threshold");
+    }
+
+    // embed_sentences must use a single batch call, producing the same
+    // vectors as EmbeddingGenerator::batch_generate (regression for #103).
+    #[test]
+    fn embed_sentences_uses_batch_call() {
+        let config = SemanticChunkerConfig::default();
+        let embedding_gen = EmbeddingGenerator::new(64);
+        let mut chunker = SemanticChunker::new(config, embedding_gen);
+
+        let sentences: Vec<String> = vec![
+            "Alice loves programming.".to_string(),
+            "Bob also codes daily.".to_string(),
+            "The weather is sunny today.".to_string(),
+            "Rain is expected tomorrow.".to_string(),
+        ];
+
+        let chunker_embeddings = chunker.embed_sentences(&sentences).unwrap();
+
+        // Independently compute the expected batch output.
+        let mut reference_gen = EmbeddingGenerator::new(64);
+        let refs: Vec<&str> = sentences.iter().map(String::as_str).collect();
+        let expected = reference_gen.batch_generate(&refs);
+
+        assert_eq!(chunker_embeddings.len(), sentences.len());
+        assert_eq!(chunker_embeddings, expected);
     }
 }

--- a/graphrag-core/src/text/semantic_chunking.rs
+++ b/graphrag-core/src/text/semantic_chunking.rs
@@ -446,8 +446,18 @@ mod tests {
         assert_eq!(result, 0.0, "empty diffs should yield default threshold");
     }
 
-    // embed_sentences must use a single batch call, producing the same
-    // vectors as EmbeddingGenerator::batch_generate (regression for #103).
+    // embed_sentences must produce the same vectors as
+    // EmbeddingGenerator::batch_generate (regression for #103).
+    //
+    // LIMITATION: this test cannot prove that `embed_sentences` actually
+    // uses the batched code path. `EmbeddingGenerator::batch_generate`
+    // currently delegates to `generate_embedding` per item, so a
+    // hypothetical regression that re-introduces a per-sentence loop
+    // would still produce identical output and pass this test. Verifying
+    // call-count behavior would require either making the embedder
+    // injectable behind a trait or adding a counting wrapper, both of
+    // which are out of scope here. The test still guards against output
+    // shape/content drift between the chunker and the embedder.
     #[test]
     fn embed_sentences_uses_batch_call() {
         let config = SemanticChunkerConfig::default();


### PR DESCRIPTION
## Summary

- **#103** — `SemanticChunker::embed_sentences` now calls `EmbeddingGenerator::batch_generate` once instead of looping `generate_embedding` per sentence. Wins on remote backends where each call is an HTTP round-trip.
- **#108** — `reciprocal_rank_fusion` and `weighted_combination` consume their inputs via `into_iter()`. ids are cloned at most once per fusion path; content strings are moved, not cloned.

## Review fixes (codex + gemini)

- **fix(core/retrieval): restore keyword-content precedence in fusion** — initial #108 refactor used `entry/or_insert` for the keyword pass too, which silently flipped content precedence: `semantic_search` returns the id as placeholder content, so overlapping ids were keeping the placeholder and discarding the real BM25 text. Keyword pass now uses plain `insert` (still no clone — `result` is owned via `into_iter`).
- **test(core/retrieval): distinguish semantic vs keyword fusion content** — fixture helpers now use `semantic-placeholder-{id}` vs `real-bm25-text-{id}` so the regression above would have been caught. Added precedence assertions for overlapping ids.
- **test(core/chunking): annotate batch-call test limitation** — flagged that `embed_sentences_uses_batch_call` only proves output equality with `batch_generate`, not that the batch path was actually taken (the field is a concrete `EmbeddingGenerator` so injection requires a wider refactor).

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo build -p graphrag-core`
- [x] `cargo nextest run -p graphrag-core --lib` — 410 passed, 12 skipped
- [x] Two previously-failing precedence tests now pass after the keyword `insert` fix

Closes #103, #108