### PR TITLE
feat(core): native Anthropic + OpenAI ChatBackend implementations

### DIFF
--- a/graphrag-core/README.md
+++ b/graphrag-core/README.md
@@ -276,6 +276,74 @@ async fn main() -> Result<()> {
 }
 ```
 
+## LLM Chat Providers
+
+In addition to the default Ollama backend, `graphrag-core` ships native
+HTTP `ChatBackend` implementations for the two main cloud providers
+(issue #90). All three implement the same `ChatBackend` trait and can be
+injected via `GraphRAG::set_chat_backend`.
+
+| Provider     | Endpoint                                | Default model                | Auth                                      | Feature flags        |
+|--------------|-----------------------------------------|------------------------------|-------------------------------------------|----------------------|
+| **Ollama**   | `http://localhost:11434/api/generate`   | `llama3.2:3b`                | none (local)                              | `ollama` + `async`   |
+| **OpenAI**   | `https://api.openai.com/v1/chat/completions` | `gpt-4o-mini`           | `Authorization: Bearer $OPENAI_API_KEY`   | `async` + `ureq`     |
+| **Anthropic**| `https://api.anthropic.com/v1/messages` | `claude-haiku-4-5-20251001`  | `x-api-key: $ANTHROPIC_API_KEY`           | `async` + `ureq`     |
+
+Documented Anthropic model options: `claude-haiku-4-5-20251001` (default,
+cheap), `claude-sonnet-4-6`, `claude-opus-4-7`.
+
+**Construction:**
+
+```rust
+use graphrag_core::core::api_chat::{OpenAiChat, AnthropicChat};
+
+// Read API key from env (recommended)
+let openai     = OpenAiChat::from_env_default()?;          // gpt-4o-mini
+let anthropic  = AnthropicChat::from_env_default()?;       // claude-haiku-4-5-20251001
+
+// Or pass an explicit key + model
+let custom = AnthropicChat::new(my_key, "claude-sonnet-4-6")
+    .with_default_max_tokens(8192);
+```
+
+**Config-driven (TOML):**
+
+```toml
+# OpenAI — reads OPENAI_API_KEY from env when api_key is omitted
+[chat]
+provider = "openai"
+model    = "gpt-4o-mini"
+```
+
+```toml
+# Anthropic — reads ANTHROPIC_API_KEY from env
+[chat]
+provider   = "anthropic"
+model      = "claude-haiku-4-5-20251001"
+max_tokens = 4096
+```
+
+```toml
+# Ollama — local, no API key needed
+[chat]
+provider = "ollama"
+model    = "llama3.2:3b"   # constructed via core::ollama_adapters
+```
+
+```rust
+use graphrag_core::core::api_chat::ChatProviderConfig;
+
+let cfg: ChatProviderConfig = toml::from_str(include_str!("chat.toml"))?;
+let backend = cfg.build()?;   // returns DynChatBackend (OpenAI/Anthropic only)
+```
+
+Sample TOML snippets live under `tests/e2e/configs/chat_openai.toml`
+and `tests/e2e/configs/chat_anthropic.toml`.
+
+**Out of scope** for the native HTTP backends (per issue #90):
+streaming, tool / function calling, Azure OpenAI / Bedrock / Vertex
+routing, and a CLI flag.
+
 ## Embedding Providers
 
 GraphRAG Core supports 8 embedding backends:

--- a/graphrag-core/src/core/api_chat/anthropic.rs
+++ b/graphrag-core/src/core/api_chat/anthropic.rs
@@ -418,6 +418,9 @@ mod tests {
     /// `AnthropicChat::from_env` reads `ANTHROPIC_API_KEY`.
     #[test]
     fn anthropic_chat_from_env_reads_api_key() {
+        // Serialize against any other test in the process that mutates
+        // OPENAI_API_KEY / ANTHROPIC_API_KEY (see `super::super::test_env_lock`).
+        let _guard = crate::core::api_chat::test_env_lock::lock();
         let prev = std::env::var("ANTHROPIC_API_KEY").ok();
         std::env::set_var("ANTHROPIC_API_KEY", "sk-ant-from-env");
         let backend = AnthropicChat::from_env_default().expect("env-based ctor ok");

--- a/graphrag-core/src/core/api_chat/anthropic.rs
+++ b/graphrag-core/src/core/api_chat/anthropic.rs
@@ -1,0 +1,431 @@
+//! Anthropic Messages API chat backend.
+//!
+//! Uses the `/v1/messages` endpoint with `x-api-key` + `anthropic-version`
+//! headers. Response `content` is an array of typed blocks (`text`,
+//! `tool_use`, etc.); we concatenate `text` blocks and ignore others —
+//! tool-use is out of scope for issue #90.
+
+use async_trait::async_trait;
+
+use crate::core::backend::{ChatBackend, ChatParams};
+use crate::core::error::{GraphRAGError, Result};
+
+const DEFAULT_ANTHROPIC_ENDPOINT: &str = "https://api.anthropic.com/v1/messages";
+const ANTHROPIC_VERSION: &str = "2023-06-01";
+/// Default model — cheap Claude 4.5 Haiku, suitable for GraphRAG synthesis.
+pub const DEFAULT_ANTHROPIC_MODEL: &str = "claude-haiku-4-5-20251001";
+/// Default `max_tokens` when the caller doesn't pass one in `ChatParams`.
+/// Anthropic's API requires this field.
+pub const DEFAULT_MAX_TOKENS: u32 = 4096;
+
+/// HTTP `ChatBackend` for Anthropic's Messages API.
+pub struct AnthropicChat {
+    api_key: String,
+    model: String,
+    endpoint: String,
+    /// Fallback `max_tokens` used when `ChatParams::max_tokens` is `None`.
+    /// Anthropic requires the field on every request.
+    default_max_tokens: u32,
+    client: ureq::Agent,
+}
+
+impl AnthropicChat {
+    /// Construct from explicit API key + model. Sends
+    /// `x-api-key` and `anthropic-version: 2023-06-01` headers per the
+    /// public Messages API spec.
+    pub fn new(api_key: impl Into<String>, model: impl Into<String>) -> Self {
+        Self {
+            api_key: api_key.into(),
+            model: model.into(),
+            endpoint: DEFAULT_ANTHROPIC_ENDPOINT.to_string(),
+            default_max_tokens: DEFAULT_MAX_TOKENS,
+            client: ureq::Agent::new(),
+        }
+    }
+
+    /// Construct from the `ANTHROPIC_API_KEY` env var.
+    pub fn from_env(model: impl Into<String>) -> Result<Self> {
+        let key = std::env::var("ANTHROPIC_API_KEY").map_err(|_| GraphRAGError::Auth {
+            message: "ANTHROPIC_API_KEY environment variable not set".to_string(),
+        })?;
+        if key.is_empty() {
+            return Err(GraphRAGError::Auth {
+                message: "ANTHROPIC_API_KEY is empty".to_string(),
+            });
+        }
+        Ok(Self::new(key, model))
+    }
+
+    /// Construct from env using the default model (`claude-haiku-4-5-20251001`).
+    pub fn from_env_default() -> Result<Self> {
+        Self::from_env(DEFAULT_ANTHROPIC_MODEL)
+    }
+
+    /// Override the fallback `max_tokens` used when `ChatParams` doesn't
+    /// specify one.
+    pub fn with_default_max_tokens(mut self, n: u32) -> Self {
+        self.default_max_tokens = n;
+        self
+    }
+
+    /// Override the HTTP endpoint. Intended for redirecting requests to a
+    /// local mock server in integration tests.
+    #[doc(hidden)]
+    pub fn with_endpoint_for_tests(mut self, endpoint: impl Into<String>) -> Self {
+        self.endpoint = endpoint.into();
+        self
+    }
+
+    fn request_ctx(&self) -> RequestCtx {
+        RequestCtx {
+            api_key: self.api_key.clone(),
+            model: self.model.clone(),
+            endpoint: self.endpoint.clone(),
+            default_max_tokens: self.default_max_tokens,
+            client: self.client.clone(),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct RequestCtx {
+    api_key: String,
+    model: String,
+    endpoint: String,
+    default_max_tokens: u32,
+    client: ureq::Agent,
+}
+
+impl RequestCtx {
+    fn complete(self, prompt: &str, params: &ChatParams) -> Result<String> {
+        let max_tokens = params.max_tokens.unwrap_or(self.default_max_tokens);
+        let mut body = serde_json::json!({
+            "model": self.model,
+            "max_tokens": max_tokens,
+            "messages": [
+                {"role": "user", "content": prompt}
+            ],
+        });
+        if let Some(t) = params.temperature {
+            body["temperature"] = serde_json::json!(t);
+        }
+
+        let response = self
+            .client
+            .post(&self.endpoint)
+            .set("x-api-key", &self.api_key)
+            .set("anthropic-version", ANTHROPIC_VERSION)
+            .set("content-type", "application/json")
+            .send_json(body);
+
+        let response = match response {
+            Ok(r) => r,
+            Err(ureq::Error::Status(code, r)) => {
+                let body = r
+                    .into_string()
+                    .unwrap_or_else(|_| "<unreadable error body>".to_string());
+                let detail = extract_anthropic_error_message(&body).unwrap_or_else(|| body.clone());
+                return Err(GraphRAGError::Generation {
+                    message: format!("Anthropic HTTP {}: {}", code, detail),
+                });
+            },
+            Err(e) => {
+                return Err(GraphRAGError::Generation {
+                    message: format!("Anthropic request failed: {}", e),
+                })
+            },
+        };
+
+        let json: serde_json::Value =
+            response
+                .into_json()
+                .map_err(|e| GraphRAGError::Generation {
+                    message: format!("Anthropic response parse failed: {}", e),
+                })?;
+
+        let blocks = json["content"]
+            .as_array()
+            .ok_or_else(|| GraphRAGError::Generation {
+                message: "Anthropic response missing content array".to_string(),
+            })?;
+
+        // Concatenate text blocks; ignore tool_use and others (out of scope).
+        let mut out = String::new();
+        for block in blocks {
+            if block["type"] == "text" {
+                if let Some(t) = block["text"].as_str() {
+                    out.push_str(t);
+                }
+            }
+        }
+
+        if out.is_empty() {
+            return Err(GraphRAGError::Generation {
+                message: "Anthropic response had no text blocks".to_string(),
+            });
+        }
+
+        Ok(out)
+    }
+}
+
+fn extract_anthropic_error_message(body: &str) -> Option<String> {
+    let v: serde_json::Value = serde_json::from_str(body).ok()?;
+    v["error"]["message"].as_str().map(|s| s.to_string())
+}
+
+#[async_trait]
+impl ChatBackend for AnthropicChat {
+    async fn complete(&self, prompt: &str, params: &ChatParams) -> Result<String> {
+        let ctx = self.request_ctx();
+        let prompt = prompt.to_string();
+        let params = params.clone();
+        tokio::task::spawn_blocking(move || ctx.complete(&prompt, &params))
+            .await
+            .map_err(|e| GraphRAGError::Generation {
+                message: format!("Anthropic worker task panicked or was cancelled: {}", e),
+            })?
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{BufRead, BufReader, Read, Write};
+    use std::net::TcpListener;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Mutex};
+    use std::thread;
+    use std::time::Duration;
+
+    #[derive(Default, Debug, Clone)]
+    struct CapturedRequest {
+        method: String,
+        path: String,
+        headers: Vec<(String, String)>,
+        body: String,
+    }
+
+    struct MockServer {
+        port: u16,
+        shutdown: Arc<AtomicBool>,
+        captured: Arc<Mutex<Option<CapturedRequest>>>,
+    }
+
+    impl MockServer {
+        fn start(status: u16, response_body: &'static str) -> Self {
+            let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+            let port = listener.local_addr().unwrap().port();
+            let shutdown = Arc::new(AtomicBool::new(false));
+            let shutdown_clone = shutdown.clone();
+            let captured: Arc<Mutex<Option<CapturedRequest>>> = Arc::new(Mutex::new(None));
+            let captured_clone = captured.clone();
+
+            listener.set_nonblocking(true).expect("nonblocking");
+
+            thread::spawn(move || {
+                while !shutdown_clone.load(Ordering::Relaxed) {
+                    match listener.accept() {
+                        Ok((stream, _)) => {
+                            let cap = captured_clone.clone();
+                            thread::spawn(move || handle_conn(stream, status, response_body, cap));
+                        },
+                        Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                            thread::sleep(Duration::from_millis(10));
+                        },
+                        Err(_) => break,
+                    }
+                }
+            });
+
+            MockServer {
+                port,
+                shutdown,
+                captured,
+            }
+        }
+
+        fn endpoint(&self, path: &str) -> String {
+            format!("http://127.0.0.1:{}{}", self.port, path)
+        }
+
+        fn captured(&self) -> Option<CapturedRequest> {
+            self.captured.lock().unwrap().clone()
+        }
+    }
+
+    impl Drop for MockServer {
+        fn drop(&mut self) {
+            self.shutdown.store(true, Ordering::Relaxed);
+        }
+    }
+
+    fn handle_conn(
+        stream: std::net::TcpStream,
+        status: u16,
+        response_body: &str,
+        captured: Arc<Mutex<Option<CapturedRequest>>>,
+    ) {
+        stream.set_nonblocking(false).ok();
+        let mut reader = BufReader::new(stream.try_clone().unwrap());
+        let mut stream = stream;
+
+        let mut request_line = String::new();
+        if reader.read_line(&mut request_line).unwrap_or(0) == 0 {
+            return;
+        }
+        let parts: Vec<&str> = request_line.split_whitespace().collect();
+        let method = parts.first().copied().unwrap_or("").to_string();
+        let path = parts.get(1).copied().unwrap_or("").to_string();
+
+        let mut headers = Vec::new();
+        let mut content_length = 0usize;
+        let mut line = String::new();
+        loop {
+            line.clear();
+            if reader.read_line(&mut line).unwrap_or(0) == 0 {
+                return;
+            }
+            if line == "\r\n" {
+                break;
+            }
+            if let Some((k, v)) = line.split_once(':') {
+                let k = k.trim().to_string();
+                let v = v.trim().to_string();
+                if k.eq_ignore_ascii_case("content-length") {
+                    content_length = v.parse().unwrap_or(0);
+                }
+                headers.push((k, v));
+            }
+        }
+
+        let mut body = String::new();
+        if content_length > 0 {
+            let mut buf = vec![0u8; content_length];
+            if reader.read_exact(&mut buf).is_ok() {
+                body = String::from_utf8_lossy(&buf).into_owned();
+            }
+        }
+
+        *captured.lock().unwrap() = Some(CapturedRequest {
+            method,
+            path,
+            headers,
+            body,
+        });
+
+        let status_text = match status {
+            200 => "OK",
+            400 => "Bad Request",
+            401 => "Unauthorized",
+            500 => "Internal Server Error",
+            _ => "OK",
+        };
+        let header = format!(
+            "HTTP/1.1 {} {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            status,
+            status_text,
+            response_body.len()
+        );
+        let _ = stream.write_all(header.as_bytes());
+        let _ = stream.write_all(response_body.as_bytes());
+        let _ = stream.flush();
+    }
+
+    /// `AnthropicChat::complete` posts to `/v1/messages` with `x-api-key`
+    /// and `anthropic-version` headers and includes `max_tokens` in the
+    /// body.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn anthropic_chat_posts_to_messages_endpoint() {
+        let server = MockServer::start(200, r#"{"content":[{"type":"text","text":"ok"}]}"#);
+        tokio::time::sleep(Duration::from_millis(30)).await;
+
+        let backend = AnthropicChat::new("test-key", "claude-haiku-4-5-20251001")
+            .with_endpoint_for_tests(server.endpoint("/v1/messages"));
+
+        let _ = backend
+            .complete("hello", &ChatParams::default())
+            .await
+            .expect("ok");
+
+        let req = server.captured().expect("request captured");
+        assert_eq!(req.method, "POST");
+        assert_eq!(req.path, "/v1/messages");
+
+        let api_key_h = req
+            .headers
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case("x-api-key"))
+            .expect("x-api-key header present");
+        assert_eq!(api_key_h.1, "test-key");
+
+        let version_h = req
+            .headers
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case("anthropic-version"))
+            .expect("anthropic-version header present");
+        assert_eq!(version_h.1, ANTHROPIC_VERSION);
+
+        let body: serde_json::Value = serde_json::from_str(&req.body).expect("body json");
+        assert_eq!(body["model"], "claude-haiku-4-5-20251001");
+        assert!(body["max_tokens"].is_number(), "max_tokens must be present");
+        assert_eq!(body["messages"][0]["role"], "user");
+        assert_eq!(body["messages"][0]["content"], "hello");
+    }
+
+    /// `AnthropicChat::complete` extracts the single `text` block from the
+    /// `content` array.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn anthropic_chat_extracts_text_from_content_array() {
+        let server = MockServer::start(
+            200,
+            r#"{"content":[{"type":"text","text":"the sky is blue"}],"role":"assistant","stop_reason":"end_turn"}"#,
+        );
+        tokio::time::sleep(Duration::from_millis(30)).await;
+
+        let backend = AnthropicChat::new("k", DEFAULT_ANTHROPIC_MODEL)
+            .with_endpoint_for_tests(server.endpoint("/v1/messages"));
+        let out = backend
+            .complete("why?", &ChatParams::default())
+            .await
+            .expect("ok");
+        assert_eq!(out, "the sky is blue");
+    }
+
+    /// `AnthropicChat::complete` concatenates multiple `text` blocks and
+    /// ignores non-text blocks (e.g. `tool_use`).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn anthropic_chat_handles_multi_block_response() {
+        let server = MockServer::start(
+            200,
+            r#"{"content":[
+                {"type":"text","text":"part one. "},
+                {"type":"tool_use","id":"abc","name":"calc","input":{}},
+                {"type":"text","text":"part two."}
+            ]}"#,
+        );
+        tokio::time::sleep(Duration::from_millis(30)).await;
+
+        let backend = AnthropicChat::new("k", DEFAULT_ANTHROPIC_MODEL)
+            .with_endpoint_for_tests(server.endpoint("/v1/messages"));
+        let out = backend
+            .complete("hi", &ChatParams::default())
+            .await
+            .expect("ok");
+        assert_eq!(out, "part one. part two.");
+    }
+
+    /// `AnthropicChat::from_env` reads `ANTHROPIC_API_KEY`.
+    #[test]
+    fn anthropic_chat_from_env_reads_api_key() {
+        let prev = std::env::var("ANTHROPIC_API_KEY").ok();
+        std::env::set_var("ANTHROPIC_API_KEY", "sk-ant-from-env");
+        let backend = AnthropicChat::from_env_default().expect("env-based ctor ok");
+        assert_eq!(backend.api_key, "sk-ant-from-env");
+        assert_eq!(backend.model, DEFAULT_ANTHROPIC_MODEL);
+        match prev {
+            Some(v) => std::env::set_var("ANTHROPIC_API_KEY", v),
+            None => std::env::remove_var("ANTHROPIC_API_KEY"),
+        }
+    }
+}

--- a/graphrag-core/src/core/api_chat/config.rs
+++ b/graphrag-core/src/core/api_chat/config.rs
@@ -107,32 +107,36 @@ impl ChatProviderConfig {
 
     /// Resolve the API key, falling back to the provider-specific env
     /// var when the config doesn't carry one. Returns `Auth` if the env
-    /// var is missing for OpenAI/Anthropic. Ollama returns `None`.
+    /// var is missing or empty for OpenAI/Anthropic. Ollama returns
+    /// `None`. Empty/whitespace-only keys (from either source) are
+    /// rejected with `Auth` so we never issue requests with blank
+    /// authorization headers.
     pub fn resolved_api_key(&self) -> Result<Option<String>> {
-        if let Some(k) = &self.api_key {
-            return Ok(Some(k.clone()));
+        let provider = self.provider_kind()?;
+        let env_var = match provider {
+            ChatProvider::OpenAi => "OPENAI_API_KEY",
+            ChatProvider::Anthropic => "ANTHROPIC_API_KEY",
+            ChatProvider::Ollama => return Ok(None),
+        };
+
+        let key = if let Some(k) = &self.api_key {
+            k.clone()
+        } else {
+            std::env::var(env_var).map_err(|_| GraphRAGError::Auth {
+                message: format!("{} env var not set and no api_key in config", env_var),
+            })?
+        };
+
+        if key.trim().is_empty() {
+            return Err(GraphRAGError::Auth {
+                message: format!(
+                    "{} is empty (set the env var or `api_key` in [chat] config)",
+                    env_var
+                ),
+            });
         }
-        match self.provider_kind()? {
-            ChatProvider::OpenAi => std::env::var("OPENAI_API_KEY").ok().map_or_else(
-                || {
-                    Err(GraphRAGError::Auth {
-                        message: "OPENAI_API_KEY env var not set and no api_key in config"
-                            .to_string(),
-                    })
-                },
-                |v| Ok(Some(v)),
-            ),
-            ChatProvider::Anthropic => std::env::var("ANTHROPIC_API_KEY").ok().map_or_else(
-                || {
-                    Err(GraphRAGError::Auth {
-                        message: "ANTHROPIC_API_KEY env var not set and no api_key in config"
-                            .to_string(),
-                    })
-                },
-                |v| Ok(Some(v)),
-            ),
-            ChatProvider::Ollama => Ok(None),
-        }
+
+        Ok(Some(key))
     }
 
     /// Build a `DynChatBackend` from this config. Returns `Unsupported`
@@ -263,6 +267,62 @@ mod tests {
             Ok(_) => panic!("ollama should not be buildable via ChatProviderConfig"),
             Err(GraphRAGError::Unsupported { .. }) => {},
             Err(other) => panic!("expected Unsupported, got {other:?}"),
+        }
+    }
+
+    /// An explicit empty `api_key` in the config must be rejected so we
+    /// never issue requests with a blank `Authorization` header.
+    #[test]
+    fn build_errors_on_empty_api_key_in_config() {
+        let cfg = ChatProviderConfig {
+            provider: "openai".into(),
+            model: None,
+            api_key: Some(String::new()),
+            max_tokens: None,
+        };
+        match cfg.build() {
+            Ok(_) => panic!("empty api_key should be rejected"),
+            Err(GraphRAGError::Auth { .. }) => {},
+            Err(other) => panic!("expected Auth, got {other:?}"),
+        }
+
+        // Whitespace-only is also rejected.
+        let cfg = ChatProviderConfig {
+            provider: "anthropic".into(),
+            model: None,
+            api_key: Some("   ".into()),
+            max_tokens: None,
+        };
+        match cfg.build() {
+            Ok(_) => panic!("whitespace api_key should be rejected"),
+            Err(GraphRAGError::Auth { .. }) => {},
+            Err(other) => panic!("expected Auth, got {other:?}"),
+        }
+    }
+
+    /// An empty `OPENAI_API_KEY` env var must be rejected the same way as
+    /// a missing one — otherwise `build` would silently issue requests
+    /// with an empty bearer token.
+    #[test]
+    fn build_errors_on_empty_api_key_in_env() {
+        let prev = std::env::var("OPENAI_API_KEY").ok();
+        std::env::set_var("OPENAI_API_KEY", "");
+        let cfg = ChatProviderConfig {
+            provider: "openai".into(),
+            model: None,
+            api_key: None,
+            max_tokens: None,
+        };
+        let result = cfg.build();
+        // Restore before asserting so a panic doesn't leak state.
+        match prev {
+            Some(v) => std::env::set_var("OPENAI_API_KEY", v),
+            None => std::env::remove_var("OPENAI_API_KEY"),
+        }
+        match result {
+            Ok(_) => panic!("empty OPENAI_API_KEY should be rejected"),
+            Err(GraphRAGError::Auth { .. }) => {},
+            Err(other) => panic!("expected Auth, got {other:?}"),
         }
     }
 }

--- a/graphrag-core/src/core/api_chat/config.rs
+++ b/graphrag-core/src/core/api_chat/config.rs
@@ -223,6 +223,9 @@ mod tests {
     /// instead of attempting an unauthenticated request.
     #[test]
     fn build_errors_when_no_api_key_and_no_env() {
+        // Serialize against any other test in the process that mutates
+        // OPENAI_API_KEY / ANTHROPIC_API_KEY (see `super::super::test_env_lock`).
+        let _guard = crate::core::api_chat::test_env_lock::lock();
         let prev = std::env::var("OPENAI_API_KEY").ok();
         std::env::remove_var("OPENAI_API_KEY");
         let cfg = ChatProviderConfig {
@@ -305,6 +308,9 @@ mod tests {
     /// with an empty bearer token.
     #[test]
     fn build_errors_on_empty_api_key_in_env() {
+        // Serialize against any other test in the process that mutates
+        // OPENAI_API_KEY / ANTHROPIC_API_KEY (see `super::super::test_env_lock`).
+        let _guard = crate::core::api_chat::test_env_lock::lock();
         let prev = std::env::var("OPENAI_API_KEY").ok();
         std::env::set_var("OPENAI_API_KEY", "");
         let cfg = ChatProviderConfig {

--- a/graphrag-core/src/core/api_chat/config.rs
+++ b/graphrag-core/src/core/api_chat/config.rs
@@ -1,0 +1,268 @@
+//! TOML-friendly chat-provider configuration.
+//!
+//! Companion to `embeddings::config::EmbeddingProviderConfig`, but for the
+//! chat side. Exposes a `provider = "openai" | "anthropic" | "ollama"`
+//! switch and falls back to `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` when
+//! the config doesn't carry an explicit `api_key`.
+
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+use crate::core::backend::{ChatBackend, DynChatBackend};
+use crate::core::error::{GraphRAGError, Result};
+
+use super::anthropic::{AnthropicChat, DEFAULT_ANTHROPIC_MODEL};
+use super::openai::{OpenAiChat, DEFAULT_OPENAI_MODEL};
+
+/// Selectable chat backend.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChatProvider {
+    /// OpenAI `/v1/chat/completions` (`gpt-4o-mini` default).
+    OpenAi,
+    /// Anthropic `/v1/messages` (`claude-haiku-4-5-20251001` default).
+    Anthropic,
+    /// Local Ollama. Construction is left to the caller — this enum
+    /// variant exists so config files can express the choice; building
+    /// the actual `OllamaAdapter` requires the `ollama` feature.
+    Ollama,
+}
+
+impl ChatProvider {
+    fn parse(s: &str) -> Result<Self> {
+        match s.to_lowercase().as_str() {
+            "openai" => Ok(Self::OpenAi),
+            "anthropic" | "claude" => Ok(Self::Anthropic),
+            "ollama" => Ok(Self::Ollama),
+            other => Err(GraphRAGError::Config {
+                message: format!("Unknown chat provider: {}", other),
+            }),
+        }
+    }
+}
+
+/// TOML-friendly chat provider configuration.
+///
+/// ```toml
+/// [chat]
+/// provider = "anthropic"          # or "openai" / "ollama"
+/// model = "claude-haiku-4-5-20251001"
+/// # api_key = "sk-ant-..."        # optional; falls back to ANTHROPIC_API_KEY
+/// max_tokens = 4096               # only honoured by Anthropic
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatProviderConfig {
+    /// `"openai" | "anthropic" | "ollama"`.
+    #[serde(default = "default_provider")]
+    pub provider: String,
+
+    /// Model identifier. Defaults differ per provider — see
+    /// [`ChatProviderConfig::resolved_model`].
+    #[serde(default)]
+    pub model: Option<String>,
+
+    /// API key (OpenAI/Anthropic). When absent we read
+    /// `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` from the environment.
+    #[serde(default)]
+    pub api_key: Option<String>,
+
+    /// Anthropic-only fallback `max_tokens` used when the call site
+    /// doesn't pass one in `ChatParams`.
+    #[serde(default)]
+    pub max_tokens: Option<u32>,
+}
+
+impl Default for ChatProviderConfig {
+    fn default() -> Self {
+        Self {
+            provider: default_provider(),
+            model: None,
+            api_key: None,
+            max_tokens: None,
+        }
+    }
+}
+
+fn default_provider() -> String {
+    "ollama".to_string()
+}
+
+impl ChatProviderConfig {
+    /// Parse the `provider` string into a typed enum.
+    pub fn provider_kind(&self) -> Result<ChatProvider> {
+        ChatProvider::parse(&self.provider)
+    }
+
+    /// Resolve the model name, applying the provider-specific default
+    /// when `model` is unset.
+    pub fn resolved_model(&self) -> Result<String> {
+        let provider = self.provider_kind()?;
+        Ok(match (&self.model, provider) {
+            (Some(m), _) => m.clone(),
+            (None, ChatProvider::OpenAi) => DEFAULT_OPENAI_MODEL.to_string(),
+            (None, ChatProvider::Anthropic) => DEFAULT_ANTHROPIC_MODEL.to_string(),
+            (None, ChatProvider::Ollama) => "llama3.2:3b".to_string(),
+        })
+    }
+
+    /// Resolve the API key, falling back to the provider-specific env
+    /// var when the config doesn't carry one. Returns `Auth` if the env
+    /// var is missing for OpenAI/Anthropic. Ollama returns `None`.
+    pub fn resolved_api_key(&self) -> Result<Option<String>> {
+        if let Some(k) = &self.api_key {
+            return Ok(Some(k.clone()));
+        }
+        match self.provider_kind()? {
+            ChatProvider::OpenAi => std::env::var("OPENAI_API_KEY").ok().map_or_else(
+                || {
+                    Err(GraphRAGError::Auth {
+                        message: "OPENAI_API_KEY env var not set and no api_key in config"
+                            .to_string(),
+                    })
+                },
+                |v| Ok(Some(v)),
+            ),
+            ChatProvider::Anthropic => std::env::var("ANTHROPIC_API_KEY").ok().map_or_else(
+                || {
+                    Err(GraphRAGError::Auth {
+                        message: "ANTHROPIC_API_KEY env var not set and no api_key in config"
+                            .to_string(),
+                    })
+                },
+                |v| Ok(Some(v)),
+            ),
+            ChatProvider::Ollama => Ok(None),
+        }
+    }
+
+    /// Build a `DynChatBackend` from this config. Returns `Unsupported`
+    /// for the Ollama variant, which the caller must construct via the
+    /// existing `core::ollama_adapters` path.
+    pub fn build(&self) -> Result<DynChatBackend> {
+        let provider = self.provider_kind()?;
+        let model = self.resolved_model()?;
+        match provider {
+            ChatProvider::OpenAi => {
+                let key = self
+                    .resolved_api_key()?
+                    .ok_or_else(|| GraphRAGError::Auth {
+                        message: "OpenAI requires an api_key".to_string(),
+                    })?;
+                let backend = OpenAiChat::new(key, model);
+                Ok(Arc::new(backend) as Arc<dyn ChatBackend>)
+            },
+            ChatProvider::Anthropic => {
+                let key = self
+                    .resolved_api_key()?
+                    .ok_or_else(|| GraphRAGError::Auth {
+                        message: "Anthropic requires an api_key".to_string(),
+                    })?;
+                let mut backend = AnthropicChat::new(key, model);
+                if let Some(mt) = self.max_tokens {
+                    backend = backend.with_default_max_tokens(mt);
+                }
+                Ok(Arc::new(backend) as Arc<dyn ChatBackend>)
+            },
+            ChatProvider::Ollama => Err(GraphRAGError::Unsupported {
+                operation: "ChatProviderConfig::build for Ollama".to_string(),
+                reason: "Ollama backend must be constructed via core::ollama_adapters \
+                         (requires the `ollama` feature)"
+                    .to_string(),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `ChatProvider::parse` accepts the documented aliases and rejects
+    /// unknown names.
+    #[test]
+    fn provider_parse_accepts_known_aliases() {
+        assert_eq!(ChatProvider::parse("openai").unwrap(), ChatProvider::OpenAi);
+        assert_eq!(
+            ChatProvider::parse("Anthropic").unwrap(),
+            ChatProvider::Anthropic
+        );
+        assert_eq!(
+            ChatProvider::parse("CLAUDE").unwrap(),
+            ChatProvider::Anthropic
+        );
+        assert_eq!(ChatProvider::parse("ollama").unwrap(), ChatProvider::Ollama);
+        assert!(ChatProvider::parse("bogus").is_err());
+    }
+
+    /// `resolved_model` falls back to provider-specific defaults when no
+    /// model is set in the config.
+    #[test]
+    fn resolved_model_uses_provider_default_when_absent() {
+        let cfg = ChatProviderConfig {
+            provider: "openai".into(),
+            model: None,
+            api_key: Some("k".into()),
+            max_tokens: None,
+        };
+        assert_eq!(cfg.resolved_model().unwrap(), DEFAULT_OPENAI_MODEL);
+
+        let cfg = ChatProviderConfig {
+            provider: "anthropic".into(),
+            model: None,
+            api_key: Some("k".into()),
+            max_tokens: None,
+        };
+        assert_eq!(cfg.resolved_model().unwrap(), DEFAULT_ANTHROPIC_MODEL);
+    }
+
+    /// When `api_key` is unset and the env var is absent, `build` errors
+    /// instead of attempting an unauthenticated request.
+    #[test]
+    fn build_errors_when_no_api_key_and_no_env() {
+        let prev = std::env::var("OPENAI_API_KEY").ok();
+        std::env::remove_var("OPENAI_API_KEY");
+        let cfg = ChatProviderConfig {
+            provider: "openai".into(),
+            model: None,
+            api_key: None,
+            max_tokens: None,
+        };
+        let res = cfg.build();
+        assert!(res.is_err(), "expected error without api key");
+        if let Some(v) = prev {
+            std::env::set_var("OPENAI_API_KEY", v);
+        }
+    }
+
+    /// `build` constructs an OpenAI backend when given an explicit key.
+    #[test]
+    fn build_constructs_openai_backend_with_explicit_key() {
+        let cfg = ChatProviderConfig {
+            provider: "openai".into(),
+            model: Some("gpt-4o-mini".into()),
+            api_key: Some("sk-test".into()),
+            max_tokens: None,
+        };
+        let backend = cfg.build().expect("ok");
+        // We only assert that we got a trait object; behaviour is covered
+        // in `openai.rs` tests.
+        let _ = &*backend;
+    }
+
+    /// `build` returns `Unsupported` for the Ollama variant — callers
+    /// must use the dedicated adapter.
+    #[test]
+    fn build_rejects_ollama_variant() {
+        let cfg = ChatProviderConfig {
+            provider: "ollama".into(),
+            model: None,
+            api_key: None,
+            max_tokens: None,
+        };
+        match cfg.build() {
+            Ok(_) => panic!("ollama should not be buildable via ChatProviderConfig"),
+            Err(GraphRAGError::Unsupported { .. }) => {},
+            Err(other) => panic!("expected Unsupported, got {other:?}"),
+        }
+    }
+}

--- a/graphrag-core/src/core/api_chat/mod.rs
+++ b/graphrag-core/src/core/api_chat/mod.rs
@@ -1,0 +1,21 @@
+//! Native HTTP `ChatBackend` implementations for OpenAI and Anthropic.
+//!
+//! Both providers speak `ureq`-based JSON over HTTPS and are wired through
+//! the standard `ChatBackend` trait so they can replace the default Ollama
+//! backend via `GraphRAG::set_chat_backend`. Streaming, tool calls, and
+//! cloud-router variants (Azure, Bedrock, Vertex) are intentionally out of
+//! scope for this module — see issue #90.
+
+#[cfg(feature = "ureq")]
+pub mod anthropic;
+#[cfg(feature = "ureq")]
+pub mod config;
+#[cfg(feature = "ureq")]
+pub mod openai;
+
+#[cfg(feature = "ureq")]
+pub use anthropic::AnthropicChat;
+#[cfg(feature = "ureq")]
+pub use config::{ChatProvider, ChatProviderConfig};
+#[cfg(feature = "ureq")]
+pub use openai::OpenAiChat;

--- a/graphrag-core/src/core/api_chat/mod.rs
+++ b/graphrag-core/src/core/api_chat/mod.rs
@@ -19,3 +19,21 @@ pub use anthropic::AnthropicChat;
 pub use config::{ChatProvider, ChatProviderConfig};
 #[cfg(feature = "ureq")]
 pub use openai::OpenAiChat;
+
+#[cfg(all(test, feature = "ureq"))]
+pub(crate) mod test_env_lock {
+    //! Process-wide mutex serializing tests that mutate `OPENAI_API_KEY`
+    //! / `ANTHROPIC_API_KEY`. `cargo test` runs unit tests in parallel
+    //! within a single process, so concurrent set/remove of shared env
+    //! vars across modules races and produces flaky failures.
+    use std::sync::Mutex;
+
+    pub(crate) static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Acquire the lock, recovering from a poisoned mutex left over by a
+    /// previous test panic — poisoning is irrelevant here because we
+    /// only protect env-var ordering, not invariants over the `()` guard.
+    pub(crate) fn lock() -> std::sync::MutexGuard<'static, ()> {
+        ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
+}

--- a/graphrag-core/src/core/api_chat/openai.rs
+++ b/graphrag-core/src/core/api_chat/openai.rs
@@ -1,0 +1,398 @@
+//! OpenAI chat-completions backend.
+//!
+//! Mirrors the sync-`ureq`-on-blocking-pool pattern used by
+//! `embeddings::api_providers::HttpEmbeddingProvider` so concurrent calls
+//! don't park tokio worker threads (issue #4).
+
+use async_trait::async_trait;
+
+use crate::core::backend::{ChatBackend, ChatParams};
+use crate::core::error::{GraphRAGError, Result};
+
+const DEFAULT_OPENAI_ENDPOINT: &str = "https://api.openai.com/v1/chat/completions";
+/// Default model — cheap, capable, suitable for GraphRAG answer synthesis.
+pub const DEFAULT_OPENAI_MODEL: &str = "gpt-4o-mini";
+
+/// HTTP `ChatBackend` for OpenAI's `/v1/chat/completions` endpoint.
+pub struct OpenAiChat {
+    api_key: String,
+    model: String,
+    endpoint: String,
+    client: ureq::Agent,
+}
+
+impl OpenAiChat {
+    /// Create a backend with an explicit API key and model. Use
+    /// [`OpenAiChat::from_env`] to read `OPENAI_API_KEY` from the
+    /// environment instead.
+    pub fn new(api_key: impl Into<String>, model: impl Into<String>) -> Self {
+        Self {
+            api_key: api_key.into(),
+            model: model.into(),
+            endpoint: DEFAULT_OPENAI_ENDPOINT.to_string(),
+            client: ureq::Agent::new(),
+        }
+    }
+
+    /// Construct from `OPENAI_API_KEY` env var. Returns `Auth` error if
+    /// unset or empty.
+    pub fn from_env(model: impl Into<String>) -> Result<Self> {
+        let key = std::env::var("OPENAI_API_KEY").map_err(|_| GraphRAGError::Auth {
+            message: "OPENAI_API_KEY environment variable not set".to_string(),
+        })?;
+        if key.is_empty() {
+            return Err(GraphRAGError::Auth {
+                message: "OPENAI_API_KEY is empty".to_string(),
+            });
+        }
+        Ok(Self::new(key, model))
+    }
+
+    /// Construct using the default model (`gpt-4o-mini`).
+    pub fn from_env_default() -> Result<Self> {
+        Self::from_env(DEFAULT_OPENAI_MODEL)
+    }
+
+    /// Override the HTTP endpoint. Intended for redirecting requests to a
+    /// local mock server in integration tests.
+    #[doc(hidden)]
+    pub fn with_endpoint_for_tests(mut self, endpoint: impl Into<String>) -> Self {
+        self.endpoint = endpoint.into();
+        self
+    }
+
+    fn request_ctx(&self) -> RequestCtx {
+        RequestCtx {
+            api_key: self.api_key.clone(),
+            model: self.model.clone(),
+            endpoint: self.endpoint.clone(),
+            client: self.client.clone(),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct RequestCtx {
+    api_key: String,
+    model: String,
+    endpoint: String,
+    client: ureq::Agent,
+}
+
+impl RequestCtx {
+    fn complete(self, prompt: &str, params: &ChatParams) -> Result<String> {
+        let mut body = serde_json::json!({
+            "model": self.model,
+            "messages": [
+                {"role": "user", "content": prompt}
+            ],
+        });
+        if let Some(max) = params.max_tokens {
+            body["max_tokens"] = serde_json::json!(max);
+        }
+        if let Some(temp) = params.temperature {
+            body["temperature"] = serde_json::json!(temp);
+        }
+
+        let response = self
+            .client
+            .post(&self.endpoint)
+            .set("Authorization", &format!("Bearer {}", self.api_key))
+            .set("Content-Type", "application/json")
+            .send_json(body);
+
+        let response = match response {
+            Ok(r) => r,
+            Err(ureq::Error::Status(code, r)) => {
+                let body = r
+                    .into_string()
+                    .unwrap_or_else(|_| "<unreadable error body>".to_string());
+                let detail = extract_openai_error_message(&body).unwrap_or_else(|| body.clone());
+                return Err(GraphRAGError::Generation {
+                    message: format!("OpenAI HTTP {}: {}", code, detail),
+                });
+            },
+            Err(e) => {
+                return Err(GraphRAGError::Generation {
+                    message: format!("OpenAI request failed: {}", e),
+                })
+            },
+        };
+
+        let json: serde_json::Value =
+            response
+                .into_json()
+                .map_err(|e| GraphRAGError::Generation {
+                    message: format!("OpenAI response parse failed: {}", e),
+                })?;
+
+        let content = json["choices"][0]["message"]["content"]
+            .as_str()
+            .ok_or_else(|| GraphRAGError::Generation {
+                message: "OpenAI response missing choices[0].message.content".to_string(),
+            })?
+            .to_string();
+
+        Ok(content)
+    }
+}
+
+fn extract_openai_error_message(body: &str) -> Option<String> {
+    let v: serde_json::Value = serde_json::from_str(body).ok()?;
+    v["error"]["message"].as_str().map(|s| s.to_string())
+}
+
+#[async_trait]
+impl ChatBackend for OpenAiChat {
+    async fn complete(&self, prompt: &str, params: &ChatParams) -> Result<String> {
+        let ctx = self.request_ctx();
+        let prompt = prompt.to_string();
+        let params = params.clone();
+        tokio::task::spawn_blocking(move || ctx.complete(&prompt, &params))
+            .await
+            .map_err(|e| GraphRAGError::Generation {
+                message: format!("OpenAI worker task panicked or was cancelled: {}", e),
+            })?
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{BufRead, BufReader, Read, Write};
+    use std::net::TcpListener;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Mutex};
+    use std::thread;
+    use std::time::Duration;
+
+    /// Records what the mock server received so tests can assert on it.
+    #[derive(Default, Debug, Clone)]
+    struct CapturedRequest {
+        method: String,
+        path: String,
+        headers: Vec<(String, String)>,
+        body: String,
+    }
+
+    struct MockServer {
+        port: u16,
+        shutdown: Arc<AtomicBool>,
+        captured: Arc<Mutex<Option<CapturedRequest>>>,
+    }
+
+    impl MockServer {
+        fn start(status: u16, response_body: &'static str) -> Self {
+            let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+            let port = listener.local_addr().unwrap().port();
+            let shutdown = Arc::new(AtomicBool::new(false));
+            let shutdown_clone = shutdown.clone();
+            let captured: Arc<Mutex<Option<CapturedRequest>>> = Arc::new(Mutex::new(None));
+            let captured_clone = captured.clone();
+
+            listener.set_nonblocking(true).expect("nonblocking");
+
+            thread::spawn(move || {
+                while !shutdown_clone.load(Ordering::Relaxed) {
+                    match listener.accept() {
+                        Ok((stream, _)) => {
+                            let cap = captured_clone.clone();
+                            thread::spawn(move || handle_conn(stream, status, response_body, cap));
+                        },
+                        Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                            thread::sleep(Duration::from_millis(10));
+                        },
+                        Err(_) => break,
+                    }
+                }
+            });
+
+            MockServer {
+                port,
+                shutdown,
+                captured,
+            }
+        }
+
+        fn endpoint(&self, path: &str) -> String {
+            format!("http://127.0.0.1:{}{}", self.port, path)
+        }
+
+        fn captured(&self) -> Option<CapturedRequest> {
+            self.captured.lock().unwrap().clone()
+        }
+    }
+
+    impl Drop for MockServer {
+        fn drop(&mut self) {
+            self.shutdown.store(true, Ordering::Relaxed);
+        }
+    }
+
+    fn handle_conn(
+        stream: std::net::TcpStream,
+        status: u16,
+        response_body: &str,
+        captured: Arc<Mutex<Option<CapturedRequest>>>,
+    ) {
+        stream.set_nonblocking(false).ok();
+        let mut reader = BufReader::new(stream.try_clone().unwrap());
+        let mut stream = stream;
+
+        // Read request line.
+        let mut request_line = String::new();
+        if reader.read_line(&mut request_line).unwrap_or(0) == 0 {
+            return;
+        }
+        let parts: Vec<&str> = request_line.split_whitespace().collect();
+        let method = parts.first().copied().unwrap_or("").to_string();
+        let path = parts.get(1).copied().unwrap_or("").to_string();
+
+        // Read headers.
+        let mut headers = Vec::new();
+        let mut content_length = 0usize;
+        let mut line = String::new();
+        loop {
+            line.clear();
+            if reader.read_line(&mut line).unwrap_or(0) == 0 {
+                return;
+            }
+            if line == "\r\n" {
+                break;
+            }
+            if let Some((k, v)) = line.split_once(':') {
+                let k = k.trim().to_string();
+                let v = v.trim().to_string();
+                if k.eq_ignore_ascii_case("content-length") {
+                    content_length = v.parse().unwrap_or(0);
+                }
+                headers.push((k, v));
+            }
+        }
+
+        let mut body = String::new();
+        if content_length > 0 {
+            let mut buf = vec![0u8; content_length];
+            if reader.read_exact(&mut buf).is_ok() {
+                body = String::from_utf8_lossy(&buf).into_owned();
+            }
+        }
+
+        *captured.lock().unwrap() = Some(CapturedRequest {
+            method,
+            path,
+            headers,
+            body,
+        });
+
+        let status_text = match status {
+            200 => "OK",
+            400 => "Bad Request",
+            401 => "Unauthorized",
+            500 => "Internal Server Error",
+            _ => "OK",
+        };
+        let header = format!(
+            "HTTP/1.1 {} {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            status,
+            status_text,
+            response_body.len()
+        );
+        let _ = stream.write_all(header.as_bytes());
+        let _ = stream.write_all(response_body.as_bytes());
+        let _ = stream.flush();
+    }
+
+    /// `OpenAiChat::complete` posts JSON to `/v1/chat/completions` with the
+    /// `Authorization: Bearer …` header and a single user message.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn openai_chat_posts_to_chat_completions_endpoint() {
+        let server = MockServer::start(200, r#"{"choices":[{"message":{"content":"hi"}}]}"#);
+        tokio::time::sleep(Duration::from_millis(30)).await;
+
+        let backend = OpenAiChat::new("sk-test-key", "gpt-4o-mini")
+            .with_endpoint_for_tests(server.endpoint("/v1/chat/completions"));
+
+        let _ = backend
+            .complete("hello world", &ChatParams::default())
+            .await
+            .expect("ok");
+
+        let req = server.captured().expect("request was captured");
+        assert_eq!(req.method, "POST");
+        assert_eq!(req.path, "/v1/chat/completions");
+
+        let auth_header = req
+            .headers
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case("authorization"))
+            .expect("authorization header present");
+        assert_eq!(auth_header.1, "Bearer sk-test-key");
+
+        let body: serde_json::Value = serde_json::from_str(&req.body).expect("body is JSON");
+        assert_eq!(body["model"], "gpt-4o-mini");
+        assert_eq!(body["messages"][0]["role"], "user");
+        assert_eq!(body["messages"][0]["content"], "hello world");
+    }
+
+    /// `OpenAiChat::complete` returns `choices[0].message.content` from the
+    /// upstream response.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn openai_chat_extracts_response_text_from_choices_array() {
+        let server = MockServer::start(
+            200,
+            r#"{"choices":[{"message":{"role":"assistant","content":"the answer is 42"}}]}"#,
+        );
+        tokio::time::sleep(Duration::from_millis(30)).await;
+
+        let backend = OpenAiChat::new("sk-x", "gpt-4o-mini")
+            .with_endpoint_for_tests(server.endpoint("/v1/chat/completions"));
+
+        let out = backend
+            .complete("what is the answer?", &ChatParams::default())
+            .await
+            .expect("ok");
+        assert_eq!(out, "the answer is 42");
+    }
+
+    /// `OpenAiChat::complete` surfaces 4xx errors as `Generation` with the
+    /// upstream `error.message` extracted.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn openai_chat_returns_error_on_4xx_with_message() {
+        let server = MockServer::start(
+            400,
+            r#"{"error":{"message":"invalid model","type":"invalid_request_error"}}"#,
+        );
+        tokio::time::sleep(Duration::from_millis(30)).await;
+
+        let backend = OpenAiChat::new("sk-x", "bogus-model")
+            .with_endpoint_for_tests(server.endpoint("/v1/chat/completions"));
+
+        let err = backend
+            .complete("hi", &ChatParams::default())
+            .await
+            .expect_err("4xx should error");
+        let s = format!("{}", err);
+        assert!(
+            s.contains("400") && s.contains("invalid model"),
+            "unexpected error: {s}"
+        );
+    }
+
+    /// `OpenAiChat::from_env` reads `OPENAI_API_KEY` and errors when unset.
+    #[test]
+    fn openai_chat_from_env_reads_api_key() {
+        // Use a unique env var setup to avoid clobbering other tests.
+        // Save and restore.
+        let prev = std::env::var("OPENAI_API_KEY").ok();
+        std::env::set_var("OPENAI_API_KEY", "sk-from-env");
+        let backend = OpenAiChat::from_env_default().expect("env-based ctor ok");
+        assert_eq!(backend.api_key, "sk-from-env");
+        assert_eq!(backend.model, DEFAULT_OPENAI_MODEL);
+        // Restore.
+        match prev {
+            Some(v) => std::env::set_var("OPENAI_API_KEY", v),
+            None => std::env::remove_var("OPENAI_API_KEY"),
+        }
+    }
+}

--- a/graphrag-core/src/core/api_chat/openai.rs
+++ b/graphrag-core/src/core/api_chat/openai.rs
@@ -382,8 +382,9 @@ mod tests {
     /// `OpenAiChat::from_env` reads `OPENAI_API_KEY` and errors when unset.
     #[test]
     fn openai_chat_from_env_reads_api_key() {
-        // Use a unique env var setup to avoid clobbering other tests.
-        // Save and restore.
+        // Serialize against any other test in the process that mutates
+        // OPENAI_API_KEY / ANTHROPIC_API_KEY (see `super::super::test_env_lock`).
+        let _guard = crate::core::api_chat::test_env_lock::lock();
         let prev = std::env::var("OPENAI_API_KEY").ok();
         std::env::set_var("OPENAI_API_KEY", "sk-from-env");
         let backend = OpenAiChat::from_env_default().expect("env-based ctor ok");

--- a/graphrag-core/src/core/mod.rs
+++ b/graphrag-core/src/core/mod.rs
@@ -10,6 +10,12 @@ pub mod metadata;
 #[cfg(feature = "async")]
 pub mod backend;
 
+// Native HTTP chat backends for OpenAI and Anthropic. Requires `async` for
+// the `ChatBackend` async trait and `ureq` for the sync HTTP client (the
+// same combination used by `embeddings::api_providers`).
+#[cfg(all(feature = "async", feature = "ureq"))]
+pub mod api_chat;
+
 // Registry requires async feature (uses storage)
 #[cfg(feature = "async")]
 pub mod registry;

--- a/tests/e2e/configs/chat_anthropic.toml
+++ b/tests/e2e/configs/chat_anthropic.toml
@@ -1,0 +1,19 @@
+# Sample chat-provider config for the native Anthropic ChatBackend (issue #90).
+#
+# Maps onto graphrag_core::core::api_chat::ChatProviderConfig. Drop this
+# under a top-level [chat] table in any TOML config the application loads.
+#
+# Auth:
+#   - `api_key` is intentionally unset; the loader will read
+#     ANTHROPIC_API_KEY from the environment. Do NOT commit a real key.
+#
+# Documented model options:
+#   - claude-haiku-4-5-20251001  (default; cheap)
+#   - claude-sonnet-4-6
+#   - claude-opus-4-7
+
+provider   = "anthropic"
+model      = "claude-haiku-4-5-20251001"
+max_tokens = 4096
+
+# api_key = "sk-ant-..."   # uncomment to override the env var

--- a/tests/e2e/configs/chat_openai.toml
+++ b/tests/e2e/configs/chat_openai.toml
@@ -1,0 +1,19 @@
+# Sample chat-provider config for the native OpenAI ChatBackend (issue #90).
+#
+# Maps onto graphrag_core::core::api_chat::ChatProviderConfig. Drop this
+# under a top-level [chat] table in any TOML config the application loads,
+# or load it directly via:
+#
+#   let cfg: graphrag_core::core::api_chat::ChatProviderConfig =
+#       toml::from_str(include_str!("chat_openai.toml")).unwrap();
+#   let backend = cfg.build()?;
+#
+# Auth:
+#   - `api_key` is intentionally unset; the loader will read OPENAI_API_KEY
+#     from the environment. Do NOT commit a real key to this repo.
+
+provider = "openai"
+model    = "gpt-4o-mini"
+
+# api_key = "sk-..."   # uncomment to override the env var
+# max_tokens = 2048    # ignored by OpenAI here; kept for symmetry


### PR DESCRIPTION
## Summary

Closes **#90** — adds native `OpenAiChat` and `AnthropicChat` implementations of the existing `ChatBackend` trait. Cloud chat no longer requires routing through Ollama's OpenAI-compatible proxy.

### New module

\`graphrag-core/src/core/api_chat/{mod,openai,anthropic,config}.rs\`

- **OpenAI** — POST \`https://api.openai.com/v1/chat/completions\`, default model \`gpt-4o-mini\`
- **Anthropic** — POST \`https://api.anthropic.com/v1/messages\`, default model \`claude-haiku-4-5-20251001\`, default \`max_tokens = 4096\`
- **ChatProvider** enum (\`openai\` / \`anthropic\` / \`ollama\`) with config-driven construction
- API key resolution: explicit config field → env var (\`OPENAI_API_KEY\` / \`ANTHROPIC_API_KEY\`)
- Multi-block Anthropic responses concatenate text blocks; \`tool_use\` blocks are skipped (out of scope per the issue)

### Implementation choice

Bridges sync \`ureq\` HTTP via \`tokio::task::spawn_blocking\`, matching the established pattern in \`embeddings/api_providers.rs\`. No new HTTP dep (no \`reqwest\`). Mock servers via in-process \`TcpListener\` (matching \`tests/embeddings_concurrent_blocking.rs\` pattern), so no \`wiremock\` dep.

### Sample configs

- \`tests/e2e/configs/chat_openai.toml\`
- \`tests/e2e/configs/chat_anthropic.toml\`

### Documentation

\`graphrag-core/README.md\` adds an "LLM Chat Providers" section with provider matrix, Rust constructor examples, and TOML samples.

## Review fixes (codex)

- **fix(core/api_chat): reject empty API keys** — codex P1 (conf 0.97). \`resolved_api_key\` was returning \`Some\` for empty strings, so an unset/empty \`OPENAI_API_KEY\` or an explicit \`api_key = \"\"\` would still build a backend and issue requests with blank auth headers. Now validates non-empty (after \`.trim()\`) for both config and env paths; returns \`GraphRAGError::Auth\` consistent with \`from_env\` constructors. Two regression tests added.
- **test(core/api_chat): serialize env-var-touching tests** — codex P2 (conf 0.95). Multiple tests mutate \`OPENAI_API_KEY\` / \`ANTHROPIC_API_KEY\` globally; \`cargo test\`'s parallel runner can interleave them. Added a process-wide \`Mutex<()>\` in \`core::api_chat::test_env_lock\` that all four env-touching tests acquire. Verified across 5 consecutive runs, no flakes.

## Out of scope (per #90)

- Streaming responses
- Tool / function calling
- Azure OpenAI / Bedrock / Vertex routing
- CLI \`--chat-provider\` flag

## Test plan

- [x] \`cargo fmt --all\` clean
- [x] \`cargo build --workspace --exclude graphrag_py --exclude graphrag-wasm\` clean
- [x] \`cargo test -p graphrag-core --lib\` — 420 passed, 12 ignored (was 407)
- [x] \`cargo test -p graphrag-core --lib api_chat\` — 15 passed, 5 consecutive runs no flakes

Closes #90