### PR TITLE
feat(core/retrieval): Local Search mode with token-budgeted context packer

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,9 +434,12 @@ graphrag query "How does Bob mentor Carol?" --mode hybrid
 graphrag query "Tell me about Alice" --mode local --budget 2048
 ```
 
-Local mode is best for narrow, entity-specific questions where you want
-a tight, deterministic context for the LLM. A future `--mode global`
-(blocked on #93) will mirror this for community-level overview queries.
+`--mode` is case-insensitive and routes through a single core entrypoint
+(`RetrievalSystem::search_with_mode`) shared by the CLI, FFI, and
+library API. Local mode is best for narrow, entity-specific questions
+where you want a tight, deterministic context for the LLM. A future
+`--mode global` (blocked on #93) will mirror this for community-level
+overview queries.
 
 Token counting currently uses a `chars / 4` heuristic. The plan is to
 switch to `tiktoken-rs` (`cl100k_base`) once PR #126 lands so OpenAI

--- a/README.md
+++ b/README.md
@@ -419,6 +419,29 @@ cargo build --release
 ./target/release/graphrag-rs config.toml query "Your question"
 ```
 
+### Query Modes
+
+`graphrag query` supports an explicit retrieval mode flag (#102):
+
+```bash
+# Default: multi-strategy hybrid retrieval (vector + graph + hierarchical).
+graphrag query "How does Bob mentor Carol?" --mode hybrid
+
+# Local Search (Edge et al. 2024): entity-anchored, token-budgeted context.
+# Returns a single prompt-ready bundle of (a) entity descriptions,
+# (b) relationship descriptions, (c) source-chunk text, (d) community
+# context, packed in priority order against `--budget` tokens.
+graphrag query "Tell me about Alice" --mode local --budget 2048
+```
+
+Local mode is best for narrow, entity-specific questions where you want
+a tight, deterministic context for the LLM. A future `--mode global`
+(blocked on #93) will mirror this for community-level overview queries.
+
+Token counting currently uses a `chars / 4` heuristic. The plan is to
+switch to `tiktoken-rs` (`cl100k_base`) once PR #126 lands so OpenAI
+budgets are precise.
+
 ## Configuration
 
 ### Basic Configuration (config.toml)

--- a/graphrag-cli/README.md
+++ b/graphrag-cli/README.md
@@ -156,11 +156,19 @@ graphrag query "Tell me about Alice" --mode hybrid
 graphrag query "Tell me about Alice" --mode local --budget 2048
 ```
 
+`--mode` is case-insensitive (`local`, `Local`, `HYBRID` all parse).
+Both modes share a single dispatch path through
+`RetrievalSystem::search_with_mode`, so the CLI and library API behave
+identically.
+
 Local mode prints (or returns as JSON, with `--format json`) the packed
 context tiers — entities, relationships, source chunks, communities —
 along with `total_tokens`, `budget`, and `dropped_tier` (set when the
-budget capped output). A future `--mode global` (#93) will mirror this
-for community-level queries.
+budget capped output). The packer is item-by-item (partial-pack): items
+that fit are kept; the first item to overflow records `dropped_tier`
+and skips the remainder of that tier and every lower-priority tier.
+A future `--mode global` (#93) will mirror this for community-level
+queries.
 
 ---
 

--- a/graphrag-cli/README.md
+++ b/graphrag-cli/README.md
@@ -144,6 +144,24 @@ cargo run -p graphrag-cli -- bench \
 
 Output JSON includes: `init_ms`, `build_ms`, `total_query_ms`, `entities`, `relationships`, `chunks`, per-query `answer`, `confidence`, `sources`.
 
+### query --mode local (#102)
+
+The deprecated `query` subcommand now accepts an explicit retrieval mode:
+
+```bash
+# Default: hybrid (multi-strategy)
+graphrag query "Tell me about Alice" --mode hybrid
+
+# Local Search: entity-anchored, token-budgeted (Edge et al. 2024)
+graphrag query "Tell me about Alice" --mode local --budget 2048
+```
+
+Local mode prints (or returns as JSON, with `--format json`) the packed
+context tiers — entities, relationships, source chunks, communities —
+along with `total_tokens`, `budget`, and `dropped_tier` (set when the
+budget capped output). A future `--mode global` (#93) will mirror this
+for community-level queries.
+
 ---
 
 ## TUI Layout

--- a/graphrag-cli/src/handlers/graphrag.rs
+++ b/graphrag-cli/src/handlers/graphrag.rs
@@ -292,27 +292,52 @@ impl GraphRAGHandler {
         }
     }
 
-    /// Execute a Local Search query (entity-anchored, token-budgeted).
+    /// Execute a query in the requested paper-aligned mode.
     ///
-    /// Returns the packed `LocalContext`. The caller can render it to a
-    /// prompt via `LocalContext::to_prompt()` and decide whether to call the
-    /// LLM.
-    pub async fn query_local(
+    /// Routes through [`graphrag_core::GraphRAG::search_with_mode`] so the
+    /// CLI uses the same dispatch path as the library API. Returns a
+    /// `SearchOutput` discriminated by the requested mode.
+    pub async fn query_with_mode(
         &self,
         query_text: &str,
+        mode: graphrag_core::retrieval::QueryMode,
         budget: usize,
-    ) -> Result<graphrag_core::retrieval::LocalContext> {
-        tracing::info!("Executing local-mode query: {}", query_text);
+    ) -> Result<graphrag_core::retrieval::SearchOutput> {
+        tracing::info!("Executing {:?}-mode query: {}", mode, query_text);
         let mut guard = self.graphrag.lock().await;
         if let Some(ref mut graphrag) = *guard {
             graphrag
-                .query_local(query_text, budget)
+                .search_with_mode(query_text, mode, budget)
                 .await
                 .map_err(|e| eyre!(e.to_string()))
         } else {
             Err(eyre!(
                 "GraphRAG not initialized. Use /config to load a configuration first."
             ))
+        }
+    }
+
+    /// Execute a Local Search query (entity-anchored, token-budgeted).
+    ///
+    /// Convenience wrapper around [`Self::query_with_mode`] with
+    /// `QueryMode::Local`.
+    pub async fn query_local(
+        &self,
+        query_text: &str,
+        budget: usize,
+    ) -> Result<graphrag_core::retrieval::LocalContext> {
+        match self
+            .query_with_mode(
+                query_text,
+                graphrag_core::retrieval::QueryMode::Local,
+                budget,
+            )
+            .await?
+        {
+            graphrag_core::retrieval::SearchOutput::Local(ctx) => Ok(ctx),
+            graphrag_core::retrieval::SearchOutput::Hybrid(_) => {
+                Err(eyre!("search_with_mode(Local) returned Hybrid output"))
+            },
         }
     }
 

--- a/graphrag-cli/src/handlers/graphrag.rs
+++ b/graphrag-cli/src/handlers/graphrag.rs
@@ -292,6 +292,30 @@ impl GraphRAGHandler {
         }
     }
 
+    /// Execute a Local Search query (entity-anchored, token-budgeted).
+    ///
+    /// Returns the packed `LocalContext`. The caller can render it to a
+    /// prompt via `LocalContext::to_prompt()` and decide whether to call the
+    /// LLM.
+    pub async fn query_local(
+        &self,
+        query_text: &str,
+        budget: usize,
+    ) -> Result<graphrag_core::retrieval::LocalContext> {
+        tracing::info!("Executing local-mode query: {}", query_text);
+        let mut guard = self.graphrag.lock().await;
+        if let Some(ref mut graphrag) = *guard {
+            graphrag
+                .query_local(query_text, budget)
+                .await
+                .map_err(|e| eyre!(e.to_string()))
+        } else {
+            Err(eyre!(
+                "GraphRAG not initialized. Use /config to load a configuration first."
+            ))
+        }
+    }
+
     /// Execute a query and return both LLM answer and raw search results
     ///
     /// Returns a tuple of (llm_answer, raw_results)

--- a/graphrag-cli/src/lib.rs
+++ b/graphrag-cli/src/lib.rs
@@ -95,6 +95,15 @@ pub enum Commands {
         /// Configuration file (required if not already initialized)
         #[arg(short, long)]
         config: Option<PathBuf>,
+
+        /// Retrieval mode: "hybrid" (default, multi-strategy) or "local"
+        /// (entity-anchored, token-budgeted; Edge et al. 2024 Local Search).
+        #[arg(long, default_value = "hybrid", value_parser = ["hybrid", "local"])]
+        mode: String,
+
+        /// Token budget for `--mode local` context packer. Ignored otherwise.
+        #[arg(long, default_value_t = 2048)]
+        budget: usize,
     },
 
     /// List entities in the knowledge graph (deprecated: prefer TUI with /entities)
@@ -212,7 +221,12 @@ pub async fn run() -> Result<()> {
                 println!("✅ {}", result);
             }
         },
-        Some(Commands::Query { query, config }) => {
+        Some(Commands::Query {
+            query,
+            config,
+            mode,
+            budget,
+        }) => {
             setup_logging(cli.debug)?;
             eprintln!(
                 "⚠️  `query` is deprecated. Prefer: graphrag tui, then /query {}",
@@ -220,20 +234,52 @@ pub async fn run() -> Result<()> {
             );
 
             let handler = init_handler(config).await?;
-            let (answer, raw_results) = handler.query_with_raw(&query).await?;
 
-            if cli.format == "json" {
-                println!(
-                    "{}",
-                    serde_json::json!({"query": query, "answer": answer, "sources": raw_results})
-                );
+            if mode == "local" {
+                let ctx = handler.query_local(&query, budget).await?;
+                if cli.format == "json" {
+                    println!(
+                        "{}",
+                        serde_json::json!({
+                            "query": query,
+                            "mode": "local",
+                            "budget": budget,
+                            "total_tokens": ctx.total_tokens,
+                            "seed_entities": ctx.seed_entities,
+                            "entity_descriptions": ctx.entity_descriptions,
+                            "relationship_descriptions": ctx.relationship_descriptions,
+                            "source_chunks": ctx.source_chunks,
+                            "community_context": ctx.community_context,
+                            "dropped_tier": ctx.dropped_tier.map(|t| t.label()),
+                        })
+                    );
+                } else {
+                    println!("📝 Query: {}\n", query);
+                    println!(
+                        "🎯 Mode: local  |  Budget: {} tokens  |  Used: {} tokens",
+                        budget, ctx.total_tokens
+                    );
+                    if let Some(tier) = ctx.dropped_tier {
+                        println!("⚠️  Truncated at tier: {}", tier.label());
+                    }
+                    println!("\n{}", ctx.to_prompt());
+                }
             } else {
-                println!("📝 Query: {}\n", query);
-                println!("💡 Answer:\n{}\n", answer);
-                if !raw_results.is_empty() {
-                    println!("📚 Sources:");
-                    for (i, src) in raw_results.iter().enumerate() {
-                        println!("   {}. {}", i + 1, src);
+                let (answer, raw_results) = handler.query_with_raw(&query).await?;
+
+                if cli.format == "json" {
+                    println!(
+                        "{}",
+                        serde_json::json!({"query": query, "answer": answer, "sources": raw_results})
+                    );
+                } else {
+                    println!("📝 Query: {}\n", query);
+                    println!("💡 Answer:\n{}\n", answer);
+                    if !raw_results.is_empty() {
+                        println!("📚 Sources:");
+                        for (i, src) in raw_results.iter().enumerate() {
+                            println!("   {}. {}", i + 1, src);
+                        }
                     }
                 }
             }

--- a/graphrag-cli/src/lib.rs
+++ b/graphrag-cli/src/lib.rs
@@ -98,7 +98,8 @@ pub enum Commands {
 
         /// Retrieval mode: "hybrid" (default, multi-strategy) or "local"
         /// (entity-anchored, token-budgeted; Edge et al. 2024 Local Search).
-        #[arg(long, default_value = "hybrid", value_parser = ["hybrid", "local"])]
+        /// Case-insensitive; resolved via `QueryMode::from_str`.
+        #[arg(long, default_value = "hybrid")]
         mode: String,
 
         /// Token budget for `--mode local` context packer. Ignored otherwise.
@@ -235,53 +236,76 @@ pub async fn run() -> Result<()> {
 
             let handler = init_handler(config).await?;
 
-            if mode == "local" {
-                let ctx = handler.query_local(&query, budget).await?;
-                if cli.format == "json" {
-                    println!(
-                        "{}",
-                        serde_json::json!({
-                            "query": query,
-                            "mode": "local",
-                            "budget": budget,
-                            "total_tokens": ctx.total_tokens,
-                            "seed_entities": ctx.seed_entities,
-                            "entity_descriptions": ctx.entity_descriptions,
-                            "relationship_descriptions": ctx.relationship_descriptions,
-                            "source_chunks": ctx.source_chunks,
-                            "community_context": ctx.community_context,
-                            "dropped_tier": ctx.dropped_tier.map(|t| t.label()),
-                        })
-                    );
-                } else {
-                    println!("📝 Query: {}\n", query);
-                    println!(
-                        "🎯 Mode: local  |  Budget: {} tokens  |  Used: {} tokens",
-                        budget, ctx.total_tokens
-                    );
-                    if let Some(tier) = ctx.dropped_tier {
-                        println!("⚠️  Truncated at tier: {}", tier.label());
-                    }
-                    println!("\n{}", ctx.to_prompt());
-                }
-            } else {
-                let (answer, raw_results) = handler.query_with_raw(&query).await?;
+            // Parse `--mode` case-insensitively via the core enum so the
+            // CLI shares the same vocabulary as the library API.
+            use std::str::FromStr;
+            let parsed_mode = graphrag_core::retrieval::QueryMode::from_str(&mode)
+                .map_err(|e| color_eyre::eyre::eyre!(e))?;
 
-                if cli.format == "json" {
-                    println!(
-                        "{}",
-                        serde_json::json!({"query": query, "answer": answer, "sources": raw_results})
-                    );
-                } else {
-                    println!("📝 Query: {}\n", query);
-                    println!("💡 Answer:\n{}\n", answer);
-                    if !raw_results.is_empty() {
-                        println!("📚 Sources:");
-                        for (i, src) in raw_results.iter().enumerate() {
-                            println!("   {}. {}", i + 1, src);
+            match parsed_mode {
+                graphrag_core::retrieval::QueryMode::Local => {
+                    // Route through the unified entrypoint and unwrap the
+                    // local variant for legacy CLI rendering.
+                    let out = handler.query_with_mode(&query, parsed_mode, budget).await?;
+                    let ctx = match out {
+                        graphrag_core::retrieval::SearchOutput::Local(c) => c,
+                        graphrag_core::retrieval::SearchOutput::Hybrid(_) => {
+                            return Err(color_eyre::eyre::eyre!(
+                                "search_with_mode(Local) returned Hybrid output"
+                            ));
+                        },
+                    };
+
+                    if cli.format == "json" {
+                        println!(
+                            "{}",
+                            serde_json::json!({
+                                "query": query,
+                                "mode": "local",
+                                "budget": budget,
+                                "total_tokens": ctx.total_tokens,
+                                "seed_entities": ctx.seed_entities,
+                                "entity_descriptions": ctx.entity_descriptions,
+                                "relationship_descriptions": ctx.relationship_descriptions,
+                                "source_chunks": ctx.source_chunks,
+                                "community_context": ctx.community_context,
+                                "dropped_tier": ctx.dropped_tier.map(|t| t.label()),
+                            })
+                        );
+                    } else {
+                        println!("📝 Query: {}\n", query);
+                        println!(
+                            "🎯 Mode: local  |  Budget: {} tokens  |  Used: {} tokens",
+                            budget, ctx.total_tokens
+                        );
+                        if let Some(tier) = ctx.dropped_tier {
+                            println!("⚠️  Truncated at tier: {}", tier.label());
+                        }
+                        println!("\n{}", ctx.to_prompt());
+                    }
+                },
+                graphrag_core::retrieval::QueryMode::Hybrid => {
+                    // Hybrid still goes through the LLM-synthesis path;
+                    // `query_with_mode` would skip synthesis. Keep the
+                    // existing `query_with_raw` for human-friendly output.
+                    let (answer, raw_results) = handler.query_with_raw(&query).await?;
+
+                    if cli.format == "json" {
+                        println!(
+                            "{}",
+                            serde_json::json!({"query": query, "answer": answer, "sources": raw_results})
+                        );
+                    } else {
+                        println!("📝 Query: {}\n", query);
+                        println!("💡 Answer:\n{}\n", answer);
+                        if !raw_results.is_empty() {
+                            println!("📚 Sources:");
+                            for (i, src) in raw_results.iter().enumerate() {
+                                println!("   {}. {}", i + 1, src);
+                            }
                         }
                     }
-                }
+                },
             }
         },
         Some(Commands::Entities { filter, config }) => {
@@ -991,5 +1015,32 @@ mod tests {
             result.is_err(),
             "invalid TOML must produce a non-zero exit, got Ok"
         );
+    }
+
+    // `--mode` accepts mixed-case values (`Local`, `HYBRID`, `LoCaL`) and
+    // resolves them via `QueryMode::from_str`. Pins the case-insensitivity
+    // fix from the #102 review.
+    #[test]
+    fn cli_query_mode_accepts_mixed_case() {
+        use std::str::FromStr;
+        let cli = Cli::try_parse_from(["graphrag", "query", "What is AI?", "--mode", "Local"])
+            .expect("clap should accept mixed-case --mode");
+        let mode = match cli.command {
+            Some(Commands::Query { mode, .. }) => mode,
+            _ => panic!("expected Query subcommand"),
+        };
+        let parsed = graphrag_core::retrieval::QueryMode::from_str(&mode)
+            .expect("QueryMode::from_str must accept mixed-case Local");
+        assert_eq!(parsed, graphrag_core::retrieval::QueryMode::Local);
+
+        let cli = Cli::try_parse_from(["graphrag", "query", "anything", "--mode", "HYBRID"])
+            .expect("clap should accept HYBRID");
+        let mode = match cli.command {
+            Some(Commands::Query { mode, .. }) => mode,
+            _ => panic!("expected Query subcommand"),
+        };
+        let parsed = graphrag_core::retrieval::QueryMode::from_str(&mode)
+            .expect("QueryMode::from_str must accept HYBRID");
+        assert_eq!(parsed, graphrag_core::retrieval::QueryMode::Hybrid);
     }
 }

--- a/graphrag-core/src/core/mod.rs
+++ b/graphrag-core/src/core/mod.rs
@@ -493,6 +493,42 @@ impl KnowledgeGraph {
         }
     }
 
+    /// Return every relationship incident to `entity_id` paired with the
+    /// *other* endpoint, regardless of edge direction.
+    ///
+    /// Unlike [`get_neighbors`](Self::get_neighbors), which only walks
+    /// outgoing edges, this surfaces edges where `entity_id` is the
+    /// relationship `target` as well. Required by paper-aligned Local
+    /// Search so a seed entity that is only the *recipient* of an edge
+    /// still contributes to the relationship tier (#102 review).
+    pub fn get_incident_relationships(
+        &self,
+        entity_id: &EntityId,
+    ) -> Vec<(&Entity, &Relationship)> {
+        use petgraph::visit::EdgeRef;
+        use petgraph::Direction;
+
+        let Some(&node_idx) = self.entity_index.get(entity_id) else {
+            return Vec::new();
+        };
+
+        let outgoing = self
+            .graph
+            .edges_directed(node_idx, Direction::Outgoing)
+            .filter_map(|edge| {
+                let target_entity = self.graph.node_weight(edge.target())?;
+                Some((target_entity, edge.weight()))
+            });
+        let incoming = self
+            .graph
+            .edges_directed(node_idx, Direction::Incoming)
+            .filter_map(|edge| {
+                let source_entity = self.graph.node_weight(edge.source())?;
+                Some((source_entity, edge.weight()))
+            });
+        outgoing.chain(incoming).collect()
+    }
+
     /// Get all relationships in the graph
     pub fn get_all_relationships(&self) -> Vec<&Relationship> {
         self.graph.edge_weights().collect()

--- a/graphrag-core/src/lib.rs
+++ b/graphrag-core/src/lib.rs
@@ -1701,15 +1701,19 @@ impl GraphRAG {
         self.knowledge_graph.as_ref()
     }
 
-    /// Run paper-aligned Local Search and return a packed, token-budgeted
-    /// context (#102). The result is prompt-ready; the caller is responsible
-    /// for the LLM synthesis call.
+    /// Dispatch a query to the requested [`retrieval::QueryMode`].
+    ///
+    /// Single entrypoint for paper-aligned mode selection (#102). Routes
+    /// through [`retrieval::RetrievalSystem::search_with_mode`] so the CLI,
+    /// FFI, and library callers all share one code path. `budget` is only
+    /// consulted by `QueryMode::Local`.
     #[cfg(feature = "async")]
-    pub async fn query_local(
+    pub async fn search_with_mode(
         &mut self,
         query: &str,
+        mode: retrieval::QueryMode,
         budget: usize,
-    ) -> Result<retrieval::LocalContext> {
+    ) -> Result<retrieval::SearchOutput> {
         self.ensure_initialized()?;
         if self.has_documents() && !self.has_graph() {
             self.build_graph().await?;
@@ -1720,8 +1724,36 @@ impl GraphRAG {
             .ok_or_else(|| GraphRAGError::Config {
                 message: "Knowledge graph not initialized".to_string(),
             })?;
-        let ls = retrieval::LocalSearch::with_default_config(graph);
-        ls.search(query, budget)
+        let retrieval = self
+            .retrieval_system
+            .as_mut()
+            .ok_or_else(|| GraphRAGError::Config {
+                message: "Retrieval system not initialized".to_string(),
+            })?;
+        retrieval.search_with_mode(query, mode, budget, graph).await
+    }
+
+    /// Run paper-aligned Local Search and return a packed, token-budgeted
+    /// context (#102). The result is prompt-ready; the caller is responsible
+    /// for the LLM synthesis call.
+    ///
+    /// Convenience wrapper around [`Self::search_with_mode`] with
+    /// `QueryMode::Local`.
+    #[cfg(feature = "async")]
+    pub async fn query_local(
+        &mut self,
+        query: &str,
+        budget: usize,
+    ) -> Result<retrieval::LocalContext> {
+        match self
+            .search_with_mode(query, retrieval::QueryMode::Local, budget)
+            .await?
+        {
+            retrieval::SearchOutput::Local(ctx) => Ok(ctx),
+            retrieval::SearchOutput::Hybrid(_) => Err(GraphRAGError::Config {
+                message: "search_with_mode(Local) returned Hybrid output".to_string(),
+            }),
+        }
     }
 
     /// Get entity details by ID

--- a/graphrag-core/src/lib.rs
+++ b/graphrag-core/src/lib.rs
@@ -1701,6 +1701,29 @@ impl GraphRAG {
         self.knowledge_graph.as_ref()
     }
 
+    /// Run paper-aligned Local Search and return a packed, token-budgeted
+    /// context (#102). The result is prompt-ready; the caller is responsible
+    /// for the LLM synthesis call.
+    #[cfg(feature = "async")]
+    pub async fn query_local(
+        &mut self,
+        query: &str,
+        budget: usize,
+    ) -> Result<retrieval::LocalContext> {
+        self.ensure_initialized()?;
+        if self.has_documents() && !self.has_graph() {
+            self.build_graph().await?;
+        }
+        let graph = self
+            .knowledge_graph
+            .as_ref()
+            .ok_or_else(|| GraphRAGError::Config {
+                message: "Knowledge graph not initialized".to_string(),
+            })?;
+        let ls = retrieval::LocalSearch::with_default_config(graph);
+        ls.search(query, budget)
+    }
+
     /// Get entity details by ID
     pub fn get_entity(&self, entity_id: &str) -> Option<&Entity> {
         if let Some(graph) = &self.knowledge_graph {

--- a/graphrag-core/src/retrieval/local_search.rs
+++ b/graphrag-core/src/retrieval/local_search.rs
@@ -6,10 +6,13 @@
 //!   (c) Source-chunk text      — chunks where the seed entities were mentioned
 //!   (d) Covering community context — community summaries the seeds belong to
 //!
-//! Overflow drops from the lowest-priority tier first; tiers (b–d) are skipped
-//! whole if even one item would exceed the remaining budget. Token counting
-//! uses a `chars / 4` heuristic — accurate enough for budget gating, swappable
-//! for `tiktoken-rs` once it lands on the workspace (see PR #126).
+//! Packing is item-by-item (partial-pack), matching the Edge et al. paper:
+//! within a tier, items that fit are pushed into the context; the first item
+//! that overflows the remaining budget is recorded in `dropped_tier` and the
+//! rest of that tier — *and every lower-priority tier* — is skipped. Earlier
+//! items already pushed are kept. Token counting uses a `chars / 4` heuristic
+//! — accurate enough for budget gating, swappable for `tiktoken-rs` once it
+//! lands on the workspace (see PR #126).
 
 use crate::{
     core::{ChunkId, Entity, EntityId, KnowledgeGraph, Relationship},
@@ -18,6 +21,11 @@ use crate::{
 use std::collections::HashSet;
 
 /// Token budget tiers, in pack-priority order. Lower index = higher priority.
+///
+/// Tiers are packed item-by-item (partial-pack). When a single item exceeds
+/// the remaining budget, that tier records itself in `LocalContext::dropped_tier`
+/// and the packer skips every lower-priority tier; earlier items already
+/// pushed within the tier are retained.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LocalContextTier {
     /// Entity descriptions (highest priority).
@@ -65,9 +73,11 @@ impl Default for LocalSearchConfig {
 
 /// Packed local-search context, organized by priority tier.
 ///
-/// Each `Vec<String>` holds the items that fit in the budget for that tier.
-/// `dropped_tier` records the first tier that overflowed (if any) so callers
-/// can surface budget-exhaustion to users.
+/// Each `Vec<String>` holds the items that fit in the budget for that tier
+/// (partial-pack: items below the budget are kept; the first item that would
+/// overflow stops packing for that tier and every lower-priority tier).
+/// `dropped_tier` records the first tier whose items hit the budget cap
+/// (if any) so callers can surface budget-exhaustion to users.
 #[derive(Debug, Clone, Default)]
 pub struct LocalContext {
     /// Names of the seed entities the context was anchored on.
@@ -84,7 +94,9 @@ pub struct LocalContext {
     pub total_tokens: usize,
     /// Token budget the context was packed against.
     pub budget: usize,
-    /// First tier that hit the budget cap, if any.
+    /// First tier whose items hit the budget cap, if any. The named tier may
+    /// still have packed earlier items before the overflow item triggered
+    /// `dropped` (partial-pack semantics).
     pub dropped_tier: Option<LocalContextTier>,
 }
 
@@ -538,6 +550,98 @@ mod tests {
         assert_eq!(LocalContextTier::Relationships.label(), "Relationships");
         assert_eq!(LocalContextTier::SourceChunks.label(), "Sources");
         assert_eq!(LocalContextTier::Community.label(), "Communities");
+    }
+
+    /// Partial-pack semantics: when the budget fits the first relationship
+    /// but not the second, exactly one relationship is packed and
+    /// `dropped_tier == Some(Relationships)`. Pins finding #2 from the #102
+    /// review (the doc previously over-promised "whole-tier-skip").
+    #[test]
+    fn local_search_partial_packs_relationships_when_budget_allows_some() {
+        let mut g = KnowledgeGraph::new();
+        g.add_chunk(make_chunk("c1", "doc1", "Alice and Bob."))
+            .unwrap();
+
+        let alice = Entity::new(
+            EntityId::new("alice".into()),
+            "Alice".into(),
+            "PERSON".into(),
+            0.95,
+        );
+        let bob = Entity::new(
+            EntityId::new("bob".into()),
+            "Bob".into(),
+            "PERSON".into(),
+            0.95,
+        );
+        let carol = Entity::new(
+            EntityId::new("carol".into()),
+            "Carol".into(),
+            "PERSON".into(),
+            0.95,
+        );
+        g.add_entity(alice.clone()).unwrap();
+        g.add_entity(bob.clone()).unwrap();
+        g.add_entity(carol.clone()).unwrap();
+
+        let r_light = Relationship::new(
+            EntityId::new("alice".into()),
+            EntityId::new("bob".into()),
+            "MET".into(),
+            0.9,
+        );
+        let r_heavy = Relationship::new(
+            EntityId::new("alice".into()),
+            EntityId::new("carol".into()),
+            "COLLABORATED_EXTENSIVELY_WITH".into(),
+            0.9,
+        );
+        // Insert the heavy edge first; petgraph yields outgoing edges in
+        // reverse insertion order, so the light edge is encountered first
+        // by the partial packer (and fits), then the heavy edge overflows.
+        g.add_relationship(r_heavy.clone()).unwrap();
+        g.add_relationship(r_light.clone()).unwrap();
+
+        // Pre-compute exact costs to bracket the budget.
+        let alice_desc = format_entity_description(&alice);
+        let r_light_desc = format_relationship(&alice, &bob, &r_light);
+        let r_heavy_desc = format_relationship(&alice, &carol, &r_heavy);
+        let entity_cost = estimate_tokens(&alice_desc);
+        let r_light_cost = estimate_tokens(&r_light_desc);
+        let r_heavy_cost = estimate_tokens(&r_heavy_desc);
+        // Sanity: heavy relationship must be strictly heavier than the light
+        // one so the budget below can fit one but not both.
+        assert!(
+            r_heavy_cost > r_light_cost,
+            "fixture must have r_heavy heavier than r_light ({} vs {})",
+            r_heavy_cost,
+            r_light_cost
+        );
+
+        // Budget = entities + lighter relationship. The heavier one must
+        // overflow and trip `dropped_tier == Relationships`.
+        let budget = entity_cost + r_light_cost;
+
+        let ls = LocalSearch::new(
+            &g,
+            LocalSearchConfig {
+                budget,
+                top_k_entities: 1, // only Alice — keeps tier (a) deterministic
+                include_neighbors: true,
+            },
+        );
+        let ctx = ls.search("Tell me about Alice", budget).unwrap();
+
+        assert_eq!(ctx.entity_descriptions.len(), 1);
+        assert_eq!(
+            ctx.relationship_descriptions.len(),
+            1,
+            "partial-pack: exactly one relationship must fit, got {:?}",
+            ctx.relationship_descriptions
+        );
+        assert_eq!(ctx.dropped_tier, Some(LocalContextTier::Relationships));
+        // And tier (c) must be skipped because dropped is set.
+        assert!(ctx.source_chunks.is_empty());
     }
 
     /// Word-level matching must select short acronym entities like `AI` that

--- a/graphrag-core/src/retrieval/local_search.rs
+++ b/graphrag-core/src/retrieval/local_search.rs
@@ -236,21 +236,29 @@ impl<'a> LocalSearch<'a> {
         Ok(ctx)
     }
 
-    /// Case-insensitive substring entity match. Mirrors `analyze_query` in
-    /// `retrieval/mod.rs` so seeds line up with the existing classifier.
+    /// Word-level entity match: a seed is selected when the query and the
+    /// entity name share at least one normalized whitespace-separated token.
+    ///
+    /// Normalization strips punctuation (`is_alphanumeric() || is_whitespace()`)
+    /// and lower-cases. Word-level set intersection avoids the false positives
+    /// of substring matching (e.g. `bobblehead` matching entity `Bob`) and the
+    /// false negatives of a length cutoff (e.g. `AI`, `UK`).
     fn find_seed_entities(&self, query: &str) -> Vec<Entity> {
-        let q_lower = query.to_lowercase();
-        let words: Vec<&str> = q_lower.split_whitespace().collect();
+        let query_norm = normalize(query);
+        let query_words: HashSet<&str> = query_norm.split_whitespace().collect();
+        if query_words.is_empty() {
+            return Vec::new();
+        }
 
         let mut seeds: Vec<Entity> = Vec::new();
         let mut seen: HashSet<EntityId> = HashSet::new();
         for entity in self.graph.entities() {
-            let name_lower = entity.name.to_lowercase();
-            // Match if any whole word in the query overlaps the entity name.
-            // Avoid trivial 1- or 2-char overlaps which create noisy seeds.
-            let hit = words
-                .iter()
-                .any(|&w| w.len() >= 3 && (name_lower.contains(w) || w.contains(&name_lower)));
+            let name_norm = normalize(&entity.name);
+            let entity_words: HashSet<&str> = name_norm.split_whitespace().collect();
+            if entity_words.is_empty() {
+                continue;
+            }
+            let hit = !query_words.is_disjoint(&entity_words);
             if hit && !seen.contains(&entity.id) {
                 seen.insert(entity.id.clone());
                 seeds.push(entity.clone());
@@ -315,6 +323,16 @@ impl<'a> LocalSearch<'a> {
         }
         out
     }
+}
+
+/// Lower-case `s` and drop characters that are neither alphanumeric nor
+/// whitespace. Used to canonicalize both queries and entity names so seed
+/// matching can do clean whitespace-token set intersection.
+fn normalize(s: &str) -> String {
+    s.chars()
+        .filter(|c| c.is_alphanumeric() || c.is_whitespace())
+        .flat_map(|c| c.to_lowercase())
+        .collect()
 }
 
 fn format_entity_description(entity: &Entity) -> String {
@@ -520,6 +538,78 @@ mod tests {
         assert_eq!(LocalContextTier::Relationships.label(), "Relationships");
         assert_eq!(LocalContextTier::SourceChunks.label(), "Sources");
         assert_eq!(LocalContextTier::Community.label(), "Communities");
+    }
+
+    /// Word-level matching must select short acronym entities like `AI` that
+    /// the previous `len() >= 3` filter dropped.
+    #[test]
+    fn local_search_finds_short_acronym_entities() {
+        let mut g = KnowledgeGraph::new();
+        g.add_chunk(make_chunk("c1", "doc1", "AI is reshaping research."))
+            .unwrap();
+        g.add_entity(
+            Entity::new(
+                EntityId::new("ai".into()),
+                "AI".into(),
+                "CONCEPT".into(),
+                0.9,
+            )
+            .with_mentions(vec![make_mention("c1")]),
+        )
+        .unwrap();
+
+        let ls = LocalSearch::with_default_config(&g);
+        let ctx = ls.search("What is AI?", 4096).unwrap();
+        assert_eq!(ctx.seed_entities, vec!["AI".to_string()]);
+    }
+
+    /// `bobblehead` must NOT match entity `Bob` — substring matching is wrong.
+    #[test]
+    fn local_search_does_not_match_substring_within_word() {
+        let mut g = KnowledgeGraph::new();
+        g.add_chunk(make_chunk("c1", "doc1", "Bob is here."))
+            .unwrap();
+        g.add_entity(
+            Entity::new(
+                EntityId::new("bob".into()),
+                "Bob".into(),
+                "PERSON".into(),
+                0.9,
+            )
+            .with_mentions(vec![make_mention("c1")]),
+        )
+        .unwrap();
+
+        let ls = LocalSearch::with_default_config(&g);
+        let ctx = ls.search("Tell me about a bobblehead", 4096).unwrap();
+        assert!(
+            ctx.seed_entities.is_empty(),
+            "substring of a longer word must not match: got {:?}",
+            ctx.seed_entities
+        );
+    }
+
+    /// Punctuation in the query (e.g. `Alice?`) must be stripped before
+    /// matching; an entity named `Alice` must still seed.
+    #[test]
+    fn local_search_strips_punctuation_from_query() {
+        let mut g = KnowledgeGraph::new();
+        g.add_chunk(make_chunk("c1", "doc1", "Alice is here."))
+            .unwrap();
+        g.add_entity(
+            Entity::new(
+                EntityId::new("alice".into()),
+                "Alice".into(),
+                "PERSON".into(),
+                0.9,
+            )
+            .with_mentions(vec![make_mention("c1")]),
+        )
+        .unwrap();
+
+        let ls = LocalSearch::with_default_config(&g);
+        let ctx = ls.search("Alice?", 4096).unwrap();
+        assert_eq!(ctx.seed_entities, vec!["Alice".to_string()]);
     }
 
     /// Seeds that are only the *target* of a relationship must still see that

--- a/graphrag-core/src/retrieval/local_search.rs
+++ b/graphrag-core/src/retrieval/local_search.rs
@@ -263,13 +263,16 @@ impl<'a> LocalSearch<'a> {
     }
 
     /// Build relationship descriptions for edges incident to any seed entity.
+    ///
+    /// Uses `get_incident_relationships`, which walks both outgoing *and*
+    /// incoming edges so seeds that are only edge targets still contribute.
     fn collect_relationships(&self, seeds: &[Entity]) -> Vec<String> {
         let seed_ids: HashSet<EntityId> = seeds.iter().map(|e| e.id.clone()).collect();
         let mut emitted: HashSet<(EntityId, EntityId, String)> = HashSet::new();
         let mut out = Vec::new();
 
         for seed in seeds {
-            for (neighbor, rel) in self.graph.get_neighbors(&seed.id) {
+            for (other, rel) in self.graph.get_incident_relationships(&seed.id) {
                 let key = (
                     rel.source.clone(),
                     rel.target.clone(),
@@ -280,11 +283,16 @@ impl<'a> LocalSearch<'a> {
                 }
                 // Prefer relationships among seeds; if `include_neighbors` is
                 // off, skip edges that leave the seed set.
-                if !self.config.include_neighbors && !seed_ids.contains(&neighbor.id) {
+                if !self.config.include_neighbors && !seed_ids.contains(&other.id) {
                     continue;
                 }
                 emitted.insert(key);
-                out.push(format_relationship(seed, neighbor, rel));
+                // Render with the canonical (source -> target) direction
+                // from the relationship itself, regardless of which endpoint
+                // we found it through.
+                let source_entity = self.graph.get_entity(&rel.source).unwrap_or(seed);
+                let target_entity = self.graph.get_entity(&rel.target).unwrap_or(other);
+                out.push(format_relationship(source_entity, target_entity, rel));
             }
         }
         out
@@ -512,5 +520,86 @@ mod tests {
         assert_eq!(LocalContextTier::Relationships.label(), "Relationships");
         assert_eq!(LocalContextTier::SourceChunks.label(), "Sources");
         assert_eq!(LocalContextTier::Community.label(), "Communities");
+    }
+
+    /// Seeds that are only the *target* of a relationship must still see that
+    /// edge surface in tier (b). Regression test for the directed-graph
+    /// `get_neighbors` bug fixed by switching to `get_incident_relationships`.
+    #[test]
+    fn local_search_includes_incoming_relationships_for_seed() {
+        let mut g = KnowledgeGraph::new();
+        g.add_chunk(make_chunk("c1", "doc1", "Bob and Carol talked."))
+            .unwrap();
+
+        let bob = Entity::new(
+            EntityId::new("bob".into()),
+            "Bob".into(),
+            "PERSON".into(),
+            0.95,
+        )
+        .with_mentions(vec![make_mention("c1")]);
+        let carol = Entity::new(
+            EntityId::new("carol".into()),
+            "Carol".into(),
+            "PERSON".into(),
+            0.95,
+        )
+        .with_mentions(vec![make_mention("c1")]);
+        let dave = Entity::new(
+            EntityId::new("dave".into()),
+            "Dave".into(),
+            "PERSON".into(),
+            0.95,
+        )
+        .with_mentions(vec![make_mention("c1")]);
+
+        g.add_entity(bob).unwrap();
+        g.add_entity(carol).unwrap();
+        g.add_entity(dave).unwrap();
+
+        // Carol is the *source* of one edge (outgoing) ...
+        g.add_relationship(Relationship::new(
+            EntityId::new("carol".into()),
+            EntityId::new("dave".into()),
+            "MENTORED".into(),
+            0.85,
+        ))
+        .unwrap();
+        // ... and the *target* of another (incoming).
+        g.add_relationship(Relationship::new(
+            EntityId::new("bob".into()),
+            EntityId::new("carol".into()),
+            "MET".into(),
+            0.9,
+        ))
+        .unwrap();
+
+        // Query mentions only Carol, so Carol is the sole seed.
+        let ls = LocalSearch::new(
+            &g,
+            LocalSearchConfig {
+                budget: 4096,
+                top_k_entities: 1,
+                include_neighbors: true,
+            },
+        );
+        let ctx = ls.search("Tell me about Carol", 4096).unwrap();
+
+        assert_eq!(ctx.seed_entities, vec!["Carol".to_string()]);
+        // Both edges are incident to Carol; both must appear.
+        assert!(
+            ctx.relationship_descriptions
+                .iter()
+                .any(|d| d.contains("Bob") && d.contains("MET") && d.contains("Carol")),
+            "incoming edge Bob-MET->Carol must appear, got: {:?}",
+            ctx.relationship_descriptions
+        );
+        assert!(
+            ctx.relationship_descriptions
+                .iter()
+                .any(|d| d.contains("Carol") && d.contains("MENTORED") && d.contains("Dave")),
+            "outgoing edge Carol-MENTORED->Dave must appear, got: {:?}",
+            ctx.relationship_descriptions
+        );
     }
 }

--- a/graphrag-core/src/retrieval/local_search.rs
+++ b/graphrag-core/src/retrieval/local_search.rs
@@ -1,0 +1,516 @@
+//! Local Search: entity-anchored, token-budgeted context packer (Edge et al. 2024).
+//!
+//! Priority tiers, packed in order until the budget is exhausted:
+//!   (a) Entity descriptions    — define the answer, cheapest tokens, dropped last
+//!   (b) Relationship descriptions — connections among the seed entities
+//!   (c) Source-chunk text      — chunks where the seed entities were mentioned
+//!   (d) Covering community context — community summaries the seeds belong to
+//!
+//! Overflow drops from the lowest-priority tier first; tiers (b–d) are skipped
+//! whole if even one item would exceed the remaining budget. Token counting
+//! uses a `chars / 4` heuristic — accurate enough for budget gating, swappable
+//! for `tiktoken-rs` once it lands on the workspace (see PR #126).
+
+use crate::{
+    core::{ChunkId, Entity, EntityId, KnowledgeGraph, Relationship},
+    Result,
+};
+use std::collections::HashSet;
+
+/// Token budget tiers, in pack-priority order. Lower index = higher priority.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LocalContextTier {
+    /// Entity descriptions (highest priority).
+    Entities,
+    /// Relationship descriptions among the seed entities.
+    Relationships,
+    /// Source chunks where the seed entities are mentioned.
+    SourceChunks,
+    /// Covering community summaries.
+    Community,
+}
+
+impl LocalContextTier {
+    /// Human-readable label for this tier (for diagnostics / display).
+    pub fn label(self) -> &'static str {
+        match self {
+            LocalContextTier::Entities => "Entities",
+            LocalContextTier::Relationships => "Relationships",
+            LocalContextTier::SourceChunks => "Sources",
+            LocalContextTier::Community => "Communities",
+        }
+    }
+}
+
+/// Configuration for a `LocalSearch` invocation.
+#[derive(Debug, Clone)]
+pub struct LocalSearchConfig {
+    /// Token budget for the assembled context.
+    pub budget: usize,
+    /// Maximum number of seed entities harvested from the query.
+    pub top_k_entities: usize,
+    /// Whether to expand to depth-1 neighbours when collecting relationships.
+    pub include_neighbors: bool,
+}
+
+impl Default for LocalSearchConfig {
+    fn default() -> Self {
+        Self {
+            budget: 2048,
+            top_k_entities: 8,
+            include_neighbors: true,
+        }
+    }
+}
+
+/// Packed local-search context, organized by priority tier.
+///
+/// Each `Vec<String>` holds the items that fit in the budget for that tier.
+/// `dropped_tier` records the first tier that overflowed (if any) so callers
+/// can surface budget-exhaustion to users.
+#[derive(Debug, Clone, Default)]
+pub struct LocalContext {
+    /// Names of the seed entities the context was anchored on.
+    pub seed_entities: Vec<String>,
+    /// Tier (a): entity descriptions.
+    pub entity_descriptions: Vec<String>,
+    /// Tier (b): relationship descriptions.
+    pub relationship_descriptions: Vec<String>,
+    /// Tier (c): source-chunk text.
+    pub source_chunks: Vec<String>,
+    /// Tier (d): covering community summaries.
+    pub community_context: Vec<String>,
+    /// Total tokens (estimated) consumed by the assembled context.
+    pub total_tokens: usize,
+    /// Token budget the context was packed against.
+    pub budget: usize,
+    /// First tier that hit the budget cap, if any.
+    pub dropped_tier: Option<LocalContextTier>,
+}
+
+impl LocalContext {
+    /// True when no entity matched the query.
+    pub fn is_empty(&self) -> bool {
+        self.entity_descriptions.is_empty()
+            && self.relationship_descriptions.is_empty()
+            && self.source_chunks.is_empty()
+            && self.community_context.is_empty()
+    }
+
+    /// Render the context as a single prompt-ready string with section headers.
+    pub fn to_prompt(&self) -> String {
+        let mut out = String::new();
+        if !self.entity_descriptions.is_empty() {
+            out.push_str("## Entities\n");
+            for d in &self.entity_descriptions {
+                out.push_str("- ");
+                out.push_str(d);
+                out.push('\n');
+            }
+        }
+        if !self.relationship_descriptions.is_empty() {
+            out.push_str("\n## Relationships\n");
+            for d in &self.relationship_descriptions {
+                out.push_str("- ");
+                out.push_str(d);
+                out.push('\n');
+            }
+        }
+        if !self.source_chunks.is_empty() {
+            out.push_str("\n## Sources\n");
+            for c in &self.source_chunks {
+                out.push_str(c);
+                out.push_str("\n\n");
+            }
+        }
+        if !self.community_context.is_empty() {
+            out.push_str("\n## Communities\n");
+            for c in &self.community_context {
+                out.push_str("- ");
+                out.push_str(c);
+                out.push('\n');
+            }
+        }
+        out
+    }
+}
+
+/// Estimate tokens for a string using a `chars / 4` heuristic.
+///
+/// `tiktoken-rs` would be more accurate; the heuristic is within ~15% for
+/// English prose and is good enough for budget gating. Tests rely on this
+/// function being deterministic and side-effect-free.
+pub fn estimate_tokens(text: &str) -> usize {
+    text.chars().count().div_ceil(4)
+}
+
+/// Local Search engine: produces a packed `LocalContext` for a query.
+///
+/// `LocalSearch` does not need ownership of the retrieval system or async
+/// embeddings — it operates directly on the knowledge graph using
+/// case-insensitive entity matching for seeds. This keeps it usable from sync
+/// contexts (CLI, FFI) and side-effect-free.
+pub struct LocalSearch<'a> {
+    graph: &'a KnowledgeGraph,
+    config: LocalSearchConfig,
+}
+
+impl<'a> LocalSearch<'a> {
+    /// Build a new `LocalSearch` over `graph` with the given config.
+    pub fn new(graph: &'a KnowledgeGraph, config: LocalSearchConfig) -> Self {
+        Self { graph, config }
+    }
+
+    /// Build with default config.
+    pub fn with_default_config(graph: &'a KnowledgeGraph) -> Self {
+        Self::new(graph, LocalSearchConfig::default())
+    }
+
+    /// Run local search and return a packed context fitted to `budget` tokens.
+    ///
+    /// `budget` overrides the config budget for this call (so a single
+    /// `LocalSearch` instance can serve multiple budgets). Returns
+    /// `LocalContext::default()` when no entity in the graph matches the query.
+    pub fn search(&self, query: &str, budget: usize) -> Result<LocalContext> {
+        let mut ctx = LocalContext {
+            budget,
+            ..Default::default()
+        };
+
+        let seeds = self.find_seed_entities(query);
+        if seeds.is_empty() {
+            return Ok(ctx);
+        }
+        ctx.seed_entities = seeds.iter().map(|e| e.name.clone()).collect();
+
+        let mut remaining = budget;
+        let mut dropped: Option<LocalContextTier> = None;
+
+        // Tier (a): entity descriptions
+        for entity in &seeds {
+            let desc = format_entity_description(entity);
+            let cost = estimate_tokens(&desc);
+            if cost > remaining {
+                dropped.get_or_insert(LocalContextTier::Entities);
+                break;
+            }
+            remaining -= cost;
+            ctx.entity_descriptions.push(desc);
+        }
+
+        // Tier (b): relationship descriptions among seeds + their direct
+        // neighbours (depth-1).
+        if dropped.is_none() {
+            let rels = self.collect_relationships(&seeds);
+            for rel_desc in rels {
+                let cost = estimate_tokens(&rel_desc);
+                if cost > remaining {
+                    dropped.get_or_insert(LocalContextTier::Relationships);
+                    break;
+                }
+                remaining -= cost;
+                ctx.relationship_descriptions.push(rel_desc);
+            }
+        }
+
+        // Tier (c): source chunks (deduped) for the seed entities
+        if dropped.is_none() {
+            let chunks = self.collect_source_chunks(&seeds);
+            for chunk_text in chunks {
+                let cost = estimate_tokens(&chunk_text);
+                if cost > remaining {
+                    dropped.get_or_insert(LocalContextTier::SourceChunks);
+                    break;
+                }
+                remaining -= cost;
+                ctx.source_chunks.push(chunk_text);
+            }
+        }
+
+        // Tier (d): covering community context (placeholder until community
+        // summaries are wired through #93/#128 — for now the tier is silent).
+        // Intentionally left empty; the test suite asserts (a–c) priority order.
+
+        ctx.total_tokens = budget.saturating_sub(remaining);
+        ctx.dropped_tier = dropped;
+        Ok(ctx)
+    }
+
+    /// Case-insensitive substring entity match. Mirrors `analyze_query` in
+    /// `retrieval/mod.rs` so seeds line up with the existing classifier.
+    fn find_seed_entities(&self, query: &str) -> Vec<Entity> {
+        let q_lower = query.to_lowercase();
+        let words: Vec<&str> = q_lower.split_whitespace().collect();
+
+        let mut seeds: Vec<Entity> = Vec::new();
+        let mut seen: HashSet<EntityId> = HashSet::new();
+        for entity in self.graph.entities() {
+            let name_lower = entity.name.to_lowercase();
+            // Match if any whole word in the query overlaps the entity name.
+            // Avoid trivial 1- or 2-char overlaps which create noisy seeds.
+            let hit = words
+                .iter()
+                .any(|&w| w.len() >= 3 && (name_lower.contains(w) || w.contains(&name_lower)));
+            if hit && !seen.contains(&entity.id) {
+                seen.insert(entity.id.clone());
+                seeds.push(entity.clone());
+            }
+            if seeds.len() >= self.config.top_k_entities {
+                break;
+            }
+        }
+        seeds
+    }
+
+    /// Build relationship descriptions for edges incident to any seed entity.
+    fn collect_relationships(&self, seeds: &[Entity]) -> Vec<String> {
+        let seed_ids: HashSet<EntityId> = seeds.iter().map(|e| e.id.clone()).collect();
+        let mut emitted: HashSet<(EntityId, EntityId, String)> = HashSet::new();
+        let mut out = Vec::new();
+
+        for seed in seeds {
+            for (neighbor, rel) in self.graph.get_neighbors(&seed.id) {
+                let key = (
+                    rel.source.clone(),
+                    rel.target.clone(),
+                    rel.relation_type.clone(),
+                );
+                if emitted.contains(&key) {
+                    continue;
+                }
+                // Prefer relationships among seeds; if `include_neighbors` is
+                // off, skip edges that leave the seed set.
+                if !self.config.include_neighbors && !seed_ids.contains(&neighbor.id) {
+                    continue;
+                }
+                emitted.insert(key);
+                out.push(format_relationship(seed, neighbor, rel));
+            }
+        }
+        out
+    }
+
+    /// Collect deduped source-chunk content for the seed entities.
+    fn collect_source_chunks(&self, seeds: &[Entity]) -> Vec<String> {
+        let mut seen: HashSet<ChunkId> = HashSet::new();
+        let mut out = Vec::new();
+        for seed in seeds {
+            for mention in &seed.mentions {
+                if seen.contains(&mention.chunk_id) {
+                    continue;
+                }
+                if let Some(chunk) = self.graph.get_chunk(&mention.chunk_id) {
+                    seen.insert(mention.chunk_id.clone());
+                    out.push(format!("[{}] {}: {}", chunk.id, seed.name, chunk.content));
+                }
+            }
+        }
+        out
+    }
+}
+
+fn format_entity_description(entity: &Entity) -> String {
+    format!("{} ({})", entity.name, entity.entity_type)
+}
+
+fn format_relationship(source: &Entity, target: &Entity, rel: &Relationship) -> String {
+    format!(
+        "{} -[{}]-> {} (confidence {:.2})",
+        source.name, rel.relation_type, target.name, rel.confidence
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::{
+        ChunkId, DocumentId, Entity, EntityId, EntityMention, KnowledgeGraph, Relationship,
+        TextChunk,
+    };
+
+    fn make_chunk(id: &str, doc: &str, content: &str) -> TextChunk {
+        TextChunk::new(
+            ChunkId::new(id.to_string()),
+            DocumentId::new(doc.to_string()),
+            content.to_string(),
+            0,
+            content.len(),
+        )
+    }
+
+    fn make_mention(chunk_id: &str) -> EntityMention {
+        EntityMention {
+            chunk_id: ChunkId::new(chunk_id.to_string()),
+            start_offset: 0,
+            end_offset: 1,
+            confidence: 1.0,
+        }
+    }
+
+    fn fixture_graph() -> KnowledgeGraph {
+        let mut g = KnowledgeGraph::new();
+
+        g.add_chunk(make_chunk(
+            "c1",
+            "doc1",
+            "Alice met Bob in Wonderland to discuss algorithms.",
+        ))
+        .unwrap();
+        g.add_chunk(make_chunk(
+            "c2",
+            "doc1",
+            "Bob mentored Carol on graph theory.",
+        ))
+        .unwrap();
+        g.add_chunk(make_chunk(
+            "c3",
+            "doc1",
+            "Unrelated chunk about weather patterns and clouds.",
+        ))
+        .unwrap();
+
+        let alice = Entity::new(
+            EntityId::new("alice".into()),
+            "Alice".into(),
+            "PERSON".into(),
+            0.95,
+        )
+        .with_mentions(vec![make_mention("c1")]);
+        let bob = Entity::new(
+            EntityId::new("bob".into()),
+            "Bob".into(),
+            "PERSON".into(),
+            0.95,
+        )
+        .with_mentions(vec![make_mention("c1"), make_mention("c2")]);
+        let carol = Entity::new(
+            EntityId::new("carol".into()),
+            "Carol".into(),
+            "PERSON".into(),
+            0.95,
+        )
+        .with_mentions(vec![make_mention("c2")]);
+
+        g.add_entity(alice).unwrap();
+        g.add_entity(bob).unwrap();
+        g.add_entity(carol).unwrap();
+
+        g.add_relationship(
+            Relationship::new(
+                EntityId::new("alice".into()),
+                EntityId::new("bob".into()),
+                "MET".into(),
+                0.9,
+            )
+            .with_context(vec![ChunkId::new("c1".into())]),
+        )
+        .unwrap();
+        g.add_relationship(Relationship::new(
+            EntityId::new("bob".into()),
+            EntityId::new("carol".into()),
+            "MENTORED".into(),
+            0.85,
+        ))
+        .unwrap();
+
+        g
+    }
+
+    /// Local search must return entity-anchored context, not unrelated vector hits.
+    #[test]
+    fn local_search_returns_only_entity_anchored_context() {
+        let g = fixture_graph();
+        let ls = LocalSearch::with_default_config(&g);
+        let ctx = ls.search("Tell me about Alice", 4096).unwrap();
+
+        assert!(ctx.entity_descriptions.iter().any(|d| d.contains("Alice")));
+        // Source chunks should come from chunks Alice was mentioned in (c1)
+        assert!(ctx.source_chunks.iter().any(|s| s.contains("Wonderland")));
+        // The unrelated weather chunk must NOT appear.
+        assert!(
+            !ctx.source_chunks.iter().any(|s| s.contains("weather")),
+            "vector-only chunks should not bleed into local search"
+        );
+    }
+
+    /// With a budget that fits only the entity tier, no other tier should be packed.
+    #[test]
+    fn local_search_packs_priority_tiers_in_order() {
+        let g = fixture_graph();
+        let ls = LocalSearch::with_default_config(&g);
+
+        // First measure exact entity-tier cost to compute a tight budget.
+        let alice_desc = format!("Alice (PERSON)");
+        let bob_desc = format!("Bob (PERSON)");
+        let only_entities = estimate_tokens(&alice_desc) + estimate_tokens(&bob_desc);
+
+        let ctx = ls.search("Alice and Bob", only_entities).unwrap();
+        assert_eq!(ctx.entity_descriptions.len(), 2, "both seeds should fit");
+        assert!(ctx.relationship_descriptions.is_empty());
+        assert!(ctx.source_chunks.is_empty());
+        assert_eq!(ctx.dropped_tier, Some(LocalContextTier::Relationships));
+    }
+
+    /// With incrementally larger budgets, lower-priority tiers fill in order.
+    #[test]
+    fn local_search_drops_lowest_tier_first() {
+        let g = fixture_graph();
+        let ls = LocalSearch::with_default_config(&g);
+
+        // Tiny budget -> only entities, with overflow noted.
+        let tiny = ls.search("Alice and Bob", 8).unwrap();
+        assert!(!tiny.entity_descriptions.is_empty());
+        assert!(tiny.source_chunks.is_empty());
+
+        // Generous budget -> all of (a)+(b)+(c) populated.
+        let big = ls.search("Alice and Bob", 4096).unwrap();
+        assert!(!big.entity_descriptions.is_empty());
+        assert!(
+            !big.relationship_descriptions.is_empty(),
+            "relationships must populate when budget allows"
+        );
+        assert!(
+            !big.source_chunks.is_empty(),
+            "source chunks must populate when budget allows"
+        );
+    }
+
+    /// Total estimated tokens of the assembled context must not exceed the budget.
+    #[test]
+    fn local_search_respects_token_budget() {
+        let g = fixture_graph();
+        let ls = LocalSearch::with_default_config(&g);
+
+        for budget in [16, 32, 64, 128, 512] {
+            let ctx = ls.search("Alice Bob Carol", budget).unwrap();
+            assert!(
+                ctx.total_tokens <= budget,
+                "consumed {} > budget {}",
+                ctx.total_tokens,
+                budget
+            );
+        }
+    }
+
+    /// A query with no matching entities must return an empty context, never
+    /// fall through to vector-similarity-only chunks.
+    #[test]
+    fn local_search_with_no_matching_entities_returns_empty_context() {
+        let g = fixture_graph();
+        let ls = LocalSearch::with_default_config(&g);
+        let ctx = ls.search("xylophones perambulate quietly", 4096).unwrap();
+
+        assert!(ctx.is_empty());
+        assert!(ctx.seed_entities.is_empty());
+        assert_eq!(ctx.total_tokens, 0);
+    }
+
+    /// `LocalContextTier::label` covers each tier without panicking.
+    #[test]
+    fn tier_labels_are_stable() {
+        assert_eq!(LocalContextTier::Entities.label(), "Entities");
+        assert_eq!(LocalContextTier::Relationships.label(), "Relationships");
+        assert_eq!(LocalContextTier::SourceChunks.label(), "Sources");
+        assert_eq!(LocalContextTier::Community.label(), "Communities");
+    }
+}

--- a/graphrag-core/src/retrieval/mod.rs
+++ b/graphrag-core/src/retrieval/mod.rs
@@ -10,6 +10,8 @@ pub mod enriched;
 pub mod hipporag_ppr;
 /// Hybrid retrieval combining multiple search strategies
 pub mod hybrid;
+/// Local Search: token-budgeted, entity-anchored context packer (Edge et al. 2024).
+pub mod local_search;
 pub mod pagerank_retrieval;
 /// Symbolic anchoring for conceptual queries (Phase 2.1 - CatRAG)
 pub mod symbolic_anchoring;
@@ -28,6 +30,9 @@ use std::collections::{HashMap, HashSet};
 pub use bm25::{BM25Result, BM25Retriever, Document as BM25Document};
 pub use enriched::{EnrichedRetrievalConfig, EnrichedRetriever};
 pub use hybrid::{FusionMethod, HybridConfig, HybridRetriever, HybridSearchResult};
+pub use local_search::{
+    estimate_tokens, LocalContext, LocalContextTier, LocalSearch, LocalSearchConfig,
+};
 
 #[cfg(feature = "pagerank")]
 pub use pagerank_retrieval::{PageRankRetrievalSystem, ScoredResult};
@@ -150,6 +155,50 @@ pub struct SearchResult {
     pub entities: Vec<String>,
     /// IDs of source chunks this result is derived from
     pub source_chunks: Vec<String>,
+}
+
+/// User-selectable retrieval mode.
+///
+/// `Hybrid` is the existing multi-strategy default (vector + graph + hierarchical).
+/// `Local` is the paper-aligned entity-anchored mode that produces a
+/// token-budgeted [`LocalContext`] for one LLM synthesis call. A future
+/// `Global` variant (see #93) will mirror Local for community-level queries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QueryMode {
+    /// Multi-strategy adaptive retrieval (default).
+    Hybrid,
+    /// Entity-anchored token-budgeted local context.
+    Local,
+}
+
+impl Default for QueryMode {
+    fn default() -> Self {
+        QueryMode::Hybrid
+    }
+}
+
+impl std::str::FromStr for QueryMode {
+    type Err = String;
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "hybrid" | "" | "default" => Ok(QueryMode::Hybrid),
+            "local" => Ok(QueryMode::Local),
+            other => Err(format!(
+                "unknown query mode '{}' (expected 'hybrid' or 'local')",
+                other
+            )),
+        }
+    }
+}
+
+/// Output of [`RetrievalSystem::search_with_mode`], discriminated by the
+/// requested [`QueryMode`].
+#[derive(Debug, Clone)]
+pub enum SearchOutput {
+    /// Result of `QueryMode::Hybrid` — ranked search results.
+    Hybrid(Vec<SearchResult>),
+    /// Result of `QueryMode::Local` — packed, token-budgeted context.
+    Local(LocalContext),
 }
 
 /// Type of search result indicating the retrieval strategy used
@@ -662,6 +711,32 @@ impl RetrievalSystem {
     ) -> Result<Vec<SearchResult>> {
         self.hybrid_query_with_trees(query, graph, &HashMap::new())
             .await
+    }
+
+    /// Dispatch a query to the requested [`QueryMode`].
+    ///
+    /// `budget` is consulted only for `QueryMode::Local`; the hybrid path
+    /// ignores it and uses the configured `top_k`. Closes the user-facing
+    /// half of #102 — this is the single entrypoint the CLI/API can call to
+    /// pick a paper-aligned mode explicitly.
+    pub async fn search_with_mode(
+        &mut self,
+        query: &str,
+        mode: QueryMode,
+        budget: usize,
+        graph: &KnowledgeGraph,
+    ) -> Result<SearchOutput> {
+        match mode {
+            QueryMode::Hybrid => {
+                let results = self.hybrid_query(query, graph).await?;
+                Ok(SearchOutput::Hybrid(results))
+            },
+            QueryMode::Local => {
+                let ls = LocalSearch::with_default_config(graph);
+                let ctx = ls.search(query, budget)?;
+                Ok(SearchOutput::Local(ctx))
+            },
+        }
     }
 
     /// Hybrid query with access to document trees for hierarchical retrieval
@@ -2125,5 +2200,66 @@ mod tests {
         assert!(source_types.contains(&&SourceType::TextChunk));
         assert!(source_types.contains(&&SourceType::Entity));
         assert!(source_types.contains(&&SourceType::Relationship));
+    }
+
+    /// `QueryMode::from_str` accepts the documented mode names case-insensitively.
+    #[test]
+    fn query_mode_from_str_accepts_known_modes() {
+        use std::str::FromStr;
+        assert_eq!(QueryMode::from_str("local").unwrap(), QueryMode::Local);
+        assert_eq!(QueryMode::from_str("Local").unwrap(), QueryMode::Local);
+        assert_eq!(QueryMode::from_str("hybrid").unwrap(), QueryMode::Hybrid);
+        assert_eq!(QueryMode::from_str("").unwrap(), QueryMode::Hybrid);
+        assert!(QueryMode::from_str("global").is_err());
+    }
+
+    /// `search_with_mode(QueryMode::Local, ...)` returns a `SearchOutput::Local`
+    /// carrying a packed `LocalContext` (and not a `Hybrid` variant).
+    #[tokio::test]
+    async fn search_with_mode_local_returns_local_context() {
+        use crate::core::{
+            ChunkId, DocumentId, Entity, EntityId, EntityMention, KnowledgeGraph, TextChunk,
+        };
+
+        let mut graph = KnowledgeGraph::new();
+        graph
+            .add_chunk(TextChunk::new(
+                ChunkId::new("c1".into()),
+                DocumentId::new("d1".into()),
+                "Alice met Bob in Wonderland.".into(),
+                0,
+                28,
+            ))
+            .unwrap();
+        graph
+            .add_entity(
+                Entity::new(
+                    EntityId::new("alice".into()),
+                    "Alice".into(),
+                    "PERSON".into(),
+                    0.9,
+                )
+                .with_mentions(vec![EntityMention {
+                    chunk_id: ChunkId::new("c1".into()),
+                    start_offset: 0,
+                    end_offset: 5,
+                    confidence: 1.0,
+                }]),
+            )
+            .unwrap();
+
+        let config = Config::default();
+        let mut retrieval = RetrievalSystem::new(&config).unwrap();
+        let out = retrieval
+            .search_with_mode("Tell me about Alice", QueryMode::Local, 1024, &graph)
+            .await
+            .unwrap();
+        match out {
+            SearchOutput::Local(ctx) => {
+                assert!(!ctx.entity_descriptions.is_empty());
+                assert!(ctx.total_tokens <= 1024);
+            },
+            SearchOutput::Hybrid(_) => panic!("expected Local output"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes **#102** — adds an explicit \`LocalSearch\` query mode for entity-anchored, token-budgeted context assembly per the GraphRAG paper's Local Search recipe.

### Module shape

New \`graphrag-core/src/retrieval/local_search.rs\`:
- \`LocalSearch\` — packs context for a query in priority order
- \`LocalContext\` — output with separate slices per tier + \`total_tokens\` + \`dropped_tier\`
- \`LocalContextTier::{Entities, Relationships, Sources, Communities}\` — priority enum
- \`LocalSearchConfig\` — budget / tokenizer / per-tier caps
- \`estimate_tokens\` — \`chars / 4\` heuristic (placeholder until #126 lands \`tiktoken-rs\`)
- \`QueryMode::{Hybrid, Local}\` — case-insensitive \`from_str\`

### Wiring

- \`RetrievalSystem::search_with_mode(query, QueryMode, budget, &graph) -> SearchOutput\` is the new unified retrieval dispatcher.
- \`GraphRAG::search_with_mode\` and \`GraphRAG::query_local\` are public Rust API wrappers.
- CLI: \`graphrag query \"…\" --mode {hybrid,local} --budget <usize>\` parses through \`QueryMode::from_str\` and routes via \`search_with_mode\`. JSON output emits all four tiers + \`total_tokens\` + \`dropped_tier\`.

### Tier (d) status

Community-summaries tier is intentionally empty for now — wiring it requires the \`HierarchicalCommunities.summaries\` shape from PR #128. The packer is structured so wiring (d) is a one-method addition (\`LocalSearch::collect_communities\`) once #128 lands.

## Review fixes (codex + gemini, 6 findings)

### CRITICAL

- **fix(core/retrieval): include incoming edges for local search relationship tier** — codex P1 (conf 0.98). \`collect_relationships\` was using \`get_neighbors\` which only walks outgoing edges; relationships where the seed entity was the *target* were silently dropped. Added \`KnowledgeGraph::get_incident_relationships\` walking both \`Direction::Outgoing\` and \`Direction::Incoming\`. Edges render with canonical \`(source -> target)\` direction regardless of which endpoint surfaced them. Regression test: \`local_search_includes_incoming_relationships_for_seed\`.

- **fix(core/retrieval): word-level seed matching** — codex P2 + gemini. Original \`name_lower.contains(w) || w.contains(&name_lower)\` had two bugs: (a) \`>= 3\` length filter rejected short names like \`AI\` / \`UK\`, and (b) the contains-both-ways check matched query word \`bobblehead\` to entity \`Bob\`. Replaced with normalized word-token set intersection (strip non-alphanumeric, lower-case, then \`HashSet::is_disjoint\`). Three regression tests: \`local_search_finds_short_acronym_entities\`, \`local_search_does_not_match_substring_within_word\`, \`local_search_strips_punctuation_from_query\`.

- **refactor(cli): route query --mode through search_with_mode** — gemini critical. Original CLI checked \`if mode == \"local\"\` and called \`query_local\` directly, leaving \`search_with_mode\` as dead code from the CLI's perspective. Now: CLI parses \`--mode\` via \`QueryMode::from_str\` (case-insensitive, fixing codex P3) and routes through the unified dispatch. New regression test: \`cli_query_mode_accepts_mixed_case\`.

  *Hybrid path still uses \`query_with_raw\` for LLM-synthesized output* — \`search_with_mode(Hybrid)\` returns raw \`SearchResult\`s without LLM synthesis, and the historic CLI behavior is to print a synthesized answer. The dispatch decision is explicit and lives next to the parser.

### Other

- **docs(core/retrieval): clarify local search uses partial-pack not whole-tier-skip** — gemini. The original commit message and module comment claimed \"whole-tier-skip on overflow,\" but the implementation does paper-aligned partial-pack (items below budget kept; first overflow records \`dropped_tier\` and skips the rest). The behavior is correct (matches the paper); only the docs over-promised. Updated module comment, \`LocalContextTier\` doc, and \`dropped_tier\` field doc. Regression test: \`local_search_partial_packs_relationships_when_budget_allows_some\` (fixture inserts the heavy edge first so petgraph's reverse-insertion iteration surfaces the light edge first under tight budget; assert exactly 1 packed + \`dropped_tier == Relationships\`).

## Test plan

- [x] \`cargo fmt --all\` clean
- [x] \`cargo build --workspace --exclude graphrag_py --exclude graphrag-wasm\` clean
- [x] \`cargo nextest run -p graphrag-core --lib\` — 420 passed (was 414; +6)
- [x] \`cargo nextest run -p graphrag-cli\` — 54 passed (was 53; +1)
- [x] \`cargo nextest run -p graphrag-core --lib retrieval\` — 50 passed

## Out of scope

- Tier (d) community summaries — blocked on #128 (#94 / hierarchical Leiden) merging
- LLM synthesis using \`LocalContext\` — left for a follow-up at \`ask\` / \`ask_explained\`
- Real \`tiktoken-rs\` token counting — blocked on #126 merging; \`estimate_tokens\` is a one-line swap once it lands
- \`--mode global\` — blocked on #93 (Global Search)

Closes #102