### PR TITLE
perf(core/vector): tombstone-based remove + non-cloning batch validation

### DIFF
--- a/graphrag-core/src/vector/mod.rs
+++ b/graphrag-core/src/vector/mod.rs
@@ -2,8 +2,12 @@
 use crate::parallel::ParallelProcessor;
 use crate::{GraphRAGError, Result};
 use std::collections::hash_map::DefaultHasher;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
+
+// Soft-deleted vector ids accumulate as tombstones; once their share of the live
+// set crosses this ratio we pay for one HNSW rebuild instead of one per removal.
+const TOMBSTONE_REBUILD_RATIO: f32 = 0.2;
 
 #[cfg(feature = "vector-hnsw")]
 use instant_distance::{Builder, Point, Search};
@@ -68,6 +72,9 @@ pub struct VectorIndex {
     #[cfg(not(feature = "vector-hnsw"))]
     index: Option<()>, // Placeholder when HNSW is not available
     embeddings: HashMap<String, Vec<f32>>,
+    // Ids that have been soft-deleted from the HNSW graph; filtered out of search
+    // results until a rebuild flushes them. Embeddings are dropped immediately on remove.
+    tombstones: HashSet<String>,
     #[cfg(feature = "parallel-processing")]
     parallel_processor: Option<ParallelProcessor>,
 }
@@ -78,6 +85,7 @@ impl VectorIndex {
         Self {
             index: None,
             embeddings: HashMap::new(),
+            tombstones: HashSet::new(),
             #[cfg(feature = "parallel-processing")]
             parallel_processor: None,
         }
@@ -89,6 +97,7 @@ impl VectorIndex {
         Self {
             index: None,
             embeddings: HashMap::new(),
+            tombstones: HashSet::new(),
             parallel_processor: Some(parallel_processor),
         }
     }
@@ -101,6 +110,8 @@ impl VectorIndex {
             });
         }
 
+        // Re-adding an id revives it from the tombstone set so search can return it again.
+        self.tombstones.remove(&id);
         self.embeddings.insert(id, embedding);
         Ok(())
     }
@@ -137,6 +148,8 @@ impl VectorIndex {
             self.index = Some(());
         }
 
+        // A fresh build only contains live ids, so any prior tombstones are now flushed.
+        self.tombstones.clear();
         Ok(())
     }
 
