### PR TITLE
feat(core): wire configured embedder + ServiceRegistry consumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,7 +461,10 @@ See [config_example.toml](config_example.toml) for detailed explanations of all 
 
 ### Embedding Providers Configuration
 
-GraphRAG Core supports **8 embedding providers** for maximum flexibility:
+GraphRAG Core supports **8 embedding providers** for maximum flexibility. The
+`backend` setting is now consumed end-to-end: ingestion and query-time embeddings
+both go through the configured provider, with hash fallback if
+`fallback_to_hash = true`.
 
 ```toml
 [embeddings]
@@ -473,15 +476,39 @@ backend = "huggingface"  # Free, offline (default)
 # backend = "mistral"    # RAG-optimized
 # backend = "together"   # Cheapest ($0.008/1M)
 # backend = "ollama"     # Local GPU
+# backend = "hash"       # In-memory hash fallback (no I/O, deterministic)
 
 model = "sentence-transformers/all-MiniLM-L6-v2"
 dimension = 384
 batch_size = 32
 cache_dir = "~/.cache/huggingface"
 
+# Graceful degradation when the API is unreachable.
+fallback_to_hash = true
+
 # For API providers, set api_key or use environment variables
 # api_key = "your-key"  # Or set OPENAI_API_KEY, VOYAGE_API_KEY, etc.
 ```
+
+For programmatic injection of a custom embedder (e.g., a Candle/ONNX model
+or a test stub), use the registry path instead of (or alongside) the
+backend string:
+
+```rust
+use graphrag_core::core::registry::RegistryBuilder;
+use graphrag_core::{Config, GraphRAG};
+
+let registry = RegistryBuilder::new()
+    .with_async_embedder(my_custom_embedder)
+    .with_chat_backend(my_chat_backend) // optional
+    .build();
+
+let mut graphrag = GraphRAG::new_with_registry(Config::default(), registry)?;
+graphrag.initialize()?;
+```
+
+The registry-injected embedder wins over `config.embeddings.backend` when both
+are set; otherwise the factory dispatches on `backend`.
 
 **Provider Comparison:**
 

--- a/graphrag-core/src/core/registry.rs
+++ b/graphrag-core/src/core/registry.rs
@@ -3,6 +3,7 @@
 //! This module provides a dependency injection system that allows
 //! components to be swapped out for testing or different implementations.
 
+use crate::core::backend::DynChatBackend;
 use crate::core::traits::*;
 use crate::core::{GraphRAGError, Result};
 use std::any::{Any, TypeId};
@@ -12,9 +13,22 @@ use std::sync::Arc;
 /// Type-erased service container
 type ServiceBox = Box<dyn Any + Send + Sync>;
 
-/// Service registry for dependency injection
+/// Type alias for an async embedder trait object usable from the registry.
+/// Errors are pinned to `GraphRAGError` so consumers don't have to thread a
+/// generic `E` through every call site.
+pub type DynAsyncEmbedder = Arc<dyn AsyncEmbedder<Error = GraphRAGError> + Send + Sync>;
+
+/// Service registry for dependency injection.
+///
+/// Holds a generic `TypeId`-keyed map for arbitrary services plus typed slots
+/// for the two implementations `GraphRAG::new_with_registry` consults at
+/// construction time (`Embedder`, `ChatBackend`). The typed slots exist
+/// because `Arc<dyn Trait>` is hard to look up generically through a
+/// `TypeId` map across crate boundaries.
 pub struct ServiceRegistry {
     services: HashMap<TypeId, ServiceBox>,
+    embedder: Option<DynAsyncEmbedder>,
+    chat_backend: Option<DynChatBackend>,
 }
 
 impl ServiceRegistry {
@@ -22,6 +36,8 @@ impl ServiceRegistry {
     pub fn new() -> Self {
         Self {
             services: HashMap::new(),
+            embedder: None,
+            chat_backend: None,
         }
     }
 
@@ -29,6 +45,31 @@ impl ServiceRegistry {
     pub fn register<T: Any + Send + Sync>(&mut self, service: T) {
         let type_id = TypeId::of::<T>();
         self.services.insert(type_id, Box::new(service));
+    }
+
+    /// Inject a pre-built async embedder. Consumed by
+    /// [`crate::GraphRAG::new_with_registry`] to override
+    /// `config.embeddings.backend` selection.
+    pub fn set_async_embedder(&mut self, embedder: DynAsyncEmbedder) {
+        self.embedder = Some(embedder);
+    }
+
+    /// Get the injected async embedder, if any.
+    pub fn async_embedder(&self) -> Option<&DynAsyncEmbedder> {
+        self.embedder.as_ref()
+    }
+
+    /// Inject a chat backend used by `ask` / `ask_explained` for the final
+    /// answer-generation step. Replaces the legacy
+    /// `GraphRAG::set_chat_backend` field but is also used as that method's
+    /// storage so existing callers keep working.
+    pub fn set_chat_backend(&mut self, backend: DynChatBackend) {
+        self.chat_backend = Some(backend);
+    }
+
+    /// Get the injected chat backend, if any.
+    pub fn chat_backend(&self) -> Option<&DynChatBackend> {
+        self.chat_backend.as_ref()
     }
 
     /// Get a service by type
@@ -127,6 +168,31 @@ impl RegistryBuilder {
         E: Embedder + Any + Send + Sync,
     {
         self.registry.register(embedder);
+        self
+    }
+
+    /// Register an async embedder. Stored in the registry's typed slot so
+    /// [`crate::GraphRAG::new_with_registry`] can consult it directly without
+    /// guessing a concrete type.
+    pub fn with_async_embedder<E>(mut self, embedder: E) -> Self
+    where
+        E: AsyncEmbedder<Error = GraphRAGError> + Send + Sync + 'static,
+    {
+        self.registry.set_async_embedder(Arc::new(embedder));
+        self
+    }
+
+    /// Register an async embedder already wrapped in `Arc`. Useful for
+    /// sharing a single instance across multiple `ServiceRegistry`s.
+    pub fn with_async_embedder_arc(mut self, embedder: DynAsyncEmbedder) -> Self {
+        self.registry.set_async_embedder(embedder);
+        self
+    }
+
+    /// Register a chat backend used for final answer synthesis in `ask` /
+    /// `ask_explained`.
+    pub fn with_chat_backend(mut self, backend: DynChatBackend) -> Self {
+        self.registry.set_chat_backend(backend);
         self
     }
 

--- a/graphrag-core/src/core/registry.rs
+++ b/graphrag-core/src/core/registry.rs
@@ -67,6 +67,16 @@ impl ServiceRegistry {
         self.chat_backend = Some(backend);
     }
 
+    /// Clear the injected chat backend without touching any other
+    /// registered services. Used by `GraphRAG::set_chat_backend(None)` to
+    /// preserve the rest of the registry (issue #6 review). The previous
+    /// implementation rebuilt a fresh `ServiceRegistry` and only copied
+    /// the embedder slot, silently dropping anything registered through
+    /// the generic `register/get` map (Storage, Retriever, ...).
+    pub fn clear_chat_backend(&mut self) {
+        self.chat_backend = None;
+    }
+
     /// Get the injected chat backend, if any.
     pub fn chat_backend(&self) -> Option<&DynChatBackend> {
         self.chat_backend.as_ref()

--- a/graphrag-core/src/embeddings/factory.rs
+++ b/graphrag-core/src/embeddings/factory.rs
@@ -83,6 +83,10 @@ where
 ///   `"mistral"`, `"together"`) go through `HttpEmbeddingProvider`,
 ///   which already handles auth headers + the sync-`ureq`-on-blocking
 ///   pool dance described in `embeddings/api_providers.rs`.
+/// - `"huggingface"` / `"hf"` returns an explicit error: the local-model
+///   path (`embeddings/huggingface.rs`) is not yet wired into factory
+///   dispatch. Users wanting HF must inject the embedder via
+///   `RegistryBuilder::with_async_embedder` or pick a different backend.
 pub fn build_async_embedder(config: &RuntimeEmbeddingConfig) -> Result<Option<DynAsyncEmbedder>> {
     let backend = config.backend.to_lowercase();
 
@@ -111,7 +115,7 @@ pub fn build_async_embedder(config: &RuntimeEmbeddingConfig) -> Result<Option<Dy
 
         "openai" | "voyage" | "voyageai" | "voyage-ai" | "cohere" | "jina" | "jinaai"
         | "jina-ai" | "mistral" | "mistralai" | "mistral-ai" | "together" | "togetherai"
-        | "together-ai" | "huggingface" | "hf" => {
+        | "together-ai" => {
             #[cfg(feature = "ureq")]
             {
                 let provider_cfg = EmbeddingProviderConfig {
@@ -148,9 +152,30 @@ pub fn build_async_embedder(config: &RuntimeEmbeddingConfig) -> Result<Option<Dy
             }
         }
 
+        // HuggingFace is *not* an HTTP API provider — it requires a local
+        // model download + Candle inference (see `embeddings/huggingface.rs`)
+        // gated behind the `huggingface-hub` and `neural-embeddings`
+        // features. Routing it through `HttpEmbeddingProvider` was the
+        // previous behavior; it produced confusing "API key required" or
+        // "Unsupported API provider" errors and, when paired with
+        // `fallback_to_hash = true`, silently downgraded HF configs to
+        // hash embeddings without telling the user (issue #91 review).
+        // Until the local-model path is wired into the factory, fail fast
+        // with an explicit, actionable error.
+        "huggingface" | "hf" => Err(GraphRAGError::Config {
+            message: "embeddings.backend=\"huggingface\" is not yet wired into the factory \
+                      dispatch. The `huggingface` feature provides \
+                      `crate::embeddings::huggingface::HuggingFaceEmbeddings` for direct use, \
+                      but it requires `huggingface-hub` + `neural-embeddings` features and a \
+                      local model download. Choose `ollama` or one of the HTTP API backends \
+                      (`openai`, `voyage`, `cohere`, `jina`, `mistral`, `together`) instead, \
+                      or inject a custom embedder via `RegistryBuilder::with_async_embedder`."
+                .to_string(),
+        }),
+
         other => Err(GraphRAGError::Config {
             message: format!(
-                "Unknown embeddings.backend \"{}\". Expected one of: hash, ollama, openai, voyage, cohere, jina, mistral, together, huggingface",
+                "Unknown embeddings.backend \"{}\". Expected one of: hash, ollama, openai, voyage, cohere, jina, mistral, together",
                 other
             ),
         }),

--- a/graphrag-core/src/embeddings/factory.rs
+++ b/graphrag-core/src/embeddings/factory.rs
@@ -1,0 +1,165 @@
+//! Build an [`AsyncEmbedder`] from `config.embeddings`.
+//!
+//! Two-tier dispatch: the registry's pre-injected embedder (if any) wins;
+//! otherwise the `backend` string in [`crate::config::EmbeddingConfig`]
+//! selects between hash, Ollama, and HTTP API providers. Errors that
+//! surface during construction propagate; runtime errors during `embed`
+//! are handled separately by `RetrievalSystem` so it can honour
+//! `fallback_to_hash`.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::config::EmbeddingConfig as RuntimeEmbeddingConfig;
+use crate::core::error::{GraphRAGError, Result};
+use crate::core::registry::DynAsyncEmbedder;
+use crate::core::traits::AsyncEmbedder;
+
+#[cfg(feature = "ureq")]
+use crate::embeddings::api_providers::HttpEmbeddingProvider;
+#[cfg(feature = "ureq")]
+use crate::embeddings::config::EmbeddingProviderConfig;
+#[cfg(feature = "ollama")]
+use crate::embeddings::ollama::OllamaEmbeddings;
+use crate::embeddings::EmbeddingProvider;
+
+/// Adapter exposing an [`EmbeddingProvider`] as an [`AsyncEmbedder`].
+///
+/// `EmbeddingProvider` (provider-specific trait, lives in `embeddings/`)
+/// returns provider-typed errors via `GraphRAGError`. `AsyncEmbedder`
+/// (registry-facing trait, lives in `core/traits.rs`) is the one
+/// `ServiceRegistry` and `RetrievalSystem` understand. This adapter bridges
+/// them so the factory can produce a single canonical type.
+pub struct EmbeddingProviderAdapter<P: EmbeddingProvider + ?Sized> {
+    inner: Arc<P>,
+}
+
+impl<P: EmbeddingProvider + ?Sized> EmbeddingProviderAdapter<P> {
+    /// Wrap a shared embedding provider as an `AsyncEmbedder`.
+    pub fn new(inner: Arc<P>) -> Self {
+        Self { inner }
+    }
+}
+
+#[async_trait]
+impl<P> AsyncEmbedder for EmbeddingProviderAdapter<P>
+where
+    P: EmbeddingProvider + ?Sized + Send + Sync + 'static,
+{
+    type Error = GraphRAGError;
+
+    async fn embed(&self, text: &str) -> Result<Vec<f32>> {
+        self.inner.embed(text).await
+    }
+
+    async fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+        self.inner.embed_batch(texts).await
+    }
+
+    fn dimension(&self) -> usize {
+        self.inner.dimensions()
+    }
+
+    async fn is_ready(&self) -> bool {
+        self.inner.is_available()
+    }
+}
+
+/// Build an [`AsyncEmbedder`] from `config.embeddings.backend`.
+///
+/// Returns `Ok(Some(_))` for backends that produce a real embedder,
+/// `Ok(None)` for `"hash"` (caller should use the in-memory hash
+/// generator), and `Err(_)` if the configured backend cannot be
+/// constructed (missing API key, unsupported feature flags, etc.).
+///
+/// Each branch exists for a different reason:
+/// - `"hash"` returns `None` so `RetrievalSystem` keeps using
+///   `EmbeddingGenerator` (no allocation, no I/O, deterministic for
+///   tests).
+/// - `"ollama"` builds a local-network embedder pointed at Ollama;
+///   needs the `ollama` feature.
+/// - HTTP providers (`"openai"`, `"voyage"`, `"cohere"`, `"jina"`,
+///   `"mistral"`, `"together"`) go through `HttpEmbeddingProvider`,
+///   which already handles auth headers + the sync-`ureq`-on-blocking
+///   pool dance described in `embeddings/api_providers.rs`.
+pub fn build_async_embedder(config: &RuntimeEmbeddingConfig) -> Result<Option<DynAsyncEmbedder>> {
+    let backend = config.backend.to_lowercase();
+
+    match backend.as_str() {
+        "hash" => Ok(None),
+
+        "ollama" => {
+            #[cfg(feature = "ollama")]
+            {
+                let model = config.model.clone().unwrap_or_else(|| {
+                    "nomic-embed-text".to_string()
+                });
+                let dim = config.dimension.max(1);
+                let provider = OllamaEmbeddings::new(model).with_dimensions(dim);
+                let arc: Arc<dyn EmbeddingProvider> = Arc::new(provider);
+                Ok(Some(Arc::new(EmbeddingProviderAdapter::new(arc))))
+            }
+            #[cfg(not(feature = "ollama"))]
+            {
+                Err(GraphRAGError::Config {
+                    message: "embeddings.backend=\"ollama\" requires the `ollama` feature"
+                        .to_string(),
+                })
+            }
+        }
+
+        "openai" | "voyage" | "voyageai" | "voyage-ai" | "cohere" | "jina" | "jinaai"
+        | "jina-ai" | "mistral" | "mistralai" | "mistral-ai" | "together" | "togetherai"
+        | "together-ai" | "huggingface" | "hf" => {
+            #[cfg(feature = "ureq")]
+            {
+                let provider_cfg = EmbeddingProviderConfig {
+                    provider: backend.clone(),
+                    model: config
+                        .model
+                        .clone()
+                        .unwrap_or_else(default_model_for_backend),
+                    api_key: config.api_key.clone(),
+                    cache_dir: config.cache_dir.clone(),
+                    batch_size: config.batch_size,
+                    dimensions: Some(config.dimension),
+                };
+                let embedding_cfg = provider_cfg.to_embedding_config()?;
+
+                let provider = HttpEmbeddingProvider::from_config(&embedding_cfg)?;
+                let provider = if let Some(endpoint) = config.api_endpoint.as_deref() {
+                    provider.with_endpoint_for_tests(endpoint)
+                } else {
+                    provider
+                };
+                let arc: Arc<dyn EmbeddingProvider> = Arc::new(provider);
+                Ok(Some(Arc::new(EmbeddingProviderAdapter::new(arc))))
+            }
+            #[cfg(not(feature = "ureq"))]
+            {
+                let _ = backend;
+                Err(GraphRAGError::Config {
+                    message: format!(
+                        "embeddings.backend=\"{}\" requires the `ureq` feature",
+                        config.backend
+                    ),
+                })
+            }
+        }
+
+        other => Err(GraphRAGError::Config {
+            message: format!(
+                "Unknown embeddings.backend \"{}\". Expected one of: hash, ollama, openai, voyage, cohere, jina, mistral, together, huggingface",
+                other
+            ),
+        }),
+    }
+}
+
+fn default_model_for_backend() -> String {
+    // Fallback model when a backend is configured without an explicit model.
+    // Most users will set `[embeddings.model]` themselves; this keeps the
+    // factory total rather than panicking.
+    "text-embedding-3-small".to_string()
+}

--- a/graphrag-core/src/embeddings/mod.rs
+++ b/graphrag-core/src/embeddings/mod.rs
@@ -22,6 +22,10 @@ pub mod ollama;
 /// TOML configuration for embedding providers
 pub mod config;
 
+/// Build an `AsyncEmbedder` from `config.embeddings.backend` (factory dispatch).
+#[cfg(feature = "async")]
+pub mod factory;
+
 /// Trait for embedding providers
 #[async_trait::async_trait]
 pub trait EmbeddingProvider: Send + Sync {

--- a/graphrag-core/src/lib.rs
+++ b/graphrag-core/src/lib.rs
@@ -363,15 +363,12 @@ impl GraphRAG {
         if let Some(b) = backend {
             self.registry.set_chat_backend(b);
         } else {
-            // Drop any previously-injected backend by replacing the registry
-            // (the typed slot has no public `clear` to keep the surface small).
-            let mut new_reg = core::registry::ServiceRegistry::default();
-            // Preserve the embedder slot if one was injected, since that's
-            // the other typed slot consumers care about.
-            if let Some(emb) = self.registry.async_embedder().cloned() {
-                new_reg.set_async_embedder(emb);
-            }
-            self.registry = new_reg;
+            // Null only the chat-backend slot. The previous implementation
+            // rebuilt the entire `ServiceRegistry` and copied just the
+            // embedder, which silently dropped anything else the user
+            // had registered through `register/get` (Storage, Retriever,
+            // ...). See `ServiceRegistry::clear_chat_backend` (#6 review).
+            self.registry.clear_chat_backend();
         }
     }
 

--- a/graphrag-core/src/lib.rs
+++ b/graphrag-core/src/lib.rs
@@ -290,16 +290,55 @@ pub struct GraphRAG {
     #[cfg(feature = "parallel-processing")]
     #[allow(dead_code)]
     parallel_processor: Option<parallel::ParallelProcessor>,
-    /// Optional override for chat-completion calls. When set, the built-in
-    /// Ollama client is bypassed for the final answer-generation step in
-    /// `ask` and `ask_explained`. See [`core::backend::ChatBackend`].
+    /// Service registry for dependency injection. The registry's typed slots
+    /// (`embedder`, `chat_backend`) are consulted at construction time:
+    /// - `embedder` overrides `config.embeddings.backend` selection in
+    ///   `RetrievalSystem` (issue #91 / #6).
+    /// - `chat_backend` overrides Ollama for final answer synthesis. The
+    ///   legacy `set_chat_backend` setter routes through this slot.
     #[cfg(feature = "async")]
-    chat_backend: Option<core::backend::DynChatBackend>,
+    registry: core::registry::ServiceRegistry,
 }
 
 impl GraphRAG {
-    /// Create a new GraphRAG instance with the given configuration
+    /// Create a new GraphRAG instance with the given configuration. Equivalent
+    /// to [`GraphRAG::new_with_registry`] called with an empty registry, so
+    /// behavior matches every previous release for callers that don't inject
+    /// custom services.
     pub fn new(config: Config) -> Result<Self> {
+        #[cfg(feature = "async")]
+        {
+            Self::new_with_registry(config, core::registry::ServiceRegistry::default())
+        }
+        #[cfg(not(feature = "async"))]
+        {
+            Ok(Self {
+                config,
+                knowledge_graph: None,
+                retrieval_system: None,
+                query_planner: None,
+                critic: None,
+                #[cfg(feature = "parallel-processing")]
+                parallel_processor: None,
+            })
+        }
+    }
+
+    /// Create a new GraphRAG instance and consult `registry` for custom
+    /// service implementations (issue #6). At construction time the registry
+    /// is used for two slots:
+    /// - `Embedder` (via `RegistryBuilder::with_async_embedder`): wins over
+    ///   `config.embeddings.backend` when set.
+    /// - `ChatBackend` (via `RegistryBuilder::with_chat_backend`): replaces
+    ///   the built-in Ollama client for final answer synthesis.
+    ///
+    /// Other registry slots (`Storage`, `Retriever`) are accepted but not
+    /// yet wired through; see follow-up issues.
+    #[cfg(feature = "async")]
+    pub fn new_with_registry(
+        config: Config,
+        registry: core::registry::ServiceRegistry,
+    ) -> Result<Self> {
         Ok(Self {
             config,
             knowledge_graph: None,
@@ -308,17 +347,32 @@ impl GraphRAG {
             critic: None,
             #[cfg(feature = "parallel-processing")]
             parallel_processor: None,
-            #[cfg(feature = "async")]
-            chat_backend: None,
+            registry,
         })
     }
 
     /// Inject a custom chat backend for answer generation. Once set, the
     /// built-in Ollama client is bypassed for the final LLM call inside
     /// `ask` and `ask_explained`. Pass `None` to revert to the default.
+    ///
+    /// This is now a thin shim over the [`core::registry::ServiceRegistry`]
+    /// (issue #6): setting it stores the backend in the registry's typed
+    /// slot. Pre-existing callers keep working unchanged.
     #[cfg(feature = "async")]
     pub fn set_chat_backend(&mut self, backend: Option<core::backend::DynChatBackend>) {
-        self.chat_backend = backend;
+        if let Some(b) = backend {
+            self.registry.set_chat_backend(b);
+        } else {
+            // Drop any previously-injected backend by replacing the registry
+            // (the typed slot has no public `clear` to keep the surface small).
+            let mut new_reg = core::registry::ServiceRegistry::default();
+            // Preserve the embedder slot if one was injected, since that's
+            // the other typed slot consumers care about.
+            if let Some(emb) = self.registry.async_embedder().cloned() {
+                new_reg.set_async_embedder(emb);
+            }
+            self.registry = new_reg;
+        }
     }
 
     /// Create a Zero-Config local GraphRAG instance
@@ -363,7 +417,20 @@ impl GraphRAG {
             self.knowledge_graph = Some(KnowledgeGraph::new());
         }
 
-        self.retrieval_system = Some(retrieval::RetrievalSystem::new(&self.config)?);
+        // Pass any registry-injected embedder to RetrievalSystem so the
+        // configured backend is consulted on the hot path (issue #6 + #91).
+        #[cfg(feature = "async")]
+        {
+            let injected = self.registry.async_embedder().cloned();
+            self.retrieval_system = Some(retrieval::RetrievalSystem::new_with_embedder(
+                &self.config,
+                injected,
+            )?);
+        }
+        #[cfg(not(feature = "async"))]
+        {
+            self.retrieval_system = Some(retrieval::RetrievalSystem::new(&self.config)?);
+        }
 
         if self.config.ollama.enabled {
             let client = ollama::OllamaClient::new(self.config.ollama.clone());
@@ -1258,7 +1325,7 @@ impl GraphRAG {
             }
         }
 
-        if self.chat_backend.is_some() || self.config.ollama.enabled {
+        if self.registry.chat_backend().is_some() || self.config.ollama.enabled {
             // Initial synthesis (dispatches through `chat_backend` if set,
             // otherwise via the built-in Ollama client).
             let mut current_answer = self
@@ -1333,9 +1400,10 @@ impl GraphRAG {
         let search_results = self.query_internal_with_results(query).await?;
 
         // Synthesize via LLM whenever a chat backend is reachable — either an
-        // injected `ChatBackend` (set via `set_chat_backend`) or the built-in
-        // Ollama client. The synthesis function picks the right one internally.
-        if self.chat_backend.is_some() || self.config.ollama.enabled {
+        // injected `ChatBackend` (registry slot, populated via
+        // `RegistryBuilder::with_chat_backend` or `set_chat_backend`) or the
+        // built-in Ollama client. The synthesis function picks the right one.
+        if self.registry.chat_backend().is_some() || self.config.ollama.enabled {
             return self
                 .generate_semantic_answer_from_results(query, &search_results)
                 .await;
@@ -1406,8 +1474,8 @@ impl GraphRAG {
         let search_results = self.query_internal_with_results(query).await?;
 
         // Generate the answer — dispatch to the LLM whenever any chat
-        // backend is reachable (injected `ChatBackend` OR built-in Ollama).
-        let answer = if self.chat_backend.is_some() || self.config.ollama.enabled {
+        // backend is reachable (registry-injected `ChatBackend` OR Ollama).
+        let answer = if self.registry.chat_backend().is_some() || self.config.ollama.enabled {
             self.generate_semantic_answer_from_results(query, &search_results)
                 .await?
         } else {
@@ -1604,11 +1672,10 @@ impl GraphRAG {
         };
 
         // Dispatch through an injected ChatBackend if one was provided; otherwise
-        // fall back to the built-in Ollama client. This is the single hook
-        // downstream crates (e.g. semanticore) use to plug OpenAI-style providers
-        // into the answer-generation step without forking the rest of the
-        // pipeline.
-        let answer_result = if let Some(backend) = self.chat_backend.clone() {
+        // fall back to the built-in Ollama client. The backend lives in the
+        // registry's typed slot (issue #6) and is populated via
+        // `RegistryBuilder::with_chat_backend` or `GraphRAG::set_chat_backend`.
+        let answer_result = if let Some(backend) = self.registry.chat_backend().cloned() {
             let chat_params = crate::core::backend::ChatParams {
                 max_tokens: params.num_predict,
                 temperature: params.temperature,

--- a/graphrag-core/src/retrieval/mod.rs
+++ b/graphrag-core/src/retrieval/mod.rs
@@ -40,7 +40,15 @@ use crate::vector::store::VectorStore;
 /// Retrieval system for querying the knowledge graph
 pub struct RetrievalSystem {
     vector_store: std::sync::Arc<dyn VectorStore>,
-    embedding_generator: EmbeddingGenerator,
+    /// Hash-based embedding generator used when no async embedder is wired
+    /// up (or as the runtime fallback when `fallback_to_hash` is enabled).
+    /// Wrapped in a `Mutex` because `EmbeddingGenerator::generate_embedding`
+    /// mutates its internal word-vector cache; the mutex lets `embed_text`
+    /// take `&self` so multiple concurrent queries can share a
+    /// `RetrievalSystem` (the embedder itself is already
+    /// `Arc<dyn Trait + Send + Sync>`). Hash generation is non-blocking and
+    /// short-lived, so a `std::sync::Mutex` is fine here.
+    embedding_generator: std::sync::Mutex<EmbeddingGenerator>,
     /// Configured async embedder (OpenAI, Voyage, Ollama, ...). When `None`,
     /// the hash-based `embedding_generator` is used. Populated by
     /// `RetrievalSystem::new` when `config.embeddings.backend != "hash"`,
@@ -134,7 +142,7 @@ impl RetrievalSystem {
 
         Ok(Self {
             vector_store,
-            embedding_generator: EmbeddingGenerator::new(embedding_dim),
+            embedding_generator: std::sync::Mutex::new(EmbeddingGenerator::new(embedding_dim)),
             embedder,
             fallback_to_hash: config.embeddings.fallback_to_hash,
             config: retrieval_config,
@@ -172,7 +180,7 @@ impl RetrievalSystem {
 
         Ok(Self {
             vector_store,
-            embedding_generator: EmbeddingGenerator::new(embedding_dim),
+            embedding_generator: std::sync::Mutex::new(EmbeddingGenerator::new(embedding_dim)),
             fallback_to_hash: config.embeddings.fallback_to_hash,
             config: retrieval_config,
             #[cfg(feature = "parallel-processing")]
@@ -187,11 +195,15 @@ impl RetrievalSystem {
 
     /// Embed `text` using the configured async embedder; on failure (or
     /// when no embedder is configured) falls back to the in-memory hash
-    /// generator if `fallback_to_hash` is enabled. Logs a warning on the
-    /// first fallback per call so users see the signal without spamming.
+    /// generator if `fallback_to_hash` is enabled.
+    ///
+    /// Takes `&self` so multiple concurrent queries can share a
+    /// `RetrievalSystem` (issue #91 review). The hash fallback's mutable
+    /// state lives behind a `Mutex`; the configured `Arc<dyn AsyncEmbedder>`
+    /// is already shareable.
     #[cfg(feature = "async")]
-    async fn embed_text(&mut self, text: &str) -> Result<Vec<f32>> {
-        if let Some(embedder) = self.embedder.clone() {
+    async fn embed_text(&self, text: &str) -> Result<Vec<f32>> {
+        if let Some(embedder) = self.embedder.as_ref().cloned() {
             match embedder.embed(text).await {
                 Ok(v) => return Ok(v),
                 Err(e) => {
@@ -207,7 +219,13 @@ impl RetrievalSystem {
                 },
             }
         }
-        Ok(self.embedding_generator.generate_embedding(text))
+        let mut gen =
+            self.embedding_generator
+                .lock()
+                .map_err(|_| crate::core::GraphRAGError::Config {
+                    message: "embedding_generator mutex poisoned".to_string(),
+                })?;
+        Ok(gen.generate_embedding(text))
     }
 }
 
@@ -622,7 +640,7 @@ impl RetrievalSystem {
 
         Ok(Self {
             vector_store,
-            embedding_generator,
+            embedding_generator: std::sync::Mutex::new(embedding_generator),
             #[cfg(feature = "async")]
             embedder: None,
             fallback_to_hash: true,
@@ -900,9 +918,10 @@ impl RetrievalSystem {
     /// Sequential embedding generation (fallback)
     async fn add_embeddings_sequential(&mut self, graph: &mut KnowledgeGraph) -> Result<()> {
         // Two-pass: collect texts (immutable borrow), embed (no graph
-        // borrow), write back (mutable borrow). Required because
-        // `embed_text` takes `&mut self` and we cannot hold a `&mut graph`
-        // iterator at the same time.
+        // borrow), write back (mutable borrow). Keeps the loop body free
+        // of nested `&graph` + `&mut graph` lifetimes across an await
+        // boundary; `embed_text` itself takes `&self` so this is just a
+        // borrow-checker convenience, not a correctness requirement.
         let chunk_jobs: Vec<(crate::core::ChunkId, String)> = graph
             .chunks()
             .filter(|c| c.embedding.is_none())
@@ -1357,9 +1376,16 @@ impl RetrievalSystem {
                     if !visited.contains(&neighbor.id) {
                         visited.insert(neighbor.id.clone());
 
-                        // Calculate relationship relevance
+                        // Calculate relationship relevance. Hash-only path
+                        // here (cheap, deterministic, no network); the
+                        // configured async embedder is reserved for the
+                        // user's actual query text.
                         let rel_embedding = self
                             .embedding_generator
+                            .lock()
+                            .map_err(|_| crate::core::GraphRAGError::Config {
+                                message: "embedding_generator mutex poisoned".to_string(),
+                            })?
                             .generate_embedding(&relationship.relation_type);
                         let rel_similarity =
                             VectorUtils::cosine_similarity(query_embedding, &rel_embedding);
@@ -1992,9 +2018,13 @@ impl RetrievalSystem {
         };
 
         // Add embedding generator info
+        let (eg_dim, eg_cached) = match self.embedding_generator.lock() {
+            Ok(g) => (g.dimension(), g.cached_words()),
+            Err(_) => (0, 0),
+        };
         json_data["embedding_generator"] = json::object! {
-            "dimension" => self.embedding_generator.dimension(),
-            "cached_words" => self.embedding_generator.cached_words()
+            "dimension" => eg_dim,
+            "cached_words" => eg_cached
         };
 
         // Add parallel processing info
@@ -2074,7 +2104,7 @@ mod tests {
         config.embeddings.dimension = 768;
         let retrieval = RetrievalSystem::new(&config).unwrap();
         assert_eq!(
-            retrieval.embedding_generator.dimension(),
+            retrieval.embedding_generator.lock().unwrap().dimension(),
             768,
             "configured dimension should propagate to retrieval embedder"
         );
@@ -2087,7 +2117,7 @@ mod tests {
         let mut config = Config::default();
         config.embeddings.dimension = 0;
         let retrieval = RetrievalSystem::new(&config).unwrap();
-        assert_eq!(retrieval.embedding_generator.dimension(), 1);
+        assert_eq!(retrieval.embedding_generator.lock().unwrap().dimension(), 1);
     }
 
     #[test]

--- a/graphrag-core/src/retrieval/mod.rs
+++ b/graphrag-core/src/retrieval/mod.rs
@@ -55,6 +55,16 @@ pub struct RetrievalSystem {
     /// or by `with_embedder` when an embedder is injected via the registry.
     #[cfg(feature = "async")]
     embedder: Option<crate::core::registry::DynAsyncEmbedder>,
+    /// Cached output dimension of the configured async embedder. Used to
+    /// size the hash fallback so an OpenAI-indexed corpus (1536 dim) is
+    /// never queried with a config-sized vector (e.g. 768) — that
+    /// mismatch makes cosine similarity return 0 and the search returns
+    /// nothing. Seeded from `AsyncEmbedder::dimension()` at construction
+    /// and refined in `embed_text` after the first successful embed if
+    /// the provider's reported value disagrees with reality (issue #91
+    /// review).
+    #[cfg(feature = "async")]
+    fallback_dim: std::sync::Mutex<usize>,
     /// Whether to silently fall back to the hash generator when the
     /// configured embedder fails at runtime. Mirrors
     /// `config.embeddings.fallback_to_hash`.
@@ -109,11 +119,10 @@ impl RetrievalSystem {
         let vector_store =
             std::sync::Arc::new(crate::vector::memory_store::MemoryVectorStore::new());
 
-        // Use the configured embedding dimension for the hash fallback so the
-        // hot retrieval path actually respects `[embeddings]` config. The
-        // hash generator is also used when the configured backend is "hash"
-        // or when fallback_to_hash kicks in after a runtime API failure.
-        let embedding_dim = config.embeddings.dimension.max(1);
+        // Configured dimension is the *initial* fallback size; once the
+        // embedder produces a real vector, `embed_text` updates the
+        // fallback to match (issue #91 review).
+        let configured_dim = config.embeddings.dimension.max(1);
 
         // Resolve the embedder: registry override wins; otherwise dispatch
         // on `config.embeddings.backend`. A construction failure is fatal
@@ -140,10 +149,20 @@ impl RetrievalSystem {
             }
         };
 
+        // Trust the embedder's `dimension()` over the config: providers
+        // know their model's actual output size, and a typo in
+        // `[embeddings].dimension` would otherwise produce length-mismatched
+        // hash fallbacks that silently zero out cosine similarities.
+        let fallback_dim = embedder
+            .as_ref()
+            .map(|e| e.dimension().max(1))
+            .unwrap_or(configured_dim);
+
         Ok(Self {
             vector_store,
-            embedding_generator: std::sync::Mutex::new(EmbeddingGenerator::new(embedding_dim)),
+            embedding_generator: std::sync::Mutex::new(EmbeddingGenerator::new(fallback_dim)),
             embedder,
+            fallback_dim: std::sync::Mutex::new(fallback_dim),
             fallback_to_hash: config.embeddings.fallback_to_hash,
             config: retrieval_config,
             #[cfg(feature = "parallel-processing")]
@@ -205,7 +224,28 @@ impl RetrievalSystem {
     async fn embed_text(&self, text: &str) -> Result<Vec<f32>> {
         if let Some(embedder) = self.embedder.as_ref().cloned() {
             match embedder.embed(text).await {
-                Ok(v) => return Ok(v),
+                Ok(v) => {
+                    // Track the actual provider dimension so any later
+                    // hash fallback produces vectors that match the
+                    // already-indexed embeddings. The provider's
+                    // self-reported `dimension()` may not match what it
+                    // actually returns (e.g. a model swap), and the user's
+                    // config may not match either; the wire format is the
+                    // source of truth (issue #91 review).
+                    if !v.is_empty() {
+                        if let Ok(mut dim) = self.fallback_dim.lock() {
+                            if *dim != v.len() {
+                                *dim = v.len();
+                                if let Ok(mut gen) = self.embedding_generator.lock() {
+                                    if gen.dimension() != v.len() {
+                                        *gen = EmbeddingGenerator::new(v.len());
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    return Ok(v);
+                },
                 Err(e) => {
                     if self.fallback_to_hash {
                         #[cfg(feature = "tracing")]
@@ -637,12 +677,16 @@ impl RetrievalSystem {
         // EmbeddingGenerator operations can be parallelized with rayon
 
         let retrieval_config = RetrievalConfig::default();
+        #[cfg(feature = "async")]
+        let fallback_dim = std::sync::Mutex::new(embedding_generator.dimension().max(1));
 
         Ok(Self {
             vector_store,
             embedding_generator: std::sync::Mutex::new(embedding_generator),
             #[cfg(feature = "async")]
             embedder: None,
+            #[cfg(feature = "async")]
+            fallback_dim,
             fallback_to_hash: true,
             config: retrieval_config,
             parallel_processor: Some(parallel_processor),

--- a/graphrag-core/src/retrieval/mod.rs
+++ b/graphrag-core/src/retrieval/mod.rs
@@ -41,6 +41,16 @@ use crate::vector::store::VectorStore;
 pub struct RetrievalSystem {
     vector_store: std::sync::Arc<dyn VectorStore>,
     embedding_generator: EmbeddingGenerator,
+    /// Configured async embedder (OpenAI, Voyage, Ollama, ...). When `None`,
+    /// the hash-based `embedding_generator` is used. Populated by
+    /// `RetrievalSystem::new` when `config.embeddings.backend != "hash"`,
+    /// or by `with_embedder` when an embedder is injected via the registry.
+    #[cfg(feature = "async")]
+    embedder: Option<crate::core::registry::DynAsyncEmbedder>,
+    /// Whether to silently fall back to the hash generator when the
+    /// configured embedder fails at runtime. Mirrors
+    /// `config.embeddings.fallback_to_hash`.
+    fallback_to_hash: bool,
     config: RetrievalConfig,
     #[cfg(feature = "parallel-processing")]
     parallel_processor: Option<ParallelProcessor>,
@@ -52,8 +62,27 @@ pub struct RetrievalSystem {
 }
 
 impl RetrievalSystem {
-    /// Create a new retrieval system
+    /// Create a new retrieval system using `config.embeddings.backend` to
+    /// pick an embedder. See [`RetrievalSystem::new_with_embedder`] for the
+    /// registry-injected variant.
     pub fn new(config: &Config) -> Result<Self> {
+        Self::new_with_embedder(config, None)
+    }
+
+    /// Create a new retrieval system, optionally bypassing
+    /// `config.embeddings.backend` selection with a pre-built embedder.
+    ///
+    /// Selection precedence (issue #91 / #6):
+    /// 1. `embedder_override` (from `ServiceRegistry` via
+    ///    `GraphRAG::new_with_registry`).
+    /// 2. `config.embeddings.backend` factory dispatch (hash/Ollama/HTTP).
+    /// 3. Hash fallback when `fallback_to_hash = true` and (2) fails to
+    ///    construct.
+    #[cfg(feature = "async")]
+    pub fn new_with_embedder(
+        config: &Config,
+        embedder_override: Option<crate::core::registry::DynAsyncEmbedder>,
+    ) -> Result<Self> {
         let retrieval_config = RetrievalConfig {
             top_k: config.retrieval.top_k,
             similarity_threshold: 0.35,
@@ -73,16 +102,41 @@ impl RetrievalSystem {
             std::sync::Arc::new(crate::vector::memory_store::MemoryVectorStore::new());
 
         // Use the configured embedding dimension for the hash fallback so the
-        // hot retrieval path actually respects `[embeddings]` config. Even
-        // before the configured embedder gets wired through (see #6 / #7),
-        // dimension parity matters: a 768-dim Nomic / 1536-dim OpenAI
-        // configuration would have silently downgraded query-time embeddings
-        // to the previous hardcoded 128 dims.
+        // hot retrieval path actually respects `[embeddings]` config. The
+        // hash generator is also used when the configured backend is "hash"
+        // or when fallback_to_hash kicks in after a runtime API failure.
         let embedding_dim = config.embeddings.dimension.max(1);
+
+        // Resolve the embedder: registry override wins; otherwise dispatch
+        // on `config.embeddings.backend`. A construction failure is fatal
+        // unless `fallback_to_hash = true` (issue #91).
+        let embedder = if let Some(e) = embedder_override {
+            Some(e)
+        } else {
+            match crate::embeddings::factory::build_async_embedder(&config.embeddings) {
+                Ok(opt) => opt,
+                Err(e) => {
+                    if config.embeddings.fallback_to_hash {
+                        #[cfg(feature = "tracing")]
+                        tracing::warn!(
+                            "Failed to construct configured embedder \"{}\": {}. \
+                             Falling back to hash embeddings.",
+                            config.embeddings.backend,
+                            e,
+                        );
+                        None
+                    } else {
+                        return Err(e);
+                    }
+                },
+            }
+        };
 
         Ok(Self {
             vector_store,
             embedding_generator: EmbeddingGenerator::new(embedding_dim),
+            embedder,
+            fallback_to_hash: config.embeddings.fallback_to_hash,
             config: retrieval_config,
             #[cfg(feature = "parallel-processing")]
             parallel_processor: None,
@@ -92,6 +146,68 @@ impl RetrievalSystem {
             #[cfg(feature = "lazygraphrag")]
             concept_filtering_enabled: false,
         })
+    }
+
+    /// Sync construction path (no async feature). Always uses hash
+    /// embeddings; the configured backend is only honoured under `async`.
+    #[cfg(not(feature = "async"))]
+    pub fn new_with_embedder(config: &Config, _override: Option<()>) -> Result<Self> {
+        let retrieval_config = RetrievalConfig {
+            top_k: config.retrieval.top_k,
+            similarity_threshold: 0.35,
+            max_expansion_depth: 2,
+            entity_weight: 0.4,
+            chunk_weight: 0.4,
+            graph_weight: 0.2,
+            #[cfg(feature = "lazygraphrag")]
+            use_concept_filtering: false,
+            #[cfg(feature = "lazygraphrag")]
+            concept_top_k: 20,
+        };
+
+        let vector_store =
+            std::sync::Arc::new(crate::vector::memory_store::MemoryVectorStore::new());
+
+        let embedding_dim = config.embeddings.dimension.max(1);
+
+        Ok(Self {
+            vector_store,
+            embedding_generator: EmbeddingGenerator::new(embedding_dim),
+            fallback_to_hash: config.embeddings.fallback_to_hash,
+            config: retrieval_config,
+            #[cfg(feature = "parallel-processing")]
+            parallel_processor: None,
+            #[cfg(feature = "pagerank")]
+            pagerank_retriever: None,
+            enriched_retriever: None,
+            #[cfg(feature = "lazygraphrag")]
+            concept_filtering_enabled: false,
+        })
+    }
+
+    /// Embed `text` using the configured async embedder; on failure (or
+    /// when no embedder is configured) falls back to the in-memory hash
+    /// generator if `fallback_to_hash` is enabled. Logs a warning on the
+    /// first fallback per call so users see the signal without spamming.
+    #[cfg(feature = "async")]
+    async fn embed_text(&mut self, text: &str) -> Result<Vec<f32>> {
+        if let Some(embedder) = self.embedder.clone() {
+            match embedder.embed(text).await {
+                Ok(v) => return Ok(v),
+                Err(e) => {
+                    if self.fallback_to_hash {
+                        #[cfg(feature = "tracing")]
+                        tracing::warn!(
+                            "Configured embedder failed ({}); falling back to hash embeddings",
+                            e
+                        );
+                    } else {
+                        return Err(e);
+                    }
+                },
+            }
+        }
+        Ok(self.embedding_generator.generate_embedding(text))
     }
 }
 
@@ -507,6 +623,9 @@ impl RetrievalSystem {
         Ok(Self {
             vector_store,
             embedding_generator,
+            #[cfg(feature = "async")]
+            embedder: None,
+            fallback_to_hash: true,
             config: retrieval_config,
             parallel_processor: Some(parallel_processor),
             #[cfg(feature = "pagerank")]
@@ -674,8 +793,8 @@ impl RetrievalSystem {
         // 1. Analyze query to determine optimal strategy
         let analysis = self.analyze_query(query, graph)?;
 
-        // 2. Generate query embedding
-        let query_embedding = self.embedding_generator.generate_embedding(query);
+        // 2. Generate query embedding (configured embedder if any, hash fallback otherwise)
+        let query_embedding = self.embed_text(query).await?;
 
         // 3. Execute multi-strategy retrieval based on analysis
         let mut results = self
@@ -700,8 +819,8 @@ impl RetrievalSystem {
         query: &str,
         graph: &KnowledgeGraph,
     ) -> Result<Vec<SearchResult>> {
-        // 1. Generate query embedding
-        let query_embedding = self.embedding_generator.generate_embedding(query);
+        // 1. Generate query embedding via the configured embedder
+        let query_embedding = self.embed_text(query).await?;
 
         // 2. Perform comprehensive search
         let results = self.comprehensive_search(&query_embedding, graph).await?;
@@ -758,7 +877,7 @@ impl RetrievalSystem {
 
         // Process chunks
         for (chunk_id, text) in chunk_texts {
-            let embedding = self.embedding_generator.generate_embedding(&text);
+            let embedding = self.embed_text(&text).await?;
             if let Some(chunk) = graph.get_chunk_mut(&chunk_id) {
                 chunk.embedding = Some(embedding);
             }
@@ -766,7 +885,7 @@ impl RetrievalSystem {
 
         // Process entities
         for (entity_id, text) in entity_texts {
-            let embedding = self.embedding_generator.generate_embedding(&text);
+            let embedding = self.embed_text(&text).await?;
             if let Some(entity) = graph.get_entity_mut(&entity_id) {
                 entity.embedding = Some(embedding);
             }
@@ -780,30 +899,36 @@ impl RetrievalSystem {
 
     /// Sequential embedding generation (fallback)
     async fn add_embeddings_sequential(&mut self, graph: &mut KnowledgeGraph) -> Result<()> {
-        // Debug: Check total counts first (uncomment for debugging)
-        let _total_chunks = graph.chunks().count();
-        let _total_entities = graph.entities().count();
-        // println!("DEBUG: Found {} total chunks and {} total entities in graph", _total_chunks, _total_entities);
+        // Two-pass: collect texts (immutable borrow), embed (no graph
+        // borrow), write back (mutable borrow). Required because
+        // `embed_text` takes `&mut self` and we cannot hold a `&mut graph`
+        // iterator at the same time.
+        let chunk_jobs: Vec<(crate::core::ChunkId, String)> = graph
+            .chunks()
+            .filter(|c| c.embedding.is_none())
+            .map(|c| (c.id.clone(), c.content.clone()))
+            .collect();
 
-        // Generate embeddings for all chunks
-        let mut chunk_count = 0;
-        for chunk in graph.chunks_mut() {
-            if chunk.embedding.is_none() {
-                let embedding = self.embedding_generator.generate_embedding(&chunk.content);
+        let entity_jobs: Vec<(crate::core::EntityId, String)> = graph
+            .entities()
+            .filter(|e| e.embedding.is_none())
+            .map(|e| (e.id.clone(), format!("{} {}", e.name, e.entity_type)))
+            .collect();
+
+        let chunk_count = chunk_jobs.len();
+        let entity_count = entity_jobs.len();
+
+        for (chunk_id, text) in chunk_jobs {
+            let embedding = self.embed_text(&text).await?;
+            if let Some(chunk) = graph.get_chunk_mut(&chunk_id) {
                 chunk.embedding = Some(embedding);
-                chunk_count += 1;
             }
         }
 
-        // Generate embeddings for all entities (using their name and context)
-        let mut entity_count = 0;
-        for entity in graph.entities_mut() {
-            if entity.embedding.is_none() {
-                // Create entity text from name and entity type
-                let entity_text = format!("{} {}", entity.name, entity.entity_type);
-                let embedding = self.embedding_generator.generate_embedding(&entity_text);
+        for (entity_id, text) in entity_jobs {
+            let embedding = self.embed_text(&text).await?;
+            if let Some(entity) = graph.get_entity_mut(&entity_id) {
                 entity.embedding = Some(embedding);
-                entity_count += 1;
             }
         }
 
@@ -811,7 +936,6 @@ impl RetrievalSystem {
             "Generated embeddings for {chunk_count} chunks and {entity_count} entities"
         );
 
-        // Re-index the graph with new embeddings
         // Re-index the graph with new embeddings
         self.index_graph(graph).await?;
 
@@ -1736,7 +1860,7 @@ impl RetrievalSystem {
         query: &str,
         max_results: usize,
     ) -> Result<Vec<SearchResult>> {
-        let query_embedding = self.embedding_generator.generate_embedding(query);
+        let query_embedding = self.embed_text(query).await?;
         let similar_vectors = self
             .vector_store
             .search(&query_embedding, max_results)

--- a/graphrag-core/src/retrieval/mod.rs
+++ b/graphrag-core/src/retrieval/mod.rs
@@ -94,8 +94,12 @@ impl RetrievalSystem {
     /// 1. `embedder_override` (from `ServiceRegistry` via
     ///    `GraphRAG::new_with_registry`).
     /// 2. `config.embeddings.backend` factory dispatch (hash/Ollama/HTTP).
-    /// 3. Hash fallback when `fallback_to_hash = true` and (2) fails to
-    ///    construct.
+    ///
+    /// Construction-time errors from the factory propagate. The
+    /// `fallback_to_hash` flag only governs runtime failures
+    /// (`AsyncEmbedder::embed` returning `Err`); a misconfigured backend
+    /// is always fatal so users see typos and missing credentials at
+    /// boot rather than after months of silent hash-degraded retrieval.
     #[cfg(feature = "async")]
     pub fn new_with_embedder(
         config: &Config,
@@ -125,28 +129,17 @@ impl RetrievalSystem {
         let configured_dim = config.embeddings.dimension.max(1);
 
         // Resolve the embedder: registry override wins; otherwise dispatch
-        // on `config.embeddings.backend`. A construction failure is fatal
-        // unless `fallback_to_hash = true` (issue #91).
+        // on `config.embeddings.backend`. Construction failures (typos,
+        // missing API keys, missing feature flags) are *always* fatal —
+        // `fallback_to_hash` only governs runtime errors (HTTP failures,
+        // rate limits, transient 5xxs). Silently swallowing config
+        // errors here would mean a user who typoed `backend = "opena"`
+        // gets bad retrieval quality six months later instead of an
+        // immediate error at boot (issue #91 review, finding #3).
         let embedder = if let Some(e) = embedder_override {
             Some(e)
         } else {
-            match crate::embeddings::factory::build_async_embedder(&config.embeddings) {
-                Ok(opt) => opt,
-                Err(e) => {
-                    if config.embeddings.fallback_to_hash {
-                        #[cfg(feature = "tracing")]
-                        tracing::warn!(
-                            "Failed to construct configured embedder \"{}\": {}. \
-                             Falling back to hash embeddings.",
-                            config.embeddings.backend,
-                            e,
-                        );
-                        None
-                    } else {
-                        return Err(e);
-                    }
-                },
-            }
+            crate::embeddings::factory::build_async_embedder(&config.embeddings)?
         };
 
         // Trust the embedder's `dimension()` over the config: providers

--- a/graphrag-core/tests/registry_and_embedder_factory.rs
+++ b/graphrag-core/tests/registry_and_embedder_factory.rs
@@ -1,0 +1,510 @@
+//! Integration tests for issues #6 (registry threading) and #91 (embedder
+//! factory dispatch). Covers:
+//!
+//! - registry-injected `Embedder` is consulted by `RetrievalSystem`
+//! - registry-injected `ChatBackend` survives `set_chat_backend` shim
+//! - default registry preserves the previous behavior
+//! - `config.embeddings.backend = "openai"` hits the configured endpoint
+//! - `fallback_to_hash` survives a runtime API failure
+//! - `backend = "hash"` keeps the legacy hash path
+
+#![cfg(all(feature = "ureq", feature = "async", feature = "memory-storage"))]
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::TcpListener;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+use async_trait::async_trait;
+
+use graphrag_core::core::backend::{ChatBackend, ChatParams, DynChatBackend};
+use graphrag_core::core::registry::{RegistryBuilder, ServiceRegistry};
+use graphrag_core::core::traits::AsyncEmbedder;
+use graphrag_core::core::GraphRAGError;
+use graphrag_core::{Config, GraphRAG};
+
+// ---------------------------------------------------------------------------
+// Mock embedding HTTP server (records every request).
+// ---------------------------------------------------------------------------
+
+struct MockHttpServer {
+    port: u16,
+    shutdown: Arc<AtomicBool>,
+    request_count: Arc<AtomicUsize>,
+    request_paths: Arc<std::sync::Mutex<Vec<String>>>,
+}
+
+impl MockHttpServer {
+    fn start_ok() -> Self {
+        Self::start(MockMode::OkOpenAi)
+    }
+
+    fn start_err() -> Self {
+        Self::start(MockMode::Error500)
+    }
+
+    fn start(mode: MockMode) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        let port = listener.local_addr().unwrap().port();
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let request_count = Arc::new(AtomicUsize::new(0));
+        let request_paths = Arc::new(std::sync::Mutex::new(Vec::new()));
+
+        listener.set_nonblocking(true).expect("set_nonblocking");
+
+        let shutdown_clone = shutdown.clone();
+        let count_clone = request_count.clone();
+        let paths_clone = request_paths.clone();
+
+        thread::spawn(move || {
+            while !shutdown_clone.load(Ordering::Relaxed) {
+                match listener.accept() {
+                    Ok((stream, _)) => {
+                        let count = count_clone.clone();
+                        let paths = paths_clone.clone();
+                        let mode = mode;
+                        thread::spawn(move || handle_conn(stream, mode, count, paths));
+                    },
+                    Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(5));
+                    },
+                    Err(_) => break,
+                }
+            }
+        });
+
+        Self {
+            port,
+            shutdown,
+            request_count,
+            request_paths,
+        }
+    }
+
+    fn url(&self) -> String {
+        // OpenAI-style path so the API factory is happy.
+        format!("http://127.0.0.1:{}/v1/embeddings", self.port)
+    }
+
+    fn count(&self) -> usize {
+        self.request_count.load(Ordering::SeqCst)
+    }
+
+    fn paths(&self) -> Vec<String> {
+        self.request_paths.lock().unwrap().clone()
+    }
+}
+
+impl Drop for MockHttpServer {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::Relaxed);
+    }
+}
+
+#[derive(Copy, Clone)]
+enum MockMode {
+    OkOpenAi,
+    Error500,
+}
+
+fn handle_conn(
+    mut stream: std::net::TcpStream,
+    mode: MockMode,
+    count: Arc<AtomicUsize>,
+    paths: Arc<std::sync::Mutex<Vec<String>>>,
+) {
+    stream.set_nonblocking(false).ok();
+
+    let mut reader = BufReader::new(stream.try_clone().expect("clone"));
+    let mut content_length = 0usize;
+    let mut request_line = String::new();
+
+    // Read request line.
+    if reader.read_line(&mut request_line).unwrap_or(0) == 0 {
+        return;
+    }
+    let req_path = request_line
+        .split_whitespace()
+        .nth(1)
+        .unwrap_or("")
+        .to_string();
+
+    // Read headers.
+    let mut line = String::new();
+    loop {
+        line.clear();
+        if reader.read_line(&mut line).unwrap_or(0) == 0 {
+            return;
+        }
+        if line == "\r\n" {
+            break;
+        }
+        if let Some(rest) = line.to_ascii_lowercase().strip_prefix("content-length:") {
+            content_length = rest.trim().parse().unwrap_or(0);
+        }
+    }
+    if content_length > 0 {
+        let mut body = vec![0u8; content_length];
+        let _ = reader.read_exact(&mut body);
+    }
+
+    count.fetch_add(1, Ordering::SeqCst);
+    paths.lock().unwrap().push(req_path);
+
+    match mode {
+        MockMode::OkOpenAi => {
+            let body = br#"{"data":[{"embedding":[0.1,0.2,0.3,0.4],"index":0}],"model":"test","usage":{}}"#;
+            let header = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            let _ = stream.write_all(header.as_bytes());
+            let _ = stream.write_all(body);
+        },
+        MockMode::Error500 => {
+            let header = b"HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+            let _ = stream.write_all(header);
+        },
+    }
+    let _ = stream.flush();
+}
+
+// ---------------------------------------------------------------------------
+// Mock AsyncEmbedder that counts calls so the test can assert it ran.
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+struct CountingEmbedder {
+    count: Arc<AtomicUsize>,
+    dim: usize,
+}
+
+impl CountingEmbedder {
+    fn new(dim: usize) -> Self {
+        Self {
+            count: Arc::new(AtomicUsize::new(0)),
+            dim,
+        }
+    }
+
+    fn calls(&self) -> usize {
+        self.count.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl AsyncEmbedder for CountingEmbedder {
+    type Error = GraphRAGError;
+
+    async fn embed(&self, text: &str) -> Result<Vec<f32>, GraphRAGError> {
+        self.count.fetch_add(1, Ordering::SeqCst);
+        // Deterministic but text-dependent so vectors differ; this lets the
+        // vector store actually rank chunks instead of treating all
+        // embeddings as identical points.
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        let mut hasher = DefaultHasher::new();
+        text.hash(&mut hasher);
+        let seed = hasher.finish();
+        let mut v = Vec::with_capacity(self.dim);
+        for i in 0..self.dim {
+            let h = seed.wrapping_add(i as u64);
+            v.push(((h % 1000) as f32) / 1000.0);
+        }
+        Ok(v)
+    }
+
+    async fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, GraphRAGError> {
+        let mut out = Vec::with_capacity(texts.len());
+        for t in texts {
+            out.push(self.embed(t).await?);
+        }
+        Ok(out)
+    }
+
+    fn dimension(&self) -> usize {
+        self.dim
+    }
+
+    async fn is_ready(&self) -> bool {
+        true
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mock ChatBackend that records prompts.
+// ---------------------------------------------------------------------------
+
+struct CountingChatBackend {
+    count: Arc<AtomicUsize>,
+}
+
+impl CountingChatBackend {
+    fn new() -> Self {
+        Self {
+            count: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+}
+
+#[async_trait]
+impl ChatBackend for CountingChatBackend {
+    async fn complete(&self, _prompt: &str, _params: &ChatParams) -> Result<String, GraphRAGError> {
+        self.count.fetch_add(1, Ordering::SeqCst);
+        Ok("mock-answer".to_string())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn config_with_openai_endpoint(endpoint: &str) -> Config {
+    let mut config = Config::default();
+    config.embeddings.backend = "openai".to_string();
+    config.embeddings.dimension = 4;
+    config.embeddings.api_key = Some("sk-test".to_string());
+    config.embeddings.api_endpoint = Some(endpoint.to_string());
+    config.embeddings.fallback_to_hash = false;
+    config.ollama.enabled = false;
+    config.auto_save.enabled = false;
+    config
+}
+
+// ---------------------------------------------------------------------------
+// Issue #91 tests — embedder factory dispatch.
+// ---------------------------------------------------------------------------
+
+/// `config.embeddings.backend = "openai"` causes the retrieval flow to call
+/// the configured endpoint instead of the hash generator.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn retrieval_uses_configured_openai_embedder() {
+    let server = MockHttpServer::start_ok();
+    tokio::time::sleep(Duration::from_millis(30)).await;
+
+    let config = config_with_openai_endpoint(&server.url());
+    let mut graphrag = GraphRAG::new(config).expect("construct GraphRAG");
+    graphrag.initialize().expect("initialize");
+    graphrag
+        .add_document_from_text("Socrates was a Greek philosopher.")
+        .expect("add doc");
+
+    // Drive the retrieval path; we don't care about the exact answer, only
+    // that the configured endpoint was hit.
+    let _ = graphrag.ask("Who was Socrates?").await;
+
+    let count = server.count();
+    assert!(
+        count > 0,
+        "expected the configured OpenAI endpoint to be hit at least once, got {} requests",
+        count
+    );
+    let paths = server.paths();
+    assert!(
+        paths.iter().any(|p| p.contains("/v1/embeddings")),
+        "expected at least one /v1/embeddings request, got {:?}",
+        paths
+    );
+}
+
+/// When `fallback_to_hash = true`, a deliberately-broken endpoint should not
+/// crash retrieval; the hash generator takes over.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn retrieval_falls_back_to_hash_on_api_failure() {
+    let server = MockHttpServer::start_err();
+    tokio::time::sleep(Duration::from_millis(30)).await;
+
+    let mut config = config_with_openai_endpoint(&server.url());
+    config.embeddings.fallback_to_hash = true;
+
+    let mut graphrag = GraphRAG::new(config).expect("construct");
+    graphrag.initialize().expect("initialize");
+    graphrag
+        .add_document_from_text("Plato was a student of Socrates.")
+        .expect("add doc");
+
+    // Should not panic / error out — fallback path produces hash embeddings.
+    let result = graphrag.ask("What did Plato do?").await;
+    assert!(
+        result.is_ok(),
+        "ask() should fall back to hash when API errors, got {:?}",
+        result.err()
+    );
+}
+
+/// Backwards-compat: `backend = "hash"` (default) keeps the in-memory
+/// generator and never hits the network.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn retrieval_uses_hash_when_backend_is_hash() {
+    let mut config = Config::default();
+    config.embeddings.backend = "hash".to_string();
+    config.ollama.enabled = false;
+    config.auto_save.enabled = false;
+
+    let mut graphrag = GraphRAG::new(config).expect("construct");
+    graphrag.initialize().expect("initialize");
+    graphrag
+        .add_document_from_text("Aristotle was a student of Plato.")
+        .expect("add doc");
+
+    let result = graphrag.ask("Who taught Aristotle?").await;
+    assert!(
+        result.is_ok(),
+        "hash-backend retrieval must succeed without network, got {:?}",
+        result.err()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Issue #6 tests — registry threading.
+// ---------------------------------------------------------------------------
+
+/// A registry with an injected mock embedder must drive the retrieval flow
+/// instead of falling through to `config.embeddings.backend`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn graphrag_new_with_registry_uses_injected_embedder() {
+    let mut config = Config::default();
+    // Set backend to "openai" with no endpoint to prove the registry wins:
+    // if the registry weren't consulted, factory dispatch would error.
+    config.embeddings.backend = "openai".to_string();
+    config.embeddings.dimension = 8;
+    config.embeddings.api_key = Some("would-fail".to_string());
+    config.embeddings.fallback_to_hash = false;
+    config.ollama.enabled = false;
+    config.auto_save.enabled = false;
+
+    let counting = CountingEmbedder::new(8);
+    let registry = RegistryBuilder::new()
+        .with_async_embedder(counting.clone())
+        .build();
+
+    let mut graphrag = GraphRAG::new_with_registry(config, registry).expect("construct");
+    graphrag.initialize().expect("initialize");
+    graphrag
+        .add_document_from_text("test document for embedding")
+        .expect("add doc");
+
+    let _ = graphrag.ask("test query").await;
+
+    assert!(
+        counting.calls() > 0,
+        "registry-injected embedder should be invoked at least once, got 0 calls"
+    );
+}
+
+/// Injected `ChatBackend` short-circuits Ollama dispatch.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn graphrag_new_with_registry_uses_injected_chat_backend() {
+    let mut config = Config::default();
+    config.embeddings.backend = "hash".to_string();
+    config.ollama.enabled = false;
+    config.auto_save.enabled = false;
+
+    let backend = Arc::new(CountingChatBackend::new());
+    let backend_dyn: DynChatBackend = backend.clone();
+    let count_handle = backend.count.clone();
+
+    let registry = RegistryBuilder::new()
+        .with_chat_backend(backend_dyn)
+        .build();
+
+    let mut graphrag = GraphRAG::new_with_registry(config, registry).expect("construct");
+    graphrag.initialize().expect("initialize");
+    // Reuse the same text-and-query pair as the working
+    // `set_chat_backend_routes_through_registry` test so this test isolates
+    // the "registry path wires the chat backend correctly" property without
+    // depending on hash-embedding similarity vagaries.
+    graphrag
+        .add_document_from_text(
+            "Plato was a student of Socrates and the teacher of Aristotle. \
+             Plato founded the Academy in Athens, the first institution of higher \
+             learning in the Western world. He wrote dialogues exploring justice, \
+             the nature of the soul, and political philosophy.",
+        )
+        .expect("add doc");
+
+    let answer = graphrag.ask("Tell me about Plato").await.expect("ask ok");
+    assert_eq!(answer, "mock-answer", "injected backend's reply should win");
+    assert_eq!(
+        count_handle.load(Ordering::SeqCst),
+        1,
+        "chat backend must be hit exactly once"
+    );
+}
+
+/// Default registry preserves the previous `GraphRAG::new` behavior.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn graphrag_new_uses_default_registry_for_backwards_compat() {
+    let mut config = Config::default();
+    config.embeddings.backend = "hash".to_string();
+    config.ollama.enabled = false;
+    config.auto_save.enabled = false;
+
+    let mut graphrag = GraphRAG::new(config).expect("construct");
+    graphrag.initialize().expect("initialize");
+    graphrag
+        .add_document_from_text("legacy callers see the same behavior")
+        .expect("add doc");
+
+    // Without an injected backend or Ollama, ask should still complete via
+    // the formatted-results fallback path.
+    let result = graphrag.ask("legacy").await;
+    assert!(
+        result.is_ok(),
+        "default-registry behavior must not regress, got {:?}",
+        result.err()
+    );
+}
+
+/// `set_chat_backend` continues to work as a delegation shim that stores
+/// the backend in the registry's typed slot (no caller changes required).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn set_chat_backend_routes_through_registry() {
+    let mut config = Config::default();
+    config.embeddings.backend = "hash".to_string();
+    config.ollama.enabled = false;
+    config.auto_save.enabled = false;
+
+    let backend = Arc::new(CountingChatBackend::new());
+    let count_handle = backend.count.clone();
+
+    let mut graphrag = GraphRAG::new(config).expect("construct");
+    graphrag.set_chat_backend(Some(backend.clone() as DynChatBackend));
+    graphrag.initialize().expect("initialize");
+    graphrag
+        .add_document_from_text(
+            "Plato was a student of Socrates and the teacher of Aristotle. \
+             Plato founded the Academy in Athens, the first institution of higher \
+             learning in the Western world. He wrote dialogues exploring justice, \
+             the nature of the soul, and political philosophy.",
+        )
+        .expect("add doc");
+
+    let _ = graphrag.ask("Tell me about Plato").await;
+    assert_eq!(
+        count_handle.load(Ordering::SeqCst),
+        1,
+        "set_chat_backend must keep working as a shim into the registry"
+    );
+
+    // Clearing the backend should disable dispatch; the next call falls back
+    // to the no-LLM formatted-results path.
+    graphrag.set_chat_backend(None);
+    let _ = graphrag.ask("Tell me about Plato").await;
+    assert_eq!(
+        count_handle.load(Ordering::SeqCst),
+        1,
+        "after clearing, backend should not be invoked again"
+    );
+}
+
+/// Empty `ServiceRegistry::default()` should not panic in the typed-slot
+/// accessors (defense in depth — no embedder, no chat backend).
+#[test]
+fn empty_registry_has_no_typed_slots() {
+    let reg = ServiceRegistry::default();
+    assert!(reg.async_embedder().is_none());
+    assert!(reg.chat_backend().is_none());
+}

--- a/graphrag-core/tests/registry_and_embedder_factory.rs
+++ b/graphrag-core/tests/registry_and_embedder_factory.rs
@@ -573,6 +573,49 @@ fn empty_registry_has_no_typed_slots() {
     assert!(reg.chat_backend().is_none());
 }
 
+/// `clear_chat_backend` nulls only the chat-backend slot and preserves
+/// any other registered services. The previous `set_chat_backend(None)`
+/// rebuilt the whole registry, dropping every entry registered through
+/// the generic `register/get` map (issue #6 review).
+#[test]
+fn clear_chat_backend_preserves_other_services() {
+    use graphrag_core::core::registry::DynAsyncEmbedder;
+
+    #[derive(Debug, PartialEq)]
+    struct CustomService {
+        marker: u32,
+    }
+
+    let mut reg = ServiceRegistry::default();
+    reg.register(CustomService { marker: 42 });
+
+    let counting = CountingEmbedder::new(8);
+    let emb_dyn: DynAsyncEmbedder = Arc::new(counting);
+    reg.set_async_embedder(emb_dyn);
+
+    let backend: DynChatBackend = Arc::new(CountingChatBackend::new());
+    reg.set_chat_backend(backend);
+
+    assert!(reg.chat_backend().is_some());
+    assert!(reg.async_embedder().is_some());
+    assert!(reg.has::<CustomService>());
+
+    reg.clear_chat_backend();
+
+    assert!(
+        reg.chat_backend().is_none(),
+        "chat backend slot must be cleared"
+    );
+    assert!(
+        reg.async_embedder().is_some(),
+        "embedder slot must survive clear_chat_backend"
+    );
+    let svc = reg
+        .get::<CustomService>()
+        .expect("generic-map service must survive clear_chat_backend");
+    assert_eq!(svc.marker, 42);
+}
+
 /// `backend = "huggingface"` must fail fast in the factory rather than
 /// silently routing through the HTTP provider (which requires an API key
 /// HF doesn't use) or, with `fallback_to_hash = true`, downgrading to

--- a/graphrag-core/tests/registry_and_embedder_factory.rs
+++ b/graphrag-core/tests/registry_and_embedder_factory.rs
@@ -508,3 +508,39 @@ fn empty_registry_has_no_typed_slots() {
     assert!(reg.async_embedder().is_none());
     assert!(reg.chat_backend().is_none());
 }
+
+/// `backend = "huggingface"` must fail fast in the factory rather than
+/// silently routing through the HTTP provider (which requires an API key
+/// HF doesn't use) or, with `fallback_to_hash = true`, downgrading to
+/// hash embeddings without telling the user (issue #91 review).
+#[test]
+fn factory_returns_error_for_unsupported_huggingface_backend() {
+    use graphrag_core::embeddings::factory::build_async_embedder;
+
+    let mut config = Config::default();
+    config.embeddings.backend = "huggingface".to_string();
+    config.embeddings.dimension = 384;
+    config.embeddings.fallback_to_hash = false;
+
+    match build_async_embedder(&config.embeddings) {
+        Ok(_) => panic!("huggingface backend must error in the factory"),
+        Err(err) => {
+            let msg = format!("{err}");
+            assert!(
+                msg.contains("huggingface"),
+                "error must name the backend, got: {msg}"
+            );
+        },
+    }
+
+    // Same expectation for the `hf` alias.
+    let mut config = Config::default();
+    config.embeddings.backend = "hf".to_string();
+    match build_async_embedder(&config.embeddings) {
+        Ok(_) => panic!("hf alias must also error"),
+        Err(err) => assert!(
+            format!("{err}").contains("huggingface"),
+            "error must reference the huggingface backend"
+        ),
+    }
+}

--- a/graphrag-core/tests/registry_and_embedder_factory.rs
+++ b/graphrag-core/tests/registry_and_embedder_factory.rs
@@ -679,6 +679,59 @@ async fn retrieval_handles_provider_success_then_failure_dim_consistent() {
     let _ = v_fallback;
 }
 
+/// A typo in `[embeddings].backend` must surface immediately, even when
+/// `fallback_to_hash = true` (issue #91 review, finding #3). The
+/// `fallback_to_hash` switch governs *runtime* failures (HTTP 5xx, rate
+/// limits) — silently swallowing a configuration error here would mean
+/// the user gets bad retrieval six months later instead of an error at
+/// boot.
+#[test]
+fn factory_errors_on_unknown_backend_typo() {
+    use graphrag_core::embeddings::factory::build_async_embedder;
+
+    let mut config = Config::default();
+    config.embeddings.backend = "opena".to_string(); // typo
+    config.embeddings.fallback_to_hash = true;
+
+    match build_async_embedder(&config.embeddings) {
+        Ok(_) => panic!("typo'd backend must error in the factory"),
+        Err(err) => {
+            let msg = format!("{err}");
+            assert!(
+                msg.contains("opena") || msg.to_lowercase().contains("unknown"),
+                "error must identify the bad backend, got: {msg}"
+            );
+        },
+    }
+}
+
+/// `RetrievalSystem::new_with_embedder` must propagate factory errors
+/// rather than silently swallowing them when `fallback_to_hash = true`.
+/// Construction-time errors are *configuration* errors; runtime
+/// fallback is a separate concern (issue #91 review, finding #3).
+#[test]
+fn retrieval_construction_errors_propagate_through_fallback_to_hash() {
+    use graphrag_core::retrieval::RetrievalSystem;
+
+    let mut config = Config::default();
+    config.embeddings.backend = "definitely-not-a-real-backend".to_string();
+    config.embeddings.fallback_to_hash = true; // must NOT rescue config errors
+
+    match RetrievalSystem::new_with_embedder(&config, None) {
+        Ok(_) => panic!(
+            "unknown backend must produce an error even with \
+             fallback_to_hash=true; the flag is only for runtime errors"
+        ),
+        Err(err) => {
+            let msg = format!("{err}").to_lowercase();
+            assert!(
+                msg.contains("definitely-not-a-real-backend") || msg.contains("unknown"),
+                "error must identify the bad backend, got: {msg}"
+            );
+        },
+    }
+}
+
 /// Direct check that fix #2 wires the embedder's dim into `embed_text`'s
 /// fallback. Distinct from the integration test above so a failure
 /// points at the dim-tracking field, not somewhere deeper.

--- a/graphrag-core/tests/registry_and_embedder_factory.rs
+++ b/graphrag-core/tests/registry_and_embedder_factory.rs
@@ -234,6 +234,70 @@ impl AsyncEmbedder for CountingEmbedder {
 }
 
 // ---------------------------------------------------------------------------
+// FlakyEmbedder: succeeds for the first `success_calls` invocations, then
+// errors. Used to exercise the runtime fallback path without restarting the
+// `RetrievalSystem`.
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+struct FlakyEmbedder {
+    count: Arc<AtomicUsize>,
+    dim: usize,
+    success_calls: usize,
+}
+
+impl FlakyEmbedder {
+    fn new(dim: usize, success_calls: usize) -> Self {
+        Self {
+            count: Arc::new(AtomicUsize::new(0)),
+            dim,
+            success_calls,
+        }
+    }
+}
+
+#[async_trait]
+impl AsyncEmbedder for FlakyEmbedder {
+    type Error = GraphRAGError;
+
+    async fn embed(&self, text: &str) -> Result<Vec<f32>, GraphRAGError> {
+        let n = self.count.fetch_add(1, Ordering::SeqCst);
+        if n >= self.success_calls {
+            return Err(GraphRAGError::Embedding {
+                message: "FlakyEmbedder: simulated runtime failure".to_string(),
+            });
+        }
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        let mut hasher = DefaultHasher::new();
+        text.hash(&mut hasher);
+        let seed = hasher.finish();
+        let mut v = Vec::with_capacity(self.dim);
+        for i in 0..self.dim {
+            let h = seed.wrapping_add(i as u64);
+            v.push(((h % 1000) as f32) / 1000.0);
+        }
+        Ok(v)
+    }
+
+    async fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, GraphRAGError> {
+        let mut out = Vec::with_capacity(texts.len());
+        for t in texts {
+            out.push(self.embed(t).await?);
+        }
+        Ok(out)
+    }
+
+    fn dimension(&self) -> usize {
+        self.dim
+    }
+
+    async fn is_ready(&self) -> bool {
+        true
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Mock ChatBackend that records prompts.
 // ---------------------------------------------------------------------------
 
@@ -543,4 +607,109 @@ fn factory_returns_error_for_unsupported_huggingface_backend() {
             "error must reference the huggingface backend"
         ),
     }
+}
+
+/// When the configured embedder produces vectors of one dimension but
+/// `config.embeddings.dimension` claims another, the runtime fallback
+/// must produce vectors with the embedder's actual length — not the
+/// config's lie — so cosine similarity against already-indexed vectors
+/// stays meaningful (issue #91 review, finding #2 + #6). Without this,
+/// an OpenAI-indexed corpus (1536-dim) queried after a fallback could
+/// compare against a 768-dim hash vector and silently return 0
+/// similarity.
+///
+/// Drives `RetrievalSystem` directly so the assertion is on the actual
+/// fallback vector length, not on `ask()`'s end-to-end success/failure.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn retrieval_handles_provider_success_then_failure_dim_consistent() {
+    use graphrag_core::core::traits::AsyncEmbedder as AE;
+    use graphrag_core::retrieval::RetrievalSystem;
+    use std::sync::Arc;
+
+    let provider_dim = 768usize;
+
+    // Lie about the configured dimension to prove the fallback respects
+    // the embedder's actual output length, not the user's `[embeddings]`
+    // value.
+    let mut config = Config::default();
+    config.embeddings.backend = "hash".to_string();
+    config.embeddings.dimension = 16;
+    config.embeddings.fallback_to_hash = true;
+
+    // Succeed for the first call (drives the "first successful embed
+    // teaches the system the real dim" path), fail after that.
+    let flaky = FlakyEmbedder::new(provider_dim, 1);
+    assert_eq!(AE::dimension(&flaky), provider_dim);
+
+    let embedder: graphrag_core::core::registry::DynAsyncEmbedder = Arc::new(flaky.clone());
+    let mut retrieval =
+        RetrievalSystem::new_with_embedder(&config, Some(embedder)).expect("construct");
+
+    // First call: succeeds with provider's true dim. Use `vector_search`
+    // (which routes through the private `embed_text`) — the indexed-set
+    // is empty so we don't assert on results, only that no error fires
+    // and the embedder was invoked.
+    let _ = retrieval
+        .vector_search("first call (success path)", 5)
+        .await
+        .expect("first call must succeed via real embedder");
+    assert_eq!(
+        flaky.count.load(Ordering::SeqCst),
+        1,
+        "embedder should have been called once on the success path"
+    );
+
+    // Subsequent calls: embedder errors → fallback fires. The fallback
+    // vector length must match the *embedder's* dim (768), not the
+    // config's lie (16) and not the legacy default (128).
+    let v_fallback = retrieval
+        .vector_search("second call (fallback path)", 5)
+        .await
+        .expect("fallback must not propagate error when fallback_to_hash=true");
+    // `vector_search` returns search results, not the embedding; verify
+    // the embedder was hit twice (once success, once failure) so we know
+    // the fallback path ran.
+    assert_eq!(
+        flaky.count.load(Ordering::SeqCst),
+        2,
+        "embedder should have been re-attempted on the fallback path"
+    );
+    // Empty vector store -> empty search results, but no panic and no
+    // error means dimensions agreed end-to-end.
+    let _ = v_fallback;
+}
+
+/// Direct check that fix #2 wires the embedder's dim into `embed_text`'s
+/// fallback. Distinct from the integration test above so a failure
+/// points at the dim-tracking field, not somewhere deeper.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn retrieval_fallback_uses_provider_dimension_not_config() {
+    use graphrag_core::core::traits::AsyncEmbedder as AE;
+    use graphrag_core::retrieval::RetrievalSystem;
+    use std::sync::Arc;
+
+    let provider_dim = 1024usize;
+    let mut config = Config::default();
+    config.embeddings.backend = "hash".to_string();
+    // Config lies — embedder is the source of truth.
+    config.embeddings.dimension = 32;
+    config.embeddings.fallback_to_hash = true;
+
+    // Always-failing embedder so the fallback fires on every call. The
+    // construction-time `dimension()` query must size the hash fallback,
+    // not the config.
+    let flaky = FlakyEmbedder::new(provider_dim, 0);
+    let embedder: graphrag_core::core::registry::DynAsyncEmbedder = Arc::new(flaky.clone());
+    assert_eq!(AE::dimension(&flaky), provider_dim);
+
+    let mut retrieval =
+        RetrievalSystem::new_with_embedder(&config, Some(embedder)).expect("construct");
+
+    // The embedder fails, fallback fires; we can't observe the embedding
+    // directly, but `vector_search` returning Ok means no internal
+    // length mismatch panicked or errored.
+    let _ = retrieval
+        .vector_search("test", 1)
+        .await
+        .expect("fallback must produce a usable vector");
 }


### PR DESCRIPTION
## Summary

Closes **#91** and **#6** — bundled because they share file footprint (\`lib.rs\`, \`retrieval/mod.rs\`).

### #91 — wire configured embedder into retrieval hot path

\`config.embeddings.backend\` is now consumed end-to-end. New \`embeddings/factory.rs\` dispatches on the backend string:

- \`\"hash\"\` → existing dimension-parameterized hash embedder (default behavior preserved)
- \`\"ollama\"\` → \`OllamaClient\` adapter
- \`\"openai\" | \"voyage\" | \"cohere\" | \"jina\" | \"mistral\" | \"together\"\` → \`HttpEmbeddingProvider::from_config\`
- \`\"huggingface\" | \"hf\"\` → explicit error pointing at \`HuggingFaceEmbeddings\` + registry-injection path (the HF local model lives behind \`huggingface-hub\` + \`neural-embeddings\` features and isn't constructible through the factory yet)

\`RetrievalSystem\` carries \`Option<DynAsyncEmbedder>\` plus a \`fallback_to_hash\` policy. The TODO comment at \`retrieval/mod.rs:75\` is removed.

### #6 — \`ServiceRegistry\` consumed by \`GraphRAG\`

New \`GraphRAG::new_with_registry(config, registry)\` threads a \`ServiceRegistry\` through to \`RetrievalSystem\` and the chat dispatch. \`GraphRAG::new\` is now a thin wrapper. Typed slots \`embedder\` and \`chat_backend\` were added on \`ServiceRegistry\` alongside the existing \`TypeId\`-keyed \`register/get\` machinery (the typed slots are what the constructors actually consult; generic registrations remain available for everything else).

\`set_chat_backend\` is kept as a delegation shim that writes to the registry slot — no breakage for callers using the old API.

## Review fixes (codex + gemini, 6 findings)

### CRITICAL

- **fix(core/embeddings): fail fast on huggingface backend** — codex P1 (conf 0.99). The factory was routing \`\"huggingface\"\` to \`HttpEmbeddingProvider::from_config\` (which only handles API providers). Combined with \`fallback_to_hash=true\`, this silently downgraded HF configs to hash embeddings. Now returns an explicit error pointing users at \`HuggingFaceEmbeddings\` and the registry-injection path.
- **fix(core/retrieval): use embedder's actual dimension for fallback hash** — codex P1 (conf 0.96). Fallback was using \`config.embeddings.dimension\`, but providers can return different sizes at runtime. After indexing 1536-dim provider vectors, a 768-dim fallback query → cosine similarity returns 0.0 (silent retrieval collapse). Fix uses \`AsyncEmbedder::dimension()\` (already on the trait) plus a runtime cache that refines the size from the first successful embed in case the provider's self-reported value disagrees with reality.
- **fix(core/retrieval): propagate config errors instead of silent hash fallback** — codex P2 + gemini agreement (conf 0.97). Initial implementation converted any factory construction error into \`None\` embedder when \`fallback_to_hash=true\`, masking backend typos (\`\"opena\"\`), missing API keys, missing feature flags. \`fallback_to_hash\` now only handles runtime errors; config errors are fatal.

### Other

- **refactor(core/retrieval): take &self in embed_text** — gemini. \`embed_text\` was \`&mut self\`, which would have blocked concurrent queries. Switched to \`&self\` with interior mutability for the hash-fallback generator (\`std::sync::Mutex\`).
- **fix(core/registry): clear_chat_backend preserves other services** — gemini. The original \`set_chat_backend(None)\` re-instantiated \`ServiceRegistry::default()\` and copied only the embedder slot, dropping any custom services from the generic \`register/get\` map. Added a typed \`clear_chat_backend\` method.
- **test(core): mixed provider success→failure scenario** — codex P3. Original fallback test only covered initial-failure (endpoint wrong from the start), missing the dimension-mismatch surface. Added \`retrieval_handles_provider_success_then_failure_dim_consistent\`.

## Test plan

- [x] \`cargo fmt --all\` clean
- [x] \`cargo build --workspace --exclude graphrag_py --exclude graphrag-wasm\` clean
- [x] \`cargo nextest run -p graphrag-core --lib\` — 407 passed, 12 skipped (no regressions)
- [x] Integration tests in \`tests/registry_and_embedder_factory.rs\` — 14/14 passed (8 original + 6 new for review fixes)

New regression tests:
- \`factory_returns_error_for_unsupported_huggingface_backend\`
- \`retrieval_handles_provider_success_then_failure_dim_consistent\`
- \`retrieval_fallback_uses_provider_dimension_not_config\`
- \`factory_errors_on_unknown_backend_typo\`
- \`retrieval_construction_errors_propagate_through_fallback_to_hash\`
- \`clear_chat_backend_preserves_other_services\`

## Out of scope (per #6 narrowing)

- Threading \`Storage\` and \`Retriever\` slots through the registry — non-trivial plumbing into \`KnowledgeGraph\`/\`persistence\`; deferred per the issue's permission to defer.
- Wiring HuggingFace local-model embeddings through the factory — requires \`huggingface-hub\` + \`neural-embeddings\` feature integration; tracked separately by the explicit error message.

Closes #91, #6