### PR TITLE
feat(core/graph): real hierarchical Leiden via super-graph contraction

### DIFF
--- a/graphrag-core/LEIDEN_INTEGRATION.md
+++ b/graphrag-core/LEIDEN_INTEGRATION.md
@@ -313,9 +313,16 @@ let mut communities = graph.detect_hierarchical_communities(config)?;
 let leiden_graph = graph.to_leiden_graph();
 communities.generate_hierarchical_summaries(&leiden_graph, 5);
 
-// Access summaries by community ID
-for (community_id, summary) in &communities.summaries {
-    println!("Community {}: {}", community_id, summary);
+// Access summaries: keyed by (level, community_id) — see "Summaries Keying" below.
+for (level, level_summaries) in &communities.summaries {
+    for (community_id, summary) in level_summaries {
+        println!("Level {} community {}: {}", level, community_id, summary);
+    }
+}
+
+// Direct lookup helper:
+if let Some(summary) = communities.get_summary(0, 3) {
+    println!("Level 0 community 3: {}", summary);
 }
 ```
 
@@ -381,8 +388,8 @@ fn retrieve_relevant_communities(
 
             // Check if any entity matches the query
             if entities.iter().any(|e| e.to_lowercase().contains(&query.to_lowercase())) {
-                // Get summary for this community
-                if let Some(summary) = communities.summaries.get(&community_id) {
+                // Get summary for this community (summaries are keyed by (level, id))
+                if let Some(summary) = communities.get_summary(level, community_id) {
                     results.push(summary.clone());
                 }
             }
@@ -589,7 +596,30 @@ Current behavior:
 `HierarchicalCommunities.hierarchy` is keyed as
 `HashMap<level, HashMap<community_id, Option<(parent_level, parent_community_id)>>>`.
 Walk leaf -> root by chasing the parent at each level. Top-level (root) communities have
-explicit `None` parents.
+explicit `None` parents at *whichever level happens to be the top* — including level 0
+when the algorithm stops at one level (e.g. `max_levels = 1` or no further merging is
+profitable).
+
+## Summaries Keying
+
+`HierarchicalCommunities.summaries` is keyed as
+`HashMap<level, HashMap<community_id, String>>` — nested by hierarchy level so a level-0
+and a level-1 community can both carry id `0` without colliding. Use the
+`get_summary(level, community_id)` helper for direct lookups.
+
+## Breaking Changes (#94 review)
+
+These types changed shape during the Group H-94 review pass. Callers built against pre-fix
+shapes must migrate:
+
+- `HierarchicalCommunities.hierarchy` is now
+  `HashMap<usize, HashMap<usize, Option<(usize, usize)>>>` (level -> id -> parent).
+  Previously a flat `HashMap<usize, Option<usize>>`.
+- `HierarchicalCommunities.summaries` is now
+  `HashMap<usize, HashMap<usize, String>>` (level -> id -> summary). Previously a flat
+  `HashMap<usize, String>`.
+- `graphrag-wasm`'s `get_community_summary` now takes `(level, community_id)` (previously
+  `(community_id)`).
 
 ## Testing
 
@@ -602,8 +632,14 @@ Tests:
 - `test_leiden_basic` - End-to-end algorithm
 - `test_is_well_connected` - Connectivity check
 - `test_config_defaults` - Configuration validation
-- `test_hierarchical_two_tier_graph` - Two-tier synthetic graph yields >=2 levels with parent links
-- `test_hierarchical_max_levels_cap` - `max_levels = 1` produces only level 0, empty hierarchy
+- `test_hierarchical_two_tier_graph` - Two-tier graph: level 0 yields 4 sub-cliques and
+  level 1 merges them into exactly 2 outer communities, each containing >=2 sub-cliques
+- `test_hierarchical_max_levels_cap` - `max_levels = 1` produces only level 0, with
+  `hierarchy[0][id] = None` for every level-0 community (roots)
+- `test_super_graph_preserves_total_degree` - Super-graph contraction preserves total
+  weighted degree (intra-community edges become parallel self-loops, not dropped)
+- `test_summaries_distinct_across_levels` - Summaries do not collide across hierarchy
+  levels when community ids overlap
 
 ## References
 

--- a/graphrag-core/LEIDEN_INTEGRATION.md
+++ b/graphrag-core/LEIDEN_INTEGRATION.md
@@ -567,6 +567,30 @@ Total Score: (0.0 × 0.5) + (0.5 × 0.3) + (0.3 × 0.2) = 0.21
 
 ```
 
+## Hierarchy Construction
+
+Issue #94 added real multi-level community detection. Prior to that fix, the algorithm
+produced only level 0 (`HierarchicalCommunities.hierarchy` was empty) despite the
+`hierarchical_leiden` name and the `max_levels` config knob.
+
+Current behavior:
+
+1. Run a Leiden pass (local moving + refinement) on the input graph -> level 0 partition.
+2. Build a super-graph: one super-node per community; for every original edge whose endpoints
+   live in different communities add a super-edge between the corresponding super-nodes
+   (multi-edges preserved so unweighted super-node degree = original inter-community edge
+   count). Intra-community edges are dropped.
+3. Run a Leiden pass on the super-graph -> level 1 partition; project the result back onto the
+   original `NodeIndex` space and record parent links.
+4. Repeat until either `max_levels` is reached, the partition stops collapsing
+   (`#communities(level L) == #communities(level L-1)`), or the graph collapses to a single
+   community.
+
+`HierarchicalCommunities.hierarchy` is keyed as
+`HashMap<level, HashMap<community_id, Option<(parent_level, parent_community_id)>>>`.
+Walk leaf -> root by chasing the parent at each level. Top-level (root) communities have
+explicit `None` parents.
+
 ## Testing
 
 Run tests with:
@@ -574,10 +598,12 @@ Run tests with:
 cargo test --package graphrag-core --features leiden --lib graph::leiden
 ```
 
-All 3 tests passing:
+Tests:
 - `test_leiden_basic` - End-to-end algorithm
 - `test_is_well_connected` - Connectivity check
 - `test_config_defaults` - Configuration validation
+- `test_hierarchical_two_tier_graph` - Two-tier synthetic graph yields >=2 levels with parent links
+- `test_hierarchical_max_levels_cap` - `max_levels = 1` produces only level 0, empty hierarchy
 
 ## References
 

--- a/graphrag-core/examples/hierarchical_graphrag_demo.rs
+++ b/graphrag-core/examples/hierarchical_graphrag_demo.rs
@@ -196,11 +196,14 @@ fn main() -> graphrag_core::Result<()> {
     let mut communities_mut = communities;
     communities_mut.generate_hierarchical_summaries(&leiden_graph, 3);
 
-    println!("  Generated {} summaries", communities_mut.summaries.len());
+    let total_summaries: usize = communities_mut.summaries.values().map(|m| m.len()).sum();
+    println!("  Generated {} summaries", total_summaries);
 
-    for (community_id, summary) in &communities_mut.summaries {
-        println!("\n  Community {} summary:", community_id);
-        println!("    {}", summary);
+    for (level, level_summaries) in &communities_mut.summaries {
+        for (community_id, summary) in level_summaries {
+            println!("\n  Level {} Community {} summary:", level, community_id);
+            println!("    {}", summary);
+        }
     }
 
     // Step 7: Demonstrate adaptive query routing (NEW!)

--- a/graphrag-core/src/graph/leiden.rs
+++ b/graphrag-core/src/graph/leiden.rs
@@ -37,9 +37,10 @@ pub struct HierarchicalCommunities {
     /// Level 0 = finest granularity, higher = coarser
     pub levels: HashMap<usize, HashMap<NodeIndex, usize>>,
 
-    /// Parent-child relationships between levels
-    /// Maps community ID at level N to parent community ID at level N+1
-    pub hierarchy: HashMap<usize, Option<usize>>,
+    /// Parent-child community relationships across hierarchy levels.
+    /// `hierarchy[level][community_id]` = `Some((parent_level, parent_community_id))` for non-root
+    /// communities, or `None` for roots at the top level. Walk leaf -> root by chasing parents.
+    pub hierarchy: HashMap<usize, HashMap<usize, Option<(usize, usize)>>>,
 
     /// LLM-generated summaries for each community (optional)
     pub summaries: HashMap<usize, String>,
@@ -496,33 +497,113 @@ impl LeidenCommunityDetector {
         })
     }
 
-    /// Hierarchical Leiden algorithm implementation
+    /// Hierarchical Leiden: run leaf-level local moving + refine, then iteratively contract
+    /// the result into a super-graph (one node per community, multi-edges for inter-community
+    /// edges) and re-cluster until communities stop collapsing or `max_levels` is reached.
     fn hierarchical_leiden(
         &self,
         graph: &Graph<String, f32, Undirected>,
     ) -> Result<(
         HashMap<usize, HashMap<NodeIndex, usize>>,
-        HashMap<usize, Option<usize>>,
+        HashMap<usize, HashMap<usize, Option<(usize, usize)>>>,
     )> {
-        let mut levels = HashMap::new();
-        let hierarchy = HashMap::new();
+        let mut levels: HashMap<usize, HashMap<NodeIndex, usize>> = HashMap::new();
+        let mut hierarchy: HashMap<usize, HashMap<usize, Option<(usize, usize)>>> = HashMap::new();
 
-        let current_graph = graph.clone();
-        let level = 0;
+        // Run level 0 directly on the input graph.
+        let level0_communities = self.run_leiden_pass(graph)?;
+        levels.insert(0, level0_communities.clone());
 
-        // Phase 1: Initialize each node in its own community
-        let mut communities = self.initialize_communities(&current_graph);
+        if self.config.max_levels <= 1 {
+            return Ok((levels, hierarchy));
+        }
 
-        // Phase 2: Local moving (greedy modularity optimization)
+        // For each subsequent level we operate on a contracted super-graph and project the
+        // resulting community ids back onto the original NodeIndex space.
+        let mut prev_assignment = level0_communities; // original NodeIndex -> level-(L-1) community id
+        let mut prev_level = 0usize;
+
+        for level in 1..self.config.max_levels {
+            let unique_prev: HashSet<usize> = prev_assignment.values().copied().collect();
+            // Stop if previous level already collapsed below 2 communities — nothing left to group.
+            if unique_prev.len() < 2 {
+                break;
+            }
+
+            // Build super-graph: one node per prev-level community, multi-edges between
+            // communities preserve inter-community edge counts (used by the unweighted modularity
+            // calc to recover correct super-node degrees). Intra-community edges are dropped.
+            let (super_graph, super_to_prev_id) = build_super_graph(graph, &prev_assignment);
+
+            // Run a Leiden pass on the super-graph.
+            let super_communities = self.run_leiden_pass(&super_graph)?;
+            let unique_super: HashSet<usize> = super_communities.values().copied().collect();
+
+            // No further grouping happened (each super-node is still its own community) — stop.
+            if unique_super.len() == unique_prev.len() {
+                break;
+            }
+
+            // Project the super-graph partition back onto the original nodes:
+            //   prev_community_id -> super_community_id
+            let mut prev_to_super: HashMap<usize, usize> = HashMap::new();
+            for (super_node, &super_comm) in &super_communities {
+                if let Some(&prev_id) = super_to_prev_id.get(super_node) {
+                    prev_to_super.insert(prev_id, super_comm);
+                }
+            }
+
+            let mut level_assignment: HashMap<NodeIndex, usize> =
+                HashMap::with_capacity(prev_assignment.len());
+            for (&node, prev_id) in &prev_assignment {
+                if let Some(&new_id) = prev_to_super.get(prev_id) {
+                    level_assignment.insert(node, new_id);
+                }
+            }
+
+            // Record parent links for every prev-level community.
+            let parent_entry = hierarchy.entry(prev_level).or_default();
+            for (&prev_id, &new_id) in &prev_to_super {
+                parent_entry.insert(prev_id, Some((level, new_id)));
+            }
+
+            levels.insert(level, level_assignment.clone());
+            prev_assignment = level_assignment;
+            prev_level = level;
+
+            // If this level collapsed to a single community, it is the root — stop.
+            if unique_super.len() < 2 {
+                break;
+            }
+        }
+
+        // Top-level communities are roots: record explicit None parents so callers can detect them.
+        let top_level = *levels.keys().max().unwrap_or(&0);
+        if top_level > 0 {
+            let unique_top: HashSet<usize> = levels[&top_level].values().copied().collect();
+            let entry = hierarchy.entry(top_level).or_default();
+            for id in unique_top {
+                entry.entry(id).or_insert(None);
+            }
+        }
+
+        Ok((levels, hierarchy))
+    }
+
+    /// One Leiden pass (local moving + refinement) on the given graph.
+    fn run_leiden_pass(
+        &self,
+        graph: &Graph<String, f32, Undirected>,
+    ) -> Result<HashMap<NodeIndex, usize>> {
+        let mut communities = self.initialize_communities(graph);
+
         let mut improved = true;
         let mut iteration = 0;
         const MAX_ITERATIONS: usize = 100;
-
         while improved && iteration < MAX_ITERATIONS {
             improved = false;
-            for node in current_graph.node_indices() {
-                let best_community = self.find_best_community(&current_graph, node, &communities);
-
+            for node in graph.node_indices() {
+                let best_community = self.find_best_community(graph, node, &communities);
                 if best_community != communities[&node] {
                     communities.insert(node, best_community);
                     improved = true;
@@ -531,13 +612,8 @@ impl LeidenCommunityDetector {
             iteration += 1;
         }
 
-        // Phase 3: Refinement (KEY difference from Louvain)
-        communities = self.refine_partition(&current_graph, communities)?;
-
-        // Store this level
-        levels.insert(level, communities);
-
-        Ok((levels, hierarchy))
+        communities = self.refine_partition(graph, communities)?;
+        Ok(communities)
     }
 
     /// Initialize each node in its own community
@@ -780,6 +856,53 @@ impl LeidenCommunityDetector {
     }
 }
 
+/// Contract a graph by collapsing each community to a single super-node.
+///
+/// Recipe (standard Leiden / Louvain aggregation): one super-node per community in the
+/// `assignment`. For every original edge (u, v), if `assignment[u] != assignment[v]` add a new
+/// edge between the corresponding super-nodes; intra-community edges are dropped (they would
+/// only become self-loops and the existing modularity calc ignores them anyway). Multi-edges
+/// are preserved so the unweighted degree of each super-node equals the original
+/// inter-community edge count of its underlying community.
+///
+/// Returns the super-graph and a `super_node -> source_community_id` mapping the caller uses
+/// to project the next-level partition back onto the original nodes.
+fn build_super_graph(
+    graph: &Graph<String, f32, Undirected>,
+    assignment: &HashMap<NodeIndex, usize>,
+) -> (Graph<String, f32, Undirected>, HashMap<NodeIndex, usize>) {
+    let mut super_graph = Graph::new_undirected();
+    let mut comm_to_super: HashMap<usize, NodeIndex> = HashMap::new();
+    let mut super_to_comm: HashMap<NodeIndex, usize> = HashMap::new();
+
+    // Stable iteration over communities by sorted id keeps super-node ordering deterministic.
+    let mut comm_ids: Vec<usize> = assignment.values().copied().collect();
+    comm_ids.sort_unstable();
+    comm_ids.dedup();
+    for cid in comm_ids {
+        let super_node = super_graph.add_node(format!("c{cid}"));
+        comm_to_super.insert(cid, super_node);
+        super_to_comm.insert(super_node, cid);
+    }
+
+    for edge in graph.edge_references() {
+        use petgraph::visit::EdgeRef;
+        let a = edge.source();
+        let b = edge.target();
+        let (Some(&ca), Some(&cb)) = (assignment.get(&a), assignment.get(&b)) else {
+            continue;
+        };
+        if ca == cb {
+            continue;
+        }
+        let sa = comm_to_super[&ca];
+        let sb = comm_to_super[&cb];
+        super_graph.add_edge(sa, sb, *edge.weight());
+    }
+
+    (super_graph, super_to_comm)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -837,5 +960,113 @@ mod tests {
         assert_eq!(config.resolution, 1.0);
         assert_eq!(config.max_levels, 5);
         assert!(config.use_lcc);
+    }
+
+    /// Builds a synthetic two-tier graph: 2 outer cliques, each with 2 inner sub-cliques of 3 nodes.
+    /// Strong intra-sub-clique edges (10), medium intra-outer-clique bridge (3), weak inter-outer edge (1).
+    fn create_two_tier_graph() -> Graph<String, f32, Undirected> {
+        let mut graph = Graph::new_undirected();
+        let mut nodes = Vec::with_capacity(12);
+        for i in 0..12 {
+            nodes.push(graph.add_node(format!("N{i}")));
+        }
+        // Four sub-cliques of 3 nodes each: [0,1,2], [3,4,5], [6,7,8], [9,10,11]
+        let sub_cliques = [[0, 1, 2], [3, 4, 5], [6, 7, 8], [9, 10, 11]];
+        for sc in &sub_cliques {
+            for i in 0..sc.len() {
+                for j in (i + 1)..sc.len() {
+                    graph.add_edge(nodes[sc[i]], nodes[sc[j]], 10.0);
+                }
+            }
+        }
+        // Outer-clique bridges: sub-clique 0<->1 inside outer A; sub-clique 2<->3 inside outer B
+        graph.add_edge(nodes[2], nodes[3], 3.0);
+        graph.add_edge(nodes[1], nodes[4], 3.0);
+        graph.add_edge(nodes[8], nodes[9], 3.0);
+        graph.add_edge(nodes[7], nodes[10], 3.0);
+        // Single weak inter-outer-clique edge
+        graph.add_edge(nodes[5], nodes[6], 1.0);
+        graph
+    }
+
+    /// Two-tier graph yields >=2 levels with parent links connecting leaf communities to coarser ones.
+    #[test]
+    fn test_hierarchical_two_tier_graph() {
+        let graph = create_two_tier_graph();
+        let config = LeidenConfig {
+            seed: Some(42),
+            max_levels: 5,
+            ..Default::default()
+        };
+        let detector = LeidenCommunityDetector::new(config);
+
+        let result = detector
+            .detect_communities(&graph)
+            .expect("detection succeeds");
+
+        assert!(
+            result.levels.len() >= 2,
+            "expected >=2 levels, got {}: {:?}",
+            result.levels.len(),
+            result.levels.keys().collect::<Vec<_>>()
+        );
+
+        // At level 0, expect at least 2 distinct communities (the algorithm partitions the graph).
+        let level0_ids: HashSet<usize> = result.levels[&0].values().copied().collect();
+        assert!(
+            level0_ids.len() >= 2,
+            "expected level 0 to have >=2 communities, got {}",
+            level0_ids.len()
+        );
+
+        // The hierarchy must record parent links from level-0 communities up to level 1+.
+        let parented: usize = result
+            .hierarchy
+            .get(&0)
+            .map(|m| m.values().filter(|p| p.is_some()).count())
+            .unwrap_or(0);
+        assert!(
+            parented >= 2,
+            "expected at least 2 level-0 communities with parents, got {parented}",
+        );
+
+        // Top level must have all entries with no parent (roots).
+        let top_level = *result.levels.keys().max().unwrap();
+        if let Some(top_map) = result.hierarchy.get(&top_level) {
+            assert!(
+                top_map.values().all(|p| p.is_none()),
+                "top level entries should have no parent"
+            );
+        }
+    }
+
+    /// max_levels = 1 caps the algorithm at the leaf partition only.
+    #[test]
+    fn test_hierarchical_max_levels_cap() {
+        let graph = create_two_tier_graph();
+        let config = LeidenConfig {
+            seed: Some(42),
+            max_levels: 1,
+            ..Default::default()
+        };
+        let detector = LeidenCommunityDetector::new(config);
+
+        let result = detector
+            .detect_communities(&graph)
+            .expect("detection succeeds");
+
+        assert_eq!(
+            result.levels.len(),
+            1,
+            "expected exactly 1 level when max_levels=1"
+        );
+        // With only one level, hierarchy should be empty (no parents to record).
+        let parented: usize = result
+            .hierarchy
+            .values()
+            .flat_map(|m| m.values())
+            .filter(|p| p.is_some())
+            .count();
+        assert_eq!(parented, 0, "expected no parent links at max_levels=1");
     }
 }

--- a/graphrag-core/src/graph/leiden.rs
+++ b/graphrag-core/src/graph/leiden.rs
@@ -531,10 +531,11 @@ impl LeidenCommunityDetector {
         let level0_communities = self.run_leiden_pass(graph)?;
         levels.insert(0, level0_communities.clone());
 
-        if self.config.max_levels <= 1 {
-            return Ok((levels, hierarchy));
-        }
-
+        // When `max_levels <= 1`, skip the contraction loop but still fall through to the
+        // top-level root-recording pass below so callers see `hierarchy[0][id] = None` for
+        // every level-0 community (matching the documented contract on
+        // `HierarchicalCommunities::hierarchy`).
+        //
         // For each subsequent level we operate on a contracted super-graph and project the
         // resulting community ids back onto the original NodeIndex space.
         let mut prev_assignment = level0_communities; // original NodeIndex -> level-(L-1) community id
@@ -594,14 +595,14 @@ impl LeidenCommunityDetector {
             }
         }
 
-        // Top-level communities are roots: record explicit None parents so callers can detect them.
+        // Top-level communities are roots: always record explicit None parents so callers can
+        // detect them, regardless of whether the top is level 0 (single-level case from
+        // `max_levels = 1` or early termination) or a deeper level.
         let top_level = *levels.keys().max().unwrap_or(&0);
-        if top_level > 0 {
-            let unique_top: HashSet<usize> = levels[&top_level].values().copied().collect();
-            let entry = hierarchy.entry(top_level).or_default();
-            for id in unique_top {
-                entry.entry(id).or_insert(None);
-            }
+        let unique_top: HashSet<usize> = levels[&top_level].values().copied().collect();
+        let entry = hierarchy.entry(top_level).or_default();
+        for id in unique_top {
+            entry.entry(id).or_insert(None);
         }
 
         Ok((levels, hierarchy))
@@ -1077,7 +1078,8 @@ mod tests {
         }
     }
 
-    /// max_levels = 1 caps the algorithm at the leaf partition only.
+    /// max_levels = 1 caps the algorithm at the leaf partition only; the top level (level 0)
+    /// must still appear in `hierarchy` with `None` parents marking those communities as roots.
     #[test]
     fn test_hierarchical_max_levels_cap() {
         let graph = create_two_tier_graph();
@@ -1097,7 +1099,7 @@ mod tests {
             1,
             "expected exactly 1 level when max_levels=1"
         );
-        // With only one level, hierarchy should be empty (no parents to record).
+        // With only one level, no community has a parent (no level-1 to chase up to).
         let parented: usize = result
             .hierarchy
             .values()
@@ -1105,6 +1107,28 @@ mod tests {
             .filter(|p| p.is_some())
             .count();
         assert_eq!(parented, 0, "expected no parent links at max_levels=1");
+
+        // Level 0 communities must still be present in `hierarchy[0]` with `None` parents,
+        // marking them as roots — matching the contract documented on `HierarchicalCommunities`.
+        let cap_communities = result.hierarchy.get(&0).expect("level 0 hierarchy");
+        assert!(
+            !cap_communities.is_empty(),
+            "level 0 hierarchy entries should be recorded for roots when max_levels=1"
+        );
+        for parent in cap_communities.values() {
+            assert!(
+                parent.is_none(),
+                "level-0 communities must be roots when max_levels=1"
+            );
+        }
+        // Coverage: every community id present in `levels[0]` should appear in `hierarchy[0]`.
+        let level_0_ids: HashSet<usize> = result.levels[&0].values().copied().collect();
+        for id in &level_0_ids {
+            assert!(
+                cap_communities.contains_key(id),
+                "missing root entry for level-0 community {id}"
+            );
+        }
     }
 
     /// Summaries must not collide when communities at different levels share an id.

--- a/graphrag-core/src/graph/leiden.rs
+++ b/graphrag-core/src/graph/leiden.rs
@@ -1027,7 +1027,8 @@ mod tests {
         graph
     }
 
-    /// Two-tier graph yields >=2 levels with parent links connecting leaf communities to coarser ones.
+    /// Two-tier graph: level 0 must recover the four sub-cliques and level 1 must merge them
+    /// into exactly two outer cliques (each containing two sub-cliques).
     #[test]
     fn test_hierarchical_two_tier_graph() {
         let graph = create_two_tier_graph();
@@ -1049,7 +1050,7 @@ mod tests {
             result.levels.keys().collect::<Vec<_>>()
         );
 
-        // At level 0, expect at least 2 distinct communities (the algorithm partitions the graph).
+        // Level 0: must produce >=2 distinct communities (the algorithm partitions the graph).
         let level0_ids: HashSet<usize> = result.levels[&0].values().copied().collect();
         assert!(
             level0_ids.len() >= 2,
@@ -1057,25 +1058,50 @@ mod tests {
             level0_ids.len()
         );
 
-        // The hierarchy must record parent links from level-0 communities up to level 1+.
-        let parented: usize = result
-            .hierarchy
-            .get(&0)
-            .map(|m| m.values().filter(|p| p.is_some()).count())
-            .unwrap_or(0);
+        // Level 1: with two well-separated outer cliques, expect at least 2 outer
+        // communities at the next level — a buggy implementation that over-collapses to a
+        // single root in one step would otherwise pass.
+        let level_1 = result.levels.get(&1).expect("level 1 present");
+        let level1_ids: HashSet<usize> = level_1.values().copied().collect();
         assert!(
-            parented >= 2,
-            "expected at least 2 level-0 communities with parents, got {parented}",
+            level1_ids.len() >= 2,
+            "expected >=2 outer communities at level 1, got {}",
+            level1_ids.len()
         );
 
-        // Top level must have all entries with no parent (roots).
-        let top_level = *result.levels.keys().max().unwrap();
-        if let Some(top_map) = result.hierarchy.get(&top_level) {
+        // Group level-0 sub-cliques by their level-1 parent. The two outer cliques each
+        // contain two sub-cliques, so we expect exactly 2 parent groups, each holding >=2
+        // children.
+        let mut parent_groups: HashMap<usize, Vec<usize>> = HashMap::new();
+        for (&l0_id, parent) in result.hierarchy.get(&0).expect("level 0 hierarchy") {
+            if let Some((_, l1_id)) = parent {
+                parent_groups.entry(*l1_id).or_default().push(l0_id);
+            }
+        }
+        assert_eq!(
+            parent_groups.len(),
+            2,
+            "expected exactly 2 outer groups at level 1, got {} ({parent_groups:?})",
+            parent_groups.len()
+        );
+        for (parent_id, children) in &parent_groups {
             assert!(
-                top_map.values().all(|p| p.is_none()),
-                "top level entries should have no parent"
+                children.len() >= 2,
+                "outer community {parent_id} should contain >=2 sub-cliques, got {}",
+                children.len()
             );
         }
+
+        // Top level must have all entries with `None` parents (roots).
+        let top_level = *result.levels.keys().max().unwrap();
+        let top_map = result
+            .hierarchy
+            .get(&top_level)
+            .expect("top level hierarchy present");
+        assert!(
+            top_map.values().all(|p| p.is_none()),
+            "top level entries should have no parent"
+        );
     }
 
     /// max_levels = 1 caps the algorithm at the leaf partition only; the top level (level 0)

--- a/graphrag-core/src/graph/leiden.rs
+++ b/graphrag-core/src/graph/leiden.rs
@@ -42,8 +42,13 @@ pub struct HierarchicalCommunities {
     /// communities, or `None` for roots at the top level. Walk leaf -> root by chasing parents.
     pub hierarchy: HashMap<usize, HashMap<usize, Option<(usize, usize)>>>,
 
-    /// LLM-generated summaries for each community (optional)
-    pub summaries: HashMap<usize, String>,
+    /// LLM- or extractor-generated summaries for each community, keyed by hierarchy level.
+    ///
+    /// `summaries[level][community_id]` holds the summary for that community. Keying by
+    /// `(level, community_id)` is required because community ids can collide across levels:
+    /// a level-0 community and a level-1 community can both carry id `7`, so a flat
+    /// `HashMap<usize, String>` would let one overwrite the other.
+    pub summaries: HashMap<usize, HashMap<usize, String>>,
 
     /// Mapping from entity names to metadata (enriched from KnowledgeGraph)
     pub entity_mapping: Option<HashMap<String, EntityMetadata>>,
@@ -210,9 +215,19 @@ impl HierarchicalCommunities {
             for community_id in community_ids {
                 let summary =
                     self.generate_community_summary(level, community_id, graph, max_length);
-                self.summaries.insert(community_id, summary);
+                self.summaries
+                    .entry(level)
+                    .or_default()
+                    .insert(community_id, summary);
             }
         }
+    }
+
+    /// Look up the summary for a specific `(level, community_id)`.
+    pub fn get_summary(&self, level: usize, community_id: usize) -> Option<&String> {
+        self.summaries
+            .get(&level)
+            .and_then(|m| m.get(&community_id))
     }
 
     /// Generate summaries for all levels bottom-up
@@ -373,10 +388,12 @@ impl HierarchicalCommunities {
                     .any(|entity| entity.to_lowercase().contains(&query_lower));
 
                 if is_relevant {
-                    // Get or generate summary
+                    // Get or generate summary, keyed by (level, community_id) to avoid
+                    // cross-level id collisions.
                     let summary = self
                         .summaries
-                        .get(&community_id)
+                        .get(&level)
+                        .and_then(|m| m.get(&community_id))
                         .cloned()
                         .unwrap_or_else(|| {
                             // Fallback: create entity list
@@ -1088,6 +1105,48 @@ mod tests {
             .filter(|p| p.is_some())
             .count();
         assert_eq!(parented, 0, "expected no parent links at max_levels=1");
+    }
+
+    /// Summaries must not collide when communities at different levels share an id.
+    #[test]
+    fn test_summaries_distinct_across_levels() {
+        // Manually construct a HierarchicalCommunities with overlapping ids across levels.
+        let mut communities = HierarchicalCommunities {
+            levels: HashMap::new(),
+            hierarchy: HashMap::new(),
+            summaries: HashMap::new(),
+            entity_mapping: None,
+        };
+
+        // Level 0: a single community with id 0.
+        let mut l0 = HashMap::new();
+        l0.insert(NodeIndex::new(0), 0usize);
+        communities.levels.insert(0, l0);
+        // Level 1: a community also with id 0 (different community semantically).
+        let mut l1 = HashMap::new();
+        l1.insert(NodeIndex::new(0), 0usize);
+        communities.levels.insert(1, l1);
+
+        // Insert distinct summaries for the colliding ids.
+        communities
+            .summaries
+            .entry(0)
+            .or_default()
+            .insert(0, "level-0 summary".to_string());
+        communities
+            .summaries
+            .entry(1)
+            .or_default()
+            .insert(0, "level-1 summary".to_string());
+
+        let s0 = communities.get_summary(0, 0).expect("level 0 summary");
+        let s1 = communities.get_summary(1, 0).expect("level 1 summary");
+        assert_ne!(
+            s0, s1,
+            "summaries collided across levels: l0={s0:?}, l1={s1:?}"
+        );
+        assert_eq!(s0, "level-0 summary");
+        assert_eq!(s1, "level-1 summary");
     }
 
     /// Total weighted degree must be preserved across super-graph contractions; intra-community

--- a/graphrag-core/src/graph/leiden.rs
+++ b/graphrag-core/src/graph/leiden.rs
@@ -809,7 +809,12 @@ impl LeidenCommunityDetector {
         delta
     }
 
-    /// Count edges from node to a specific community
+    /// Count edges from `node` to *other* nodes in `community`.
+    ///
+    /// Self-loops are excluded: when a super-graph node carries self-loops representing
+    /// internal edges of an aggregated community, those edges always travel with the node
+    /// across moves, so they do not contribute to "edges to community members" in either
+    /// the source or destination side of a modularity-delta calculation.
     fn edges_to_community(
         &self,
         graph: &Graph<String, f32, Undirected>,
@@ -819,7 +824,7 @@ impl LeidenCommunityDetector {
     ) -> usize {
         graph
             .neighbors(node)
-            .filter(|&neighbor| communities.get(&neighbor) == Some(&community))
+            .filter(|&neighbor| neighbor != node && communities.get(&neighbor) == Some(&community))
             .count()
     }
 
@@ -859,11 +864,18 @@ impl LeidenCommunityDetector {
 /// Contract a graph by collapsing each community to a single super-node.
 ///
 /// Recipe (standard Leiden / Louvain aggregation): one super-node per community in the
-/// `assignment`. For every original edge (u, v), if `assignment[u] != assignment[v]` add a new
-/// edge between the corresponding super-nodes; intra-community edges are dropped (they would
-/// only become self-loops and the existing modularity calc ignores them anyway). Multi-edges
-/// are preserved so the unweighted degree of each super-node equals the original
-/// inter-community edge count of its underlying community.
+/// `assignment`. For every original edge (u, v):
+///   - If `assignment[u] != assignment[v]` add an inter-community edge between the
+///     corresponding super-nodes.
+///   - If `assignment[u] == assignment[v]` add **two parallel self-loops** on the super-node.
+///     Petgraph counts each self-loop once in `edges(n).count()`, so two parallel self-loops
+///     contribute 2 to the super-node's edge count — exactly matching the contribution of the
+///     original intra-community edge to `sum_n edges(n).count()` (1 to each endpoint). This
+///     preserves total weighted/unweighted degree across contractions, which is required for
+///     the modularity calculation to remain consistent across hierarchy levels.
+///
+/// Multi-edges and self-loops are preserved so the unweighted degree of each super-node equals
+/// the sum of original edge endpoints attached to its underlying community.
 ///
 /// Returns the super-graph and a `super_node -> source_community_id` mapping the caller uses
 /// to project the next-level partition back onto the original nodes.
@@ -893,11 +905,16 @@ fn build_super_graph(
             continue;
         };
         if ca == cb {
-            continue;
+            // Intra-community edge: add two parallel self-loops to preserve total degree
+            // under petgraph's edges(n).count() semantics (each self-loop counted once).
+            let s = comm_to_super[&ca];
+            super_graph.add_edge(s, s, *edge.weight());
+            super_graph.add_edge(s, s, *edge.weight());
+        } else {
+            let sa = comm_to_super[&ca];
+            let sb = comm_to_super[&cb];
+            super_graph.add_edge(sa, sb, *edge.weight());
         }
-        let sa = comm_to_super[&ca];
-        let sb = comm_to_super[&cb];
-        super_graph.add_edge(sa, sb, *edge.weight());
     }
 
     (super_graph, super_to_comm)
@@ -962,8 +979,11 @@ mod tests {
         assert!(config.use_lcc);
     }
 
-    /// Builds a synthetic two-tier graph: 2 outer cliques, each with 2 inner sub-cliques of 3 nodes.
-    /// Strong intra-sub-clique edges (10), medium intra-outer-clique bridge (3), weak inter-outer edge (1).
+    /// Builds a synthetic two-tier graph: 2 outer cliques, each containing 2 inner sub-cliques
+    /// of 3 nodes. Strong intra-sub-clique edges dominate at level 0 so the leaf partition
+    /// recovers the four sub-cliques; sparse intra-outer bridges (2 per outer-pair) plus a
+    /// single weak inter-outer edge make level-1 contraction merge same-outer sub-cliques
+    /// without merging across outers.
     fn create_two_tier_graph() -> Graph<String, f32, Undirected> {
         let mut graph = Graph::new_undirected();
         let mut nodes = Vec::with_capacity(12);
@@ -1068,5 +1088,27 @@ mod tests {
             .filter(|p| p.is_some())
             .count();
         assert_eq!(parented, 0, "expected no parent links at max_levels=1");
+    }
+
+    /// Total weighted degree must be preserved across super-graph contractions; intra-community
+    /// edges become self-loops on super-nodes rather than being dropped.
+    #[test]
+    fn test_super_graph_preserves_total_degree() {
+        let g = create_two_tier_graph();
+        let degree_g: usize = g.node_indices().map(|n| g.edges(n).count()).sum();
+
+        // Partition: assign each node deterministically to a community matching its sub-clique.
+        let mut partition: HashMap<NodeIndex, usize> = HashMap::new();
+        for (idx, node) in g.node_indices().enumerate() {
+            partition.insert(node, idx / 3); // 4 sub-cliques of 3 nodes
+        }
+
+        let (sg, _) = build_super_graph(&g, &partition);
+        let degree_sg: usize = sg.node_indices().map(|n| sg.edges(n).count()).sum();
+
+        assert_eq!(
+            degree_g, degree_sg,
+            "super-graph dropped edges: g={degree_g}, sg={degree_sg}"
+        );
     }
 }

--- a/graphrag-wasm/src/lib.rs
+++ b/graphrag-wasm/src/lib.rs
@@ -564,18 +564,29 @@ impl GraphRAG {
             .map_err(|e| JsValue::from_str(&format!("JSON serialization failed: {}", e)))
     }
 
-    /// Get summary for a specific community
-    pub fn get_community_summary(&self, community_id: usize) -> Result<String, JsValue> {
+    /// Get summary for a specific community at a given hierarchy level.
+    ///
+    /// Summaries are keyed by `(level, community_id)` to avoid id collisions across
+    /// hierarchy levels.
+    pub fn get_community_summary(
+        &self,
+        level: usize,
+        community_id: usize,
+    ) -> Result<String, JsValue> {
         let communities = self
             .hierarchical_communities
             .as_ref()
             .ok_or_else(|| JsValue::from_str("No communities detected"))?;
 
         communities
-            .summaries
-            .get(&community_id)
+            .get_summary(level, community_id)
             .cloned()
-            .ok_or_else(|| JsValue::from_str(&format!("No summary for community {}", community_id)))
+            .ok_or_else(|| {
+                JsValue::from_str(&format!(
+                    "No summary for community {} at level {}",
+                    community_id, level
+                ))
+            })
     }
 
     /// Get all community summaries as JSON


### PR DESCRIPTION
## Summary

Closes **#94** — \`hierarchical_leiden\` now produces a real multi-level hierarchy instead of just level 0. Iterative super-graph contraction runs Leiden on the contracted graph until \`max_levels\` is reached, the partition stops collapsing, or a single community remains.

This unblocks #95 (LLM community reports) and #93 (Global Search), both of which require multi-level community structure.

## Implementation

- After level 0 stabilizes, contract each community to a single super-node and aggregate edges.
- Re-run Leiden on the super-graph for level 1; repeat.
- \`hierarchy[level][community_id] = Some((parent_level, parent_id))\` lets callers walk leaf → root; \`None\` marks roots.
- Stop conditions: \`max_levels\` (default 5), partition non-collapse (\`#communities(L) == #communities(L-1)\`), single-community root.

## Review fixes (codex + gemini)

### CRITICAL

- **fix(core/graph): preserve self-loops in super-graph contraction** — codex P1 (conf 0.97) + gemini agreement. Initial implementation dropped intra-community edges (\`if ca == cb { continue; }\`). The standard Leiden recipe **must** preserve them as self-loops to keep total weighted degree (\`2m\`) invariant across levels — otherwise level-1+ modularity calc is broken and clusters over-merge.
  
  Companion fix in \`edges_to_community\`: filter out the moving node itself when counting neighbors-in-community, so self-loops travel with the moving node rather than appearing as already-in-community attachment. Without this, level-1 refused all merges. Confirmed by \`test_super_graph_preserves_total_degree\` which originally showed \`g=34, sg=10\`; now \`g=34, sg=34\`.

- **fix(core/graph): re-key community summaries by (level, id)** — codex P2 (conf 0.95). With multi-level output now enabled, the flat \`HashMap<community_id, String>\` collides across levels (a level-0 query could return a level-1 summary). Re-keyed to \`HashMap<level, HashMap<community_id, String>>\` with \`get_summary(level, id)\` accessor. Updated read sites in \`retrieve_at_level\`, \`graphrag-wasm/src/lib.rs::get_community_summary\` (now takes \`level, community_id\`), and the \`hierarchical_graphrag_demo\` example.

### Other

- **fix(core/graph): record None parents for top-level roots in single-level case** — gemini. Removed the \`top_level > 0\` guard so even \`max_levels = 1\` produces a populated \`hierarchy[0]\` with \`None\` parents, matching the docstring.
- **test(core/graph): tighten two-tier hierarchy assertions** — codex P3. The original \`levels.len() >= 2\` assertion would have passed an over-collapsing buggy implementation. Now asserts \`level_1.len() >= 2\`, exactly 2 outer-clique parents, and ≥2 sub-cliques per outer.
- **docs(core/graph): document #94 review breaking changes and new tests** — \`LEIDEN_INTEGRATION.md\` calls out the \`hierarchy\`, \`summaries\`, and \`get_community_summary\` shape changes.

## BREAKING CHANGES

- \`HierarchicalCommunities.hierarchy\` field type: \`HashMap<usize, Option<usize>>\` → \`HashMap<usize, HashMap<usize, Option<(usize, usize)>>>\` (level → community_id → \`Option<(parent_level, parent_id)>\`)
- \`HierarchicalCommunities.summaries\` field type: \`HashMap<usize, String>\` → \`HashMap<usize, HashMap<usize, String>>\`. Use the new \`get_summary(level, community_id)\` accessor.
- \`graphrag-wasm::get_community_summary\` now takes \`(level: usize, community_id: usize)\`.

## Test plan

- [x] \`cargo fmt --all\` clean
- [x] \`cargo build -p graphrag-core --features leiden,async\` clean
- [x] \`cargo build --example hierarchical_graphrag_demo\` clean
- [x] \`cargo build -p graphrag-wasm\` clean
- [x] \`cargo nextest run -p graphrag-core --features leiden --lib\` — 415 passed, 12 skipped (was 412)
- [x] All 7 leiden tests green: 4 new (\`test_super_graph_preserves_total_degree\`, \`test_summaries_distinct_across_levels\`, \`test_hierarchical_two_tier_graph\`, \`test_hierarchical_max_levels_cap\`) + 3 pre-existing

## Out of scope

- LLM-driven community reports for the new levels (#95)
- Global Search (#93)
- Modularity calc is currently unweighted (\`graph.edges(node).count()\`); a weighted-modularity rewrite is a separate, larger change

Closes #94