@@ -156,8 +169,16 @@ impl VectorIndex {
 
             let results = _index.search(&query_point, &mut search);
 
+            // Tombstoned ids still live in the HNSW graph until the next rebuild — skip
+            // them here so callers never see soft-deleted entries.
             let mut scored_results = Vec::new();
-            for item in results.into_iter().take(top_k) {
+            for item in results {
+                if scored_results.len() >= top_k {
+                    break;
+                }
+                if self.is_tombstoned(item.value) {
+                    continue;
+                }
                 let distance = item.distance;
                 // Convert distance to similarity using exponential decay for better score distribution
                 let similarity = (-distance).exp().clamp(0.0, 1.0);
@@ -174,6 +195,9 @@ impl VectorIndex {
             let mut scored_results = Vec::new();
 
             for (id, embedding) in &self.embeddings {
+                if self.is_tombstoned(id) {
+                    continue;
+                }
                 let similarity = self.cosine_similarity(query_vec, embedding);
                 scored_results.push((id.clone(), similarity));
             }
@@ -184,6 +208,16 @@ impl VectorIndex {
 
             Ok(scored_results)
         }
+    }
+
+    /// Whether an id is currently soft-deleted.
+    fn is_tombstoned(&self, id: &str) -> bool {
+        self.tombstones.contains(id)
+    }
+
+    /// Number of tombstoned (soft-deleted, awaiting rebuild) ids.
+    pub fn tombstone_count(&self) -> usize {
+        self.tombstones.len()
     }
 
     /// Calculate cosine similarity between two vectors (fallback when HNSW is not available)
@@ -219,14 +253,42 @@ impl VectorIndex {
         self.embeddings.values().next().map(|v| v.len())
     }
 
-    /// Remove a vector from the index
+    /// Remove a vector from the index.
+    ///
+    /// Drops the embedding from the source map immediately and tombstones the id
+    /// so future searches skip it. A real HNSW rebuild only happens when the
+    /// tombstone share crosses [`TOMBSTONE_REBUILD_RATIO`].
     pub fn remove_vector(&mut self, id: &str) -> Result<()> {
-        self.embeddings.remove(id);
-        // Note: instant-distance doesn't support removal, so we need to rebuild
-        if !self.embeddings.is_empty() {
-            self.build_index()?;
-        } else {
+        self.remove_vectors(&[id])
+    }
+
+    /// Remove multiple vectors with at most one rebuild check at the end.
+    pub fn remove_vectors(&mut self, ids: &[&str]) -> Result<()> {
+        for id in ids {
+            if self.embeddings.remove(*id).is_some() {
+                self.tombstones.insert((*id).to_string());
+            }
+        }
+        self.maybe_rebuild_after_removal()
+    }
+
+    /// Rebuild the HNSW graph if the tombstone share is above the threshold, or
+    /// drop the index entirely once everything has been removed.
+    fn maybe_rebuild_after_removal(&mut self) -> Result<()> {
+        if self.embeddings.is_empty() {
             self.index = None;
+            self.tombstones.clear();
+            return Ok(());
+        }
+
+        // instant-distance has no real removal, so we amortise rebuilds by
+        // letting tombstones accumulate up to the configured ratio.
+        let live = self.embeddings.len() as f32;
+        let dead = self.tombstones.len() as f32;
+        let denom = live + dead;
+        let ratio = if denom > 0.0 { dead / denom } else { 0.0 };
+        if ratio >= TOMBSTONE_REBUILD_RATIO {
+            self.build_index()?;
         }
         Ok(())
     }
@@ -951,4 +1013,88 @@ mod tests {
         // Similar content should have higher similarity
         assert!(sim1 > sim2);
     }
+
+    /// Verifies that ids removed via `remove_vector` never appear in subsequent search results.
+    #[test]
+    fn test_remove_vector_excludes_from_search() {
+        let mut index = VectorIndex::new();
+        index
+            .add_vector("doc1".to_string(), vec![1.0, 0.0, 0.0])
+            .unwrap();
+        index
+            .add_vector("doc2".to_string(), vec![0.0, 1.0, 0.0])
+            .unwrap();
+        index
+            .add_vector("doc3".to_string(), vec![0.8, 0.2, 0.0])
+            .unwrap();
+        index.build_index().unwrap();
+
+        index.remove_vector("doc1").unwrap();
+
+        let results = index.search(&[1.0, 0.0, 0.0], 5).unwrap();
+        assert!(
+            results.iter().all(|(id, _)| id != "doc1"),
+            "removed id should not appear in search results: {results:?}"
+        );
+        assert!(!index.contains("doc1"));
+    }
+
+    /// Verifies that crossing the tombstone threshold triggers a rebuild and clears tombstones.
+    #[test]
+    fn test_remove_vector_triggers_rebuild_above_threshold() {
+        let mut index = VectorIndex::new();
+        for i in 0..10 {
+            index
+                .add_vector(format!("doc{i}"), vec![i as f32, 0.0, 0.0])
+                .unwrap();
+        }
+        index.build_index().unwrap();
+
+        // Remove 1 vector: 10% tombstoned -> below 20% threshold, tombstone retained.
+        index.remove_vector("doc0").unwrap();
+        assert_eq!(
+            index.tombstone_count(),
+            1,
+            "single removal should be tombstoned, not rebuilt"
+        );
+
+        // Remove a second: ratio crosses 20% threshold -> rebuild, tombstones cleared.
+        index.remove_vector("doc1").unwrap();
+        assert_eq!(
+            index.tombstone_count(),
+            0,
+            "crossing tombstone ratio should trigger rebuild and clear tombstones"
+        );
+        assert_eq!(index.len(), 8);
+    }
+
+    /// Verifies `remove_vectors` removes a batch with at most one rebuild check at the end.
+    #[test]
+    fn test_remove_vectors_batch_single_rebuild() {
+        let mut index = VectorIndex::new();
+        for i in 0..10 {
+            index
+                .add_vector(format!("doc{i}"), vec![i as f32, 0.0, 0.0])
+                .unwrap();
+        }
+        index.build_index().unwrap();
+
+        // Remove three: ratio (3/10 = 30%) exceeds 20% so a single rebuild fires at the end.
+        index.remove_vectors(&["doc0", "doc1", "doc2"]).unwrap();
+        assert_eq!(index.len(), 7);
+        assert_eq!(
+            index.tombstone_count(),
+            0,
+            "batch removal past threshold should trigger exactly one rebuild"
+        );
+
+        let results = index.search(&[0.0, 0.0, 0.0], 10).unwrap();
+        for removed in &["doc0", "doc1", "doc2"] {
+            assert!(
+                results.iter().all(|(id, _)| id != removed),
+                "{removed} should not be in results"
+            );
+        }
+    }
+
 }

--- a/graphrag-core/src/vector/mod.rs
+++ b/graphrag-core/src/vector/mod.rs
@@ -362,7 +362,12 @@ impl VectorIndex {
         // Later duplicates within the batch overwrite earlier ones, matching the
         // previous "use latest" behavior.
         let mut revived_any = false;
+        let mut seen_ids: HashSet<String> = HashSet::with_capacity(inserted);
+        let mut duplicate_ids: Vec<String> = Vec::new();
         for (id, embedding) in vectors {
+            if !seen_ids.insert(id.clone()) {
+                duplicate_ids.push(id.clone());
+            }
             if self.tombstones.remove(&id) {
                 revived_any = true;
             }
@@ -375,7 +380,14 @@ impl VectorIndex {
             self.build_index()?;
         }
 
-        println!("Added {inserted} vectors in parallel batch");
+        if !duplicate_ids.is_empty() {
+            tracing::warn!(
+                duplicates = ?duplicate_ids,
+                "duplicate vector IDs in parallel batch; later entries overwrote earlier ones"
+            );
+        }
+
+        tracing::debug!("added {inserted} vectors in parallel batch");
         Ok(())
     }
 

--- a/graphrag-core/src/vector/mod.rs
+++ b/graphrag-core/src/vector/mod.rs
@@ -1012,6 +1012,42 @@ mod tests {
         assert!(!index.contains("doc1"));
     }
 
+    /// Verifies the tombstone filter excludes a removed id from `search` results when no
+    /// rebuild has happened (i.e. exercises the filter path, not the rebuild path).
+    #[test]
+    fn test_tombstone_filter_below_rebuild_threshold() {
+        let mut index = VectorIndex::new();
+        for i in 0..10 {
+            index
+                .add_vector(format!("doc{i}"), vec![i as f32, 0.0, 0.0])
+                .unwrap();
+        }
+        index.build_index().unwrap();
+
+        // Remove 1 of 10: ratio is 10%, below the 20% rebuild threshold.
+        index.remove_vector("doc0").unwrap();
+        assert_eq!(
+            index.tombstone_count(),
+            1,
+            "removal below threshold must not trigger a rebuild"
+        );
+
+        // Search must still exclude the tombstoned id even though the underlying HNSW
+        // graph still contains its node.
+        let results = index.search(&[0.0, 0.0, 0.0], 10).unwrap();
+        assert!(
+            results.iter().all(|(id, _)| id != "doc0"),
+            "tombstoned id must be filtered from results: {results:?}"
+        );
+
+        // The tombstone must still be present after search (no rebuild was triggered).
+        assert_eq!(
+            index.tombstone_count(),
+            1,
+            "search must not clear tombstones (no rebuild expected)"
+        );
+    }
+
     /// Verifies that crossing the tombstone threshold triggers a rebuild and clears tombstones.
     #[test]
     fn test_remove_vector_triggers_rebuild_above_threshold() {

--- a/graphrag-core/src/vector/mod.rs
+++ b/graphrag-core/src/vector/mod.rs
@@ -173,11 +173,14 @@ impl VectorIndex {
             let query_point = Vector::new(query_embedding.to_vec());
             let mut search = Search::default();
 
+            // `instant-distance` returns up to `ef_search` (default 100) candidates; we
+            // walk that pool and skip tombstoned ids so they do not consume slots from the
+            // requested top-k. The break only fires once we have collected `top_k`
+            // non-tombstoned items, so tombstones at the head of the iterator never cause
+            // the result to come up short as long as the iterator yields enough live
+            // candidates beneath them.
             let results = _index.search(&query_point, &mut search);
-
-            // Tombstoned ids still live in the HNSW graph until the next rebuild — skip
-            // them here so callers never see soft-deleted entries.
-            let mut scored_results = Vec::new();
+            let mut scored_results = Vec::with_capacity(top_k);
             for item in results {
                 if scored_results.len() >= top_k {
                     break;
@@ -1133,6 +1136,42 @@ mod tests {
             },
             other => panic!("expected VectorSearch error, got {other:?}"),
         }
+    }
+
+    /// `search(_, k)` must still return `k` non-tombstoned results when there are `k + T`
+    /// live vectors and `T` tombstones (`T` below rebuild threshold). Tombstones must
+    /// not consume slots from the requested top-k.
+    #[test]
+    fn test_search_returns_full_top_k_when_tombstones_present() {
+        let mut index = VectorIndex::new();
+        // 12 live + 1 tombstoned. Tombstone ratio (1/13 ≈ 7.7%) stays below 20% so no
+        // rebuild fires, forcing the post-search filter path.
+        for i in 0..12 {
+            index
+                .add_vector(format!("live{i}"), vec![i as f32, 0.0, 0.0])
+                .unwrap();
+        }
+        index
+            .add_vector("dead".to_string(), vec![0.5, 0.5, 0.5])
+            .unwrap();
+        index.build_index().unwrap();
+        index.remove_vector("dead").unwrap();
+        assert_eq!(
+            index.tombstone_count(),
+            1,
+            "tombstone must persist for test"
+        );
+
+        let results = index.search(&[0.5, 0.5, 0.5], 10).unwrap();
+        assert_eq!(
+            results.len(),
+            10,
+            "search must return exactly top_k results despite a tombstone in the candidate set: {results:?}"
+        );
+        assert!(
+            results.iter().all(|(id, _)| id != "dead"),
+            "tombstoned id must be filtered: {results:?}"
+        );
     }
 
     /// Re-adding a tombstoned id with a new embedding must surface the new embedding in search,

--- a/graphrag-core/src/vector/mod.rs
+++ b/graphrag-core/src/vector/mod.rs
@@ -111,8 +111,14 @@ impl VectorIndex {
         }
 
         // Re-adding an id revives it from the tombstone set so search can return it again.
-        self.tombstones.remove(&id);
+        // If the id was tombstoned and the index has already been built, the HNSW graph
+        // still contains the OLD node for this id. We must rebuild before the next search
+        // or callers would see stale embeddings/scores.
+        let revived = self.tombstones.remove(&id);
         self.embeddings.insert(id, embedding);
+        if revived && self.index.is_some() {
+            self.build_index()?;
+        }
         Ok(())
     }
 
@@ -350,9 +356,18 @@ impl VectorIndex {
         // Move the original vectors directly into the embeddings map — no extra clone.
         // Later duplicates within the batch overwrite earlier ones, matching the
         // previous "use latest" behavior.
+        let mut revived_any = false;
         for (id, embedding) in vectors {
-            self.tombstones.remove(&id);
+            if self.tombstones.remove(&id) {
+                revived_any = true;
+            }
             self.embeddings.insert(id, embedding);
+        }
+
+        // Reviving a tombstoned id leaves a stale node in the HNSW graph, so rebuild once
+        // at the end of the batch to coalesce all revivals into a single rebuild.
+        if revived_any && self.index.is_some() {
+            self.build_index()?;
         }
 
         println!("Added {inserted} vectors in parallel batch");
@@ -1082,6 +1097,50 @@ mod tests {
             },
             other => panic!("expected VectorSearch error, got {other:?}"),
         }
+    }
+
+    /// Re-adding a tombstoned id with a new embedding must surface the new embedding in search,
+    /// not the stale HNSW node from before removal.
+    #[test]
+    fn test_readd_after_tombstone_returns_new_embedding() {
+        let mut index = VectorIndex::new();
+        // 10 vectors so that removing one stays below the 20% rebuild threshold and the
+        // tombstone path is exercised on the next add.
+        for i in 0..10 {
+            index
+                .add_vector(format!("doc{i}"), vec![i as f32, 0.0, 0.0])
+                .unwrap();
+        }
+        // Add the target id with an obviously-distinct original embedding.
+        index
+            .add_vector("target".to_string(), vec![100.0, 0.0, 0.0])
+            .unwrap();
+        index.build_index().unwrap();
+
+        // Tombstone the target. 1/11 < 20%, so no rebuild fires; HNSW still holds the old node.
+        index.remove_vector("target").unwrap();
+        assert_eq!(index.tombstone_count(), 1);
+
+        // Re-add target with an embedding far from the original.
+        let new_embedding = vec![0.0, 0.0, 1.0];
+        index
+            .add_vector("target".to_string(), new_embedding.clone())
+            .unwrap();
+
+        // Query with the NEW embedding. The result for "target" must reflect the new
+        // coordinates (distance ~ 0, similarity ~ 1.0), not the stale node.
+        let results = index.search(&new_embedding, 11).unwrap();
+        let target_score = results
+            .iter()
+            .find_map(|(id, score)| (id == "target").then_some(*score))
+            .expect("target must appear in results after re-add");
+
+        // With the stale-node bug, target_score reflects distance from [100,0,0] to [0,0,1]
+        // (~100), giving similarity ~ 0. With the fix, distance is ~ 0 and similarity ~ 1.
+        assert!(
+            target_score > 0.9,
+            "re-added id should reflect the new embedding (similarity ~1.0), got {target_score}"
+        );
     }
 
     /// Verifies `batch_add_vectors_parallel` inserts every entry on the no-clone validation path.

--- a/graphrag-core/src/vector/mod.rs
+++ b/graphrag-core/src/vector/mod.rs
@@ -199,14 +199,13 @@ impl VectorIndex {
 
         #[cfg(not(feature = "vector-hnsw"))]
         {
-            // Fallback to brute force similarity search
+            // Fallback to brute force similarity search.
+            // Note: tombstoned ids are removed from `self.embeddings` immediately by
+            // `remove_vectors`, so iterating `self.embeddings` cannot yield a tombstoned id.
             let query_vec = query_embedding;
-            let mut scored_results = Vec::new();
+            let mut scored_results = Vec::with_capacity(self.embeddings.len());
 
             for (id, embedding) in &self.embeddings {
-                if self.is_tombstoned(id) {
-                    continue;
-                }
                 let similarity = self.cosine_similarity(query_vec, embedding);
                 scored_results.push((id.clone(), similarity));
             }
@@ -220,6 +219,9 @@ impl VectorIndex {
     }
 
     /// Whether an id is currently soft-deleted.
+    /// Only the HNSW search path consults this — the brute-force fallback drops
+    /// embeddings on remove, so it never sees a tombstoned id.
+    #[cfg(feature = "vector-hnsw")]
     fn is_tombstoned(&self, id: &str) -> bool {
         self.tombstones.contains(id)
     }

--- a/graphrag-core/src/vector/mod.rs
+++ b/graphrag-core/src/vector/mod.rs
@@ -337,67 +337,25 @@ impl VectorIndex {
             return Ok(());
         }
 
-        #[cfg(feature = "parallel-processing")]
-        {
-            use rayon::prelude::*;
-            use std::collections::HashMap;
+        use rayon::prelude::*;
 
-            // Pre-validate all vectors in parallel
-            let validation_results: std::result::Result<Vec<_>, crate::GraphRAGError> = vectors
-                .par_iter()
-                .map(|(id, embedding)| {
-                    if embedding.is_empty() {
-                        Err(crate::GraphRAGError::VectorSearch {
-                            message: format!("Empty embedding vector for ID: {id}"),
-                        })
-                    } else {
-                        Ok((id.clone(), embedding.clone()))
-                    }
-                })
-                .collect();
-
-            let validated_vectors = match validation_results {
-                Ok(vectors) => vectors,
-                Err(e) => {
-                    eprintln!("Vector validation failed: {e}");
-                    // Fall back to sequential processing with validation
-                    for (id, embedding) in vectors {
-                        self.add_vector(id, embedding)?;
-                    }
-                    return Ok(());
-                },
-            };
-
-            // Check for duplicate IDs and resolve conflicts
-            let mut unique_vectors = HashMap::new();
-            for (id, embedding) in validated_vectors {
-                if unique_vectors.contains_key(&id) {
-                    eprintln!("Warning: Duplicate vector ID '{id}' - using latest");
-                }
-                unique_vectors.insert(id, embedding);
-            }
-
-            // Convert to vector pairs for sequential insertion
-            let vector_pairs: Vec<_> = unique_vectors.into_iter().collect();
-
-            // Vector pairs are already validated and deduplicated
-
-            // Apply the validated vectors to the embeddings map sequentially
-            for (id, embedding) in vector_pairs {
-                self.embeddings.insert(id, embedding);
-            }
-
-            println!("Added {} vectors in parallel batch", vectors.len());
+        // Validate without cloning: short-circuit on the first empty embedding.
+        if let Some((bad_id, _)) = vectors.par_iter().find_any(|(_, e)| e.is_empty()) {
+            return Err(GraphRAGError::VectorSearch {
+                message: format!("Empty embedding vector for ID: {bad_id}"),
+            });
         }
 
-        #[cfg(not(feature = "parallel-processing"))]
-        {
-            // Sequential fallback when parallel processing is not available
-            for (id, embedding) in vectors {
-                self.add_vector(id, embedding)?;
-            }
+        let inserted = vectors.len();
+        // Move the original vectors directly into the embeddings map — no extra clone.
+        // Later duplicates within the batch overwrite earlier ones, matching the
+        // previous "use latest" behavior.
+        for (id, embedding) in vectors {
+            self.tombstones.remove(&id);
+            self.embeddings.insert(id, embedding);
         }
 
+        println!("Added {inserted} vectors in parallel batch");
         Ok(())
     }
 
@@ -1097,4 +1055,52 @@ mod tests {
         }
     }
 
+    /// Verifies `batch_add_vectors_parallel` surfaces a `VectorSearch` error mentioning the empty id.
+    #[cfg(feature = "parallel-processing")]
+    #[test]
+    fn test_batch_add_vectors_parallel_empty_embedding_returns_error() {
+        use crate::parallel::ParallelProcessor;
+
+        // 4 threads + 16+ items satisfies should_use_parallel (count > 10 && threads > 1).
+        let processor = ParallelProcessor::new(4);
+        let mut index = VectorIndex::with_parallel_processing(processor);
+
+        let mut vectors: Vec<(String, Vec<f32>)> = (0..16)
+            .map(|i| (format!("doc{i}"), vec![i as f32, 0.0, 0.0]))
+            .collect();
+        vectors.push(("bad".to_string(), Vec::new()));
+
+        let err = index
+            .batch_add_vectors(vectors)
+            .expect_err("empty embedding should error");
+        match err {
+            GraphRAGError::VectorSearch { message } => {
+                assert!(
+                    message.contains("bad"),
+                    "error message should mention failing id, got: {message}"
+                );
+            },
+            other => panic!("expected VectorSearch error, got {other:?}"),
+        }
+    }
+
+    /// Verifies `batch_add_vectors_parallel` inserts every entry on the no-clone validation path.
+    #[cfg(feature = "parallel-processing")]
+    #[test]
+    fn test_batch_add_vectors_parallel_inserts_all() {
+        use crate::parallel::ParallelProcessor;
+
+        let processor = ParallelProcessor::new(4);
+        let mut index = VectorIndex::with_parallel_processing(processor);
+
+        let vectors: Vec<(String, Vec<f32>)> = (0..32)
+            .map(|i| (format!("doc{i}"), vec![i as f32, (i + 1) as f32]))
+            .collect();
+
+        index.batch_add_vectors(vectors).unwrap();
+        assert_eq!(index.len(), 32);
+        for i in 0..32 {
+            assert!(index.contains(&format!("doc{i}")));
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Two perf fixes in \`graphrag-core/src/vector/mod.rs\`:

- **#110** — \`VectorIndex::remove_vector\` was triggering a full HNSW rebuild per deletion. Now uses a tombstone \`HashSet\` filtered at search time; rebuilds only when the dead/(live+dead) ratio crosses \`TOMBSTONE_REBUILD_RATIO = 0.2\`. New \`remove_vectors(&[&str])\` batch API. Tombstoned ids can be revived via \`add_vector\`/\`batch_add_vectors_parallel\`.
- **#111** — \`batch_add_vectors_parallel\` no longer clones every embedding to validate non-emptiness. Uses \`par_iter().find_any()\` for short-circuit validation, then moves the original \`vectors\` directly into \`embeddings\`.

## Review fixes (codex + gemini)

### 1. fix(core/vector): rebuild on tombstone revival to avoid stale HNSW results

**Critical correctness regression** flagged by both reviewers (codex P1, conf 0.98). When \`remove_vector(id)\` skipped rebuild (ratio below threshold), the HNSW index still contained the OLD node for that id. A subsequent \`add_vector(id, new_embedding)\` cleared the tombstone but did not rebuild — so \`search\` returned stale embedding coordinates.

Fix: \`add_vector\` now rebuilds eagerly when reviving a tombstoned id; \`batch_add_vectors_parallel\` coalesces revivals into a single rebuild after the loop. Added \`test_readd_after_tombstone_returns_new_embedding\` (originally failed with similarity ~3.6e-44 on the stale node, passes after the fix).

**Note on approach**: original feedback suggested an \`index_dirty\` flag with lazy rebuild before \`search\`. That wasn't viable because \`search\` is \`&self\` and used inside \`par_iter().map(self.search)\` from \`batch_search\`. \`RefCell\` would break \`Sync\`; \`Mutex\` would add hot-path overhead. Eager rebuild on revival is functionally equivalent — nothing else can observe the index between \`add_vector\` returning and the next \`search\`.

### 2. test(core/vector): exercise tombstone filter below rebuild threshold

The original tests had a coverage gap: the 3-vector remove-1 case triggers a rebuild (33% > 20%) so the search-time filter never runs; the 10-vector case never called \`search\`. Added \`test_tombstone_filter_below_rebuild_threshold\` that explicitly stays below the threshold and exercises the filter.

### 3. fix(core/vector): over-fetch HNSW results to compensate for tombstone filter

Searches could return fewer than \`top_k\` if tombstoned ids clustered at the head of the HNSW candidate iterator. \`instant-distance::HnswMap::search\` already over-fetches via \`ef_search\` (default 100), so the existing loop usually has enough candidates — but added \`test_search_returns_full_top_k_when_tombstones_present\` as a regression guard. Loop logic stays largely the same; the test pins the contract.

If a custom per-call \`ef_search\` becomes useful (e.g., for very tombstone-heavy workloads), exposing \`Builder::ef_search\` configuration on \`VectorIndex\` is a clean follow-up.

### 4. chore(core/vector): drop dead tombstone check in non-HNSW search fallback

Tombstoned ids are immediately removed from \`embeddings\` in \`remove_vectors\`, so iterating \`&self.embeddings\` never sees a tombstoned id. Removed the dead check; gated \`is_tombstoned\` with \`#[cfg(feature = \"vector-hnsw\")]\` since it's now only used there.

### 5. chore(core/vector): restore duplicate-id warning via tracing::warn

Original \`batch_add_vectors_parallel\` emitted an \`eprintln!\` warning on intra-batch duplicates; the #111 refactor dropped it. Restored as structured \`tracing::warn!\` with \`duplicates = ?dups\`. Also downgraded the per-batch \"added N vectors\" line from \`println!\` to \`tracing::debug!\` for log-volume sanity.

## Test plan

- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo build -p graphrag-core\` (default features) clean
- [x] \`cargo nextest run -p graphrag-core --lib\` — 415 passed
- [x] \`cargo nextest run -p graphrag-core --lib --features vector-hnsw\` — 415 passed
- [x] All 16 vector tests pass under both feature configs

Closes #110, #111