### PR TITLE
feat(core/entity): paper-aligned gleaning + element-summary preview + extraction mode

### DIFF
--- a/graphrag-core/PIPELINE_ARCHITECTURE.md
+++ b/graphrag-core/PIPELINE_ARCHITECTURE.md
@@ -132,9 +132,9 @@ This document details the 7-phase architecture of the GraphRAG pipeline, coverin
 | | `entities.mode` | enum | n/a | `algorithmic` \| `llm_single_pass` \| `llm_gleaning` (overrides `use_gleaning`) |
 | | `entity_extraction.use_gleaning` | bool | true | Legacy back-compat flag |
 | | `entities.max_gleaning_rounds` | int | 1 | Paper default per Edge et al. 2024 §2.1 |
-| | `entities.element_summary.enabled` | bool | true | LLM collapse of multi-chunk descriptions (§2.2) |
-| | `entities.element_summary.min_instances` | int | 2 | Min descriptions before collapsing |
-| | `entities.element_summary.max_chars_for_concat` | int | 800 | Below budget concatenate locally |
+| | `entities.element_summary.enabled` | bool | true | (Preview, not yet wired into indexing) LLM collapse of multi-chunk descriptions (§2.2) |
+| | `entities.element_summary.min_instances` | int | 2 | (Preview) Min descriptions before collapsing |
+| | `entities.element_summary.max_chars_for_concat` | int | 800 | (Preview) Below budget concatenate locally |
 | | `relationship_extraction.enabled` | bool | true | Extract relationships |
 | **Graph** | `graph.enable_pagerank` | bool | true | Calculate PageRank |
 | | `graph.max_connections` | int | 50 | Max node degree |

--- a/graphrag-core/PIPELINE_ARCHITECTURE.md
+++ b/graphrag-core/PIPELINE_ARCHITECTURE.md
@@ -129,7 +129,12 @@ This document details the 7-phase architecture of the GraphRAG pipeline, coverin
 | | `chunk_overlap` | int | 30 | Overlap tokens |
 | **Extraction** | `entity_extraction.approach` | enum | hybrid | Extraction method |
 | | `entity_extraction.entity_types` | list | [...] | Target entities |
-| | `entity_extraction.use_gleaning` | bool | true | Multi-pass extraction |
+| | `entities.mode` | enum | n/a | `algorithmic` \| `llm_single_pass` \| `llm_gleaning` (overrides `use_gleaning`) |
+| | `entity_extraction.use_gleaning` | bool | true | Legacy back-compat flag |
+| | `entities.max_gleaning_rounds` | int | 1 | Paper default per Edge et al. 2024 §2.1 |
+| | `entities.element_summary.enabled` | bool | true | LLM collapse of multi-chunk descriptions (§2.2) |
+| | `entities.element_summary.min_instances` | int | 2 | Min descriptions before collapsing |
+| | `entities.element_summary.max_chars_for_concat` | int | 800 | Below budget concatenate locally |
 | | `relationship_extraction.enabled` | bool | true | Extract relationships |
 | **Graph** | `graph.enable_pagerank` | bool | true | Calculate PageRank |
 | | `graph.max_connections` | int | 50 | Max node degree |

--- a/graphrag-core/README.md
+++ b/graphrag-core/README.md
@@ -140,10 +140,12 @@ use_gleaning = true
 max_gleaning_rounds = 1
 entity_types = ["PERSON", "ORGANIZATION", "LOCATION", "DATE", "EVENT"]
 
-# Element-summary collapse (Edge et al. 2024 §2.2): synthesize one coherent
-# description per entity/relationship described in multiple chunks. Below
-# `max_chars_for_concat` total chars descriptions are joined locally rather
-# than sent to the LLM.
+# Element-summary collapse (Edge et al. 2024 §2.2): preview API only.
+# These keys are accepted by all config loaders and round-trip through
+# serialisation, but they are NOT yet invoked during `build_graph` —
+# `core::Entity` does not yet carry a description field for the collapsed
+# text. The collapse functions in `entity::element_summary` are public and
+# usable directly. See issue #97 review for the wiring follow-up.
 [entities.element_summary]
 enabled = true
 min_instances = 2

--- a/graphrag-core/README.md
+++ b/graphrag-core/README.md
@@ -128,10 +128,32 @@ chat_model = "llama3.2:3b"
 
 [entities]
 min_confidence = 0.7
+# Extraction strategy. When set, takes precedence over `use_gleaning` below.
+#   "algorithmic"     - regex/capitalization only, never calls the LLM
+#   "llm_single_pass" - one LLM call per chunk, no iterative refinement
+#   "llm_gleaning"    - iterative LLM gleaning (Edge et al. 2024 §2.1)
+mode = "llm_gleaning"
+# Legacy back-compat flag. Ignored when `mode` is set.
 use_gleaning = true
-max_gleaning_rounds = 3
+# Paper default is 1 (Edge et al. 2024 §2.1). Higher values trade index time
+# for marginal recall.
+max_gleaning_rounds = 1
 entity_types = ["PERSON", "ORGANIZATION", "LOCATION", "DATE", "EVENT"]
+
+# Element-summary collapse (Edge et al. 2024 §2.2): synthesize one coherent
+# description per entity/relationship described in multiple chunks. Below
+# `max_chars_for_concat` total chars descriptions are joined locally rather
+# than sent to the LLM.
+[entities.element_summary]
+enabled = true
+min_instances = 2
+max_chars_for_concat = 800
 ```
+
+> **Note:** `mode = "algorithmic"` (or `ollama.enabled = false`) is the only
+> way to fully skip per-chunk LLM entity-extraction calls at index time. The
+> legacy `use_gleaning = false` setting alone still runs an LLM single-pass
+> per chunk when Ollama is enabled.
 
 Load with:
 ```rust
@@ -386,8 +408,8 @@ GraphRAG uses a configurable pipeline with different methods for each phase:
 | Phase | Key Parameters | Config |
 |-------|----------------|--------|
 | **1. Chunking** | `chunk_size`, `chunk_overlap` | `chunk_size = 1000` |
-| **2. Entity Extraction** | `approach`, `entity_types`, `use_gleaning` | `approach = "hybrid"` |
-| **3. Relationship Extraction** | `extract_relationships`, `use_gleaning` | `[graph] extract_relationships = true` |
+| **2. Entity Extraction** | `approach`, `entity_types`, `mode`, `max_gleaning_rounds` | `mode = "llm_gleaning"` |
+| **3. Relationship Extraction** | `extract_relationships`, `mode` | `[graph] extract_relationships = true` |
 | **4. Graph Construction** | `enable_pagerank`, `max_connections` | `[graph] enable_pagerank = true` |
 | **5. Embedding** | `backend`, `dimension`, `model` | `[embeddings] backend = "ollama"` |
 | **6. Retrieval** | `strategy`, `top_k` | `[retrieval] strategy = "hybrid"` |
@@ -397,8 +419,8 @@ GraphRAG uses a configurable pipeline with different methods for each phase:
 
 | Phase | Methods Available | Config Setting |
 |-------|-------------------|----------------|
-| **Entity Extraction** | Algorithmic / Semantic / Hybrid | `approach = "algorithmic\|semantic\|hybrid"` |
-| **Relationship Extraction** | Co-occurrence / LLM-based / Gleaning | `entities.use_gleaning = true\|false` |
+| **Entity Extraction** | Algorithmic / LLM single-pass / LLM gleaning | `entities.mode = "algorithmic\|llm_single_pass\|llm_gleaning"` |
+| **Relationship Extraction** | Co-occurrence / LLM-based / Gleaning | `entities.mode = "llm_gleaning"` |
 | **Embedding** | Ollama / Hash / OpenAI / HuggingFace / 8 providers | `embeddings.backend = "ollama"` |
 | **Retrieval** | Vector / BM25 / PageRank / Hybrid / Adaptive / LightRAG | `retrieval.strategy = "hybrid"` |
 

--- a/graphrag-core/src/config/mod.rs
+++ b/graphrag-core/src/config/mod.rs
@@ -1092,6 +1092,50 @@ pub struct EntityConfig {
     /// Facts longer than this will be rejected
     #[serde(default = "default_max_fact_tokens")]
     pub max_fact_tokens: usize,
+
+    /// Element-summary collapse settings (Edge et al. 2024 §2.2).
+    #[serde(default)]
+    pub element_summary: ElementSummaryConfig,
+}
+
+/// Configuration for element-summary collapse (paper §2.2).
+///
+/// When the same entity or relationship appears in multiple chunks, this
+/// step synthesizes a single coherent description from the per-instance
+/// descriptions, calling the chat backend only when the total instance
+/// length exceeds the cost-guard threshold.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ElementSummaryConfig {
+    /// Master switch.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+
+    /// Minimum instances of an element required to trigger summarization.
+    #[serde(default = "default_element_summary_min_instances")]
+    pub min_instances: usize,
+
+    /// Total character budget below which descriptions are concatenated
+    /// locally instead of being sent to the LLM.
+    #[serde(default = "default_element_summary_max_chars_concat")]
+    pub max_chars_for_concat: usize,
+}
+
+impl Default for ElementSummaryConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            min_instances: default_element_summary_min_instances(),
+            max_chars_for_concat: default_element_summary_max_chars_concat(),
+        }
+    }
+}
+
+fn default_element_summary_min_instances() -> usize {
+    2
+}
+
+fn default_element_summary_max_chars_concat() -> usize {
+    800
 }
 
 /// Configuration for advanced GraphRAG features (Phases 2-3)
@@ -1475,6 +1519,7 @@ impl Default for Config {
                 validation_min_confidence: default_validation_confidence(),
                 use_atomic_facts: false,
                 max_fact_tokens: default_max_fact_tokens(),
+                element_summary: ElementSummaryConfig::default(),
             },
             retrieval: RetrievalConfig {
                 top_k: default_top_k(),
@@ -1807,6 +1852,7 @@ impl Config {
                 max_fact_tokens: parsed["entities"]["max_fact_tokens"]
                     .as_usize()
                     .unwrap_or(default_max_fact_tokens()),
+                element_summary: ElementSummaryConfig::default(),
             },
             retrieval: RetrievalConfig {
                 top_k: parsed["retrieval"]["top_k"]

--- a/graphrag-core/src/config/mod.rs
+++ b/graphrag-core/src/config/mod.rs
@@ -1426,6 +1426,27 @@ fn default_max_gleaning_rounds() -> usize {
     1
 }
 
+/// Parse the `entities.mode` string used by manual TOML/JSON code paths.
+///
+/// Recognises the snake_case names emitted by `EntityExtractionMode`'s serde
+/// representation (`algorithmic`, `llm_single_pass`, `llm_gleaning`).
+fn parse_entity_extraction_mode(value: &str) -> Option<EntityExtractionMode> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "algorithmic" => Some(EntityExtractionMode::Algorithmic),
+        "llm_single_pass" => Some(EntityExtractionMode::LlmSinglePass),
+        "llm_gleaning" => Some(EntityExtractionMode::LlmGleaning),
+        _ => None,
+    }
+}
+
+fn entity_extraction_mode_to_str(mode: EntityExtractionMode) -> &'static str {
+    match mode {
+        EntityExtractionMode::Algorithmic => "algorithmic",
+        EntityExtractionMode::LlmSinglePass => "llm_single_pass",
+        EntityExtractionMode::LlmGleaning => "llm_gleaning",
+    }
+}
+
 fn default_validation_confidence() -> f32 {
     0.7
 }
@@ -1880,7 +1901,9 @@ impl Config {
                 } else {
                     default_entity_types()
                 },
-                mode: None,
+                mode: parsed["entities"]["mode"]
+                    .as_str()
+                    .and_then(parse_entity_extraction_mode),
                 use_gleaning: parsed["entities"]["use_gleaning"]
                     .as_bool()
                     .unwrap_or(false),
@@ -1899,7 +1922,18 @@ impl Config {
                 max_fact_tokens: parsed["entities"]["max_fact_tokens"]
                     .as_usize()
                     .unwrap_or(default_max_fact_tokens()),
-                element_summary: ElementSummaryConfig::default(),
+                element_summary: ElementSummaryConfig {
+                    enabled: parsed["entities"]["element_summary"]["enabled"]
+                        .as_bool()
+                        .unwrap_or(true),
+                    min_instances: parsed["entities"]["element_summary"]["min_instances"]
+                        .as_usize()
+                        .unwrap_or_else(default_element_summary_min_instances),
+                    max_chars_for_concat: parsed["entities"]["element_summary"]
+                        ["max_chars_for_concat"]
+                        .as_usize()
+                        .unwrap_or_else(default_element_summary_max_chars_concat),
+                },
             },
             retrieval: RetrievalConfig {
                 top_k: parsed["retrieval"]["top_k"]
@@ -2380,8 +2414,19 @@ impl Config {
             .map(|s| json::JsonValue::from(s.as_str()))
             .collect();
         entities["entity_types"] = json::JsonValue::from(entity_types_array);
+        if let Some(mode) = self.entities.mode {
+            entities["mode"] = json::JsonValue::from(entity_extraction_mode_to_str(mode));
+        }
         entities["use_gleaning"] = json::JsonValue::from(self.entities.use_gleaning);
         entities["max_gleaning_rounds"] = json::JsonValue::from(self.entities.max_gleaning_rounds);
+        let mut element_summary = json::JsonValue::new_object();
+        element_summary["enabled"] =
+            json::JsonValue::from(self.entities.element_summary.enabled);
+        element_summary["min_instances"] =
+            json::JsonValue::from(self.entities.element_summary.min_instances);
+        element_summary["max_chars_for_concat"] =
+            json::JsonValue::from(self.entities.element_summary.max_chars_for_concat);
+        entities["element_summary"] = element_summary;
         config_json["entities"] = entities;
 
         // Retrieval
@@ -2603,5 +2648,65 @@ mod entity_mode_tests {
             element_summary: ElementSummaryConfig::default(),
         };
         assert_eq!(cfg.resolved_mode(true), EntityExtractionMode::LlmSinglePass);
+    }
+}
+
+#[cfg(test)]
+mod config_io_round_trip_tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    /// JSON I/O round-trip preserves the explicit `entities.mode` field.
+    #[test]
+    fn config_round_trip_preserves_entity_mode() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("config.json");
+        let path_str = path.to_string_lossy().to_string();
+
+        let mut cfg = Config::default();
+        cfg.entities.mode = Some(EntityExtractionMode::LlmSinglePass);
+        cfg.to_file(&path_str).expect("write config");
+
+        let loaded = Config::from_file(&path_str).expect("read config");
+        assert_eq!(loaded.entities.mode, Some(EntityExtractionMode::LlmSinglePass));
+    }
+
+    /// JSON I/O round-trip preserves the `entities.element_summary` block.
+    #[test]
+    fn config_round_trip_preserves_element_summary_settings() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("config.json");
+        let path_str = path.to_string_lossy().to_string();
+
+        let mut cfg = Config::default();
+        cfg.entities.element_summary = ElementSummaryConfig {
+            enabled: false,
+            min_instances: 7,
+            max_chars_for_concat: 4321,
+        };
+        cfg.to_file(&path_str).expect("write config");
+
+        let loaded = Config::from_file(&path_str).expect("read config");
+        assert!(!loaded.entities.element_summary.enabled);
+        assert_eq!(loaded.entities.element_summary.min_instances, 7);
+        assert_eq!(loaded.entities.element_summary.max_chars_for_concat, 4321);
+    }
+
+    /// `parse_entity_extraction_mode` accepts the snake_case serde names.
+    #[test]
+    fn parse_entity_extraction_mode_accepts_snake_case_variants() {
+        assert_eq!(
+            parse_entity_extraction_mode("algorithmic"),
+            Some(EntityExtractionMode::Algorithmic)
+        );
+        assert_eq!(
+            parse_entity_extraction_mode("llm_single_pass"),
+            Some(EntityExtractionMode::LlmSinglePass)
+        );
+        assert_eq!(
+            parse_entity_extraction_mode("llm_gleaning"),
+            Some(EntityExtractionMode::LlmGleaning)
+        );
+        assert_eq!(parse_entity_extraction_mode("nonsense"), None);
     }
 }

--- a/graphrag-core/src/config/mod.rs
+++ b/graphrag-core/src/config/mod.rs
@@ -2420,8 +2420,7 @@ impl Config {
         entities["use_gleaning"] = json::JsonValue::from(self.entities.use_gleaning);
         entities["max_gleaning_rounds"] = json::JsonValue::from(self.entities.max_gleaning_rounds);
         let mut element_summary = json::JsonValue::new_object();
-        element_summary["enabled"] =
-            json::JsonValue::from(self.entities.element_summary.enabled);
+        element_summary["enabled"] = json::JsonValue::from(self.entities.element_summary.enabled);
         element_summary["min_instances"] =
             json::JsonValue::from(self.entities.element_summary.min_instances);
         element_summary["max_chars_for_concat"] =
@@ -2668,7 +2667,10 @@ mod config_io_round_trip_tests {
         cfg.to_file(&path_str).expect("write config");
 
         let loaded = Config::from_file(&path_str).expect("read config");
-        assert_eq!(loaded.entities.mode, Some(EntityExtractionMode::LlmSinglePass));
+        assert_eq!(
+            loaded.entities.mode,
+            Some(EntityExtractionMode::LlmSinglePass)
+        );
     }
 
     /// JSON I/O round-trip preserves the `entities.element_summary` block.

--- a/graphrag-core/src/config/mod.rs
+++ b/graphrag-core/src/config/mod.rs
@@ -1056,6 +1056,23 @@ pub struct TextConfig {
     pub languages: Vec<String>,
 }
 
+/// Entity extraction strategy.
+///
+/// Resolution order at index time (see [`EntityConfig::resolved_mode`]):
+/// 1. Explicit `mode` field, when set.
+/// 2. Back-compat mapping from the legacy `use_gleaning` boolean.
+/// 3. `Algorithmic` if Ollama is disabled in the active config.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EntityExtractionMode {
+    /// Pattern/regex/capitalization-only extraction. Never invokes the LLM.
+    Algorithmic,
+    /// One LLM call per chunk (no iterative refinement).
+    LlmSinglePass,
+    /// Iterative LLM gleaning per Edge et al. 2024 §2.1.
+    LlmGleaning,
+}
+
 /// Configuration for entity extraction
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct EntityConfig {
@@ -1064,6 +1081,11 @@ pub struct EntityConfig {
 
     /// Types of entities to extract
     pub entity_types: Vec<String>,
+
+    /// Explicit extraction mode. When set, takes precedence over the legacy
+    /// `use_gleaning` flag below.
+    #[serde(default)]
+    pub mode: Option<EntityExtractionMode>,
 
     /// Whether to use LLM-based gleaning for entity extraction
     #[serde(default)]
@@ -1096,6 +1118,29 @@ pub struct EntityConfig {
     /// Element-summary collapse settings (Edge et al. 2024 §2.2).
     #[serde(default)]
     pub element_summary: ElementSummaryConfig,
+}
+
+impl EntityConfig {
+    /// Resolve the active extraction mode, applying the precedence rules
+    /// described on [`EntityExtractionMode`].
+    ///
+    /// `ollama_enabled` should be the value of `config.ollama.enabled` in the
+    /// surrounding `Config`; when false, this method always returns
+    /// `Algorithmic` regardless of the configured mode (the LLM paths
+    /// require a chat backend).
+    pub fn resolved_mode(&self, ollama_enabled: bool) -> EntityExtractionMode {
+        if !ollama_enabled {
+            return EntityExtractionMode::Algorithmic;
+        }
+        if let Some(m) = self.mode {
+            return m;
+        }
+        if self.use_gleaning {
+            EntityExtractionMode::LlmGleaning
+        } else {
+            EntityExtractionMode::LlmSinglePass
+        }
+    }
 }
 
 /// Configuration for element-summary collapse (paper §2.2).
@@ -1513,6 +1558,7 @@ impl Default for Config {
             entities: EntityConfig {
                 min_confidence: default_min_confidence(),
                 entity_types: default_entity_types(),
+                mode: None,
                 use_gleaning: false,
                 max_gleaning_rounds: default_max_gleaning_rounds(),
                 enable_triple_reflection: false,
@@ -1834,6 +1880,7 @@ impl Config {
                 } else {
                     default_entity_types()
                 },
+                mode: None,
                 use_gleaning: parsed["entities"]["use_gleaning"]
                     .as_bool()
                     .unwrap_or(false),
@@ -2477,5 +2524,84 @@ impl Config {
         let content = json::stringify_pretty(config_json, 2);
         fs::write(path, content)?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod entity_mode_tests {
+    use super::*;
+
+    /// Algorithmic mode is forced when Ollama is disabled, even if mode says LLM.
+    #[test]
+    fn resolved_mode_ollama_disabled_forces_algorithmic() {
+        let mut cfg = EntityConfig {
+            min_confidence: 0.5,
+            entity_types: vec![],
+            mode: Some(EntityExtractionMode::LlmGleaning),
+            use_gleaning: true,
+            max_gleaning_rounds: 1,
+            enable_triple_reflection: false,
+            validation_min_confidence: 0.7,
+            use_atomic_facts: false,
+            max_fact_tokens: 400,
+            element_summary: ElementSummaryConfig::default(),
+        };
+        assert_eq!(cfg.resolved_mode(false), EntityExtractionMode::Algorithmic);
+        cfg.mode = None;
+        assert_eq!(cfg.resolved_mode(false), EntityExtractionMode::Algorithmic);
+    }
+
+    /// Explicit mode wins over the legacy use_gleaning flag.
+    #[test]
+    fn resolved_mode_explicit_mode_wins_over_use_gleaning() {
+        let cfg = EntityConfig {
+            min_confidence: 0.5,
+            entity_types: vec![],
+            mode: Some(EntityExtractionMode::Algorithmic),
+            use_gleaning: true,
+            max_gleaning_rounds: 1,
+            enable_triple_reflection: false,
+            validation_min_confidence: 0.7,
+            use_atomic_facts: false,
+            max_fact_tokens: 400,
+            element_summary: ElementSummaryConfig::default(),
+        };
+        assert_eq!(cfg.resolved_mode(true), EntityExtractionMode::Algorithmic);
+    }
+
+    /// Back-compat: use_gleaning=true maps to LlmGleaning when no mode is set.
+    #[test]
+    fn resolved_mode_use_gleaning_true_maps_to_gleaning() {
+        let cfg = EntityConfig {
+            min_confidence: 0.5,
+            entity_types: vec![],
+            mode: None,
+            use_gleaning: true,
+            max_gleaning_rounds: 1,
+            enable_triple_reflection: false,
+            validation_min_confidence: 0.7,
+            use_atomic_facts: false,
+            max_fact_tokens: 400,
+            element_summary: ElementSummaryConfig::default(),
+        };
+        assert_eq!(cfg.resolved_mode(true), EntityExtractionMode::LlmGleaning);
+    }
+
+    /// Back-compat: use_gleaning=false maps to LlmSinglePass when no mode is set.
+    #[test]
+    fn resolved_mode_use_gleaning_false_maps_to_single_pass() {
+        let cfg = EntityConfig {
+            min_confidence: 0.5,
+            entity_types: vec![],
+            mode: None,
+            use_gleaning: false,
+            max_gleaning_rounds: 1,
+            enable_triple_reflection: false,
+            validation_min_confidence: 0.7,
+            use_atomic_facts: false,
+            max_fact_tokens: 400,
+            element_summary: ElementSummaryConfig::default(),
+        };
+        assert_eq!(cfg.resolved_mode(true), EntityExtractionMode::LlmSinglePass);
     }
 }

--- a/graphrag-core/src/config/mod.rs
+++ b/graphrag-core/src/config/mod.rs
@@ -1333,7 +1333,8 @@ fn default_relationship_confidence() -> f32 {
     0.5
 }
 fn default_max_gleaning_rounds() -> usize {
-    3
+    // Edge et al. 2024 §2.1 default: a single gleaning round.
+    1
 }
 
 fn default_validation_confidence() -> f32 {

--- a/graphrag-core/src/config/setconfig.rs
+++ b/graphrag-core/src/config/setconfig.rs
@@ -1269,7 +1269,8 @@ fn default_max_retries() -> u32 {
     3
 }
 fn default_gleaning_rounds() -> usize {
-    3
+    // Edge et al. 2024 §2.1 default: a single gleaning round.
+    1
 }
 fn default_gleaning_improvement() -> f32 {
     0.1
@@ -1304,7 +1305,8 @@ fn default_semantic_entity_method() -> String {
     "llm".to_string()
 }
 fn default_max_gleaning_rounds() -> usize {
-    3
+    // Edge et al. 2024 §2.1 default: a single gleaning round.
+    1
 }
 fn default_semantic_temperature() -> f32 {
     0.1

--- a/graphrag-core/src/config/setconfig.rs
+++ b/graphrag-core/src/config/setconfig.rs
@@ -1100,6 +1100,13 @@ pub struct EntityExtractionTopLevelConfig {
     #[serde(default = "default_confidence_threshold")]
     pub min_confidence: f32,
 
+    /// Explicit extraction mode. When set, takes precedence over the legacy
+    /// `use_gleaning` flag. Accepted values are the snake_case variants of
+    /// [`crate::config::EntityExtractionMode`]: `algorithmic`,
+    /// `llm_single_pass`, `llm_gleaning`.
+    #[serde(default)]
+    pub mode: Option<String>,
+
     /// Use LLM-based gleaning
     #[serde(default)]
     pub use_gleaning: bool,
@@ -1134,6 +1141,7 @@ impl Default for EntityExtractionTopLevelConfig {
         Self {
             enabled: true,
             min_confidence: default_confidence_threshold(),
+            mode: None,
             use_gleaning: false,
             max_gleaning_rounds: default_gleaning_rounds(),
             gleaning_improvement_threshold: default_gleaning_improvement(),
@@ -1142,6 +1150,21 @@ impl Default for EntityExtractionTopLevelConfig {
             automatic_linking: false,
             linking_confidence_threshold: default_confidence_threshold(),
         }
+    }
+}
+
+/// Parse the `entities.mode` string emitted by SetConfig TOML files.
+///
+/// Mirrors the snake_case shape used by
+/// [`crate::config::EntityExtractionMode`]'s serde representation. Returns
+/// `None` for unrecognised values so the default precedence rules in
+/// `EntityConfig::resolved_mode` continue to apply.
+fn parse_entity_extraction_mode_str(value: &str) -> Option<crate::config::EntityExtractionMode> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "algorithmic" => Some(crate::config::EntityExtractionMode::Algorithmic),
+        "llm_single_pass" => Some(crate::config::EntityExtractionMode::LlmSinglePass),
+        "llm_gleaning" => Some(crate::config::EntityExtractionMode::LlmGleaning),
+        _ => None,
     }
 }
 
@@ -1868,6 +1891,12 @@ impl SetConfig {
             },
         }
 
+        // Map the explicit `entities.mode` field. When set, it takes
+        // precedence over `use_gleaning` per `EntityConfig::resolved_mode`.
+        if let Some(ref raw) = self.entity_extraction.mode {
+            config.entities.mode = parse_entity_extraction_mode_str(raw);
+        }
+
         // Map graph building
         config.graph.similarity_threshold = self.pipeline.graph_building.min_relation_score;
         config.graph.max_connections = self.pipeline.graph_building.max_connections_per_node;
@@ -1926,5 +1955,47 @@ impl SetConfig {
         };
 
         config
+    }
+}
+
+#[cfg(test)]
+mod entity_mode_plumbing_tests {
+    use super::*;
+    use crate::config::EntityExtractionMode;
+
+    /// `to_graphrag_config` propagates `entity_extraction.mode = "llm_single_pass"`.
+    #[test]
+    fn to_graphrag_config_maps_entities_mode_llm_single_pass() {
+        let mut set_cfg = SetConfig::default();
+        set_cfg.entity_extraction.mode = Some("llm_single_pass".to_string());
+        let cfg = set_cfg.to_graphrag_config();
+        assert_eq!(cfg.entities.mode, Some(EntityExtractionMode::LlmSinglePass));
+    }
+
+    /// `to_graphrag_config` propagates `entity_extraction.mode = "algorithmic"`.
+    #[test]
+    fn to_graphrag_config_maps_entities_mode_algorithmic() {
+        let mut set_cfg = SetConfig::default();
+        set_cfg.entity_extraction.mode = Some("algorithmic".to_string());
+        let cfg = set_cfg.to_graphrag_config();
+        assert_eq!(cfg.entities.mode, Some(EntityExtractionMode::Algorithmic));
+    }
+
+    /// `to_graphrag_config` propagates `entity_extraction.mode = "llm_gleaning"`.
+    #[test]
+    fn to_graphrag_config_maps_entities_mode_llm_gleaning() {
+        let mut set_cfg = SetConfig::default();
+        set_cfg.entity_extraction.mode = Some("llm_gleaning".to_string());
+        let cfg = set_cfg.to_graphrag_config();
+        assert_eq!(cfg.entities.mode, Some(EntityExtractionMode::LlmGleaning));
+    }
+
+    /// Unrecognised mode strings round-trip as `None` so default precedence applies.
+    #[test]
+    fn to_graphrag_config_ignores_unknown_mode_string() {
+        let mut set_cfg = SetConfig::default();
+        set_cfg.entity_extraction.mode = Some("not_a_real_mode".to_string());
+        let cfg = set_cfg.to_graphrag_config();
+        assert_eq!(cfg.entities.mode, None);
     }
 }

--- a/graphrag-core/src/entity/element_summary.rs
+++ b/graphrag-core/src/entity/element_summary.rs
@@ -5,6 +5,25 @@
 //! single coherent description from the per-instance descriptions. Below a
 //! cost-guard threshold the descriptions are concatenated locally to avoid
 //! unnecessary LLM calls.
+//!
+//! # Status: Preview API — not yet wired into indexing
+//!
+//! As of this revision, this module is **not invoked during
+//! `GraphRAG::build_graph`**. Both LLM extraction paths add entities and
+//! relationships directly to the graph without grouping by element and
+//! collapsing their descriptions, because `core::Entity` does not yet carry
+//! a `description` field for the collapsed text to live in.
+//!
+//! The functions below (`collapse_descriptions`, `collapse_all`,
+//! `collapse_entity_descriptions`, `collapse_relationship_descriptions`) are
+//! a stable public API that downstream callers can use today against their
+//! own description storage. The corresponding `entities.element_summary.*`
+//! configuration block is plumbed end-to-end through serialization and the
+//! `SetConfig` → `Config` conversion, so no config-file changes will be
+//! required when indexing-time wiring lands.
+//!
+//! Tracking: see issue #97 / PR review notes for the description-schema
+//! follow-up that will hook this into `build_graph`.
 
 use std::collections::HashMap;
 

--- a/graphrag-core/src/entity/element_summary.rs
+++ b/graphrag-core/src/entity/element_summary.rs
@@ -241,9 +241,10 @@ mod tests {
     async fn collapse_single_description_returns_none() {
         let cfg = ElementSummaryConfig::default();
         let backend = RecordingBackend::new("synth");
-        let out = collapse_descriptions("entity", "Tom", &["only one".into()], &cfg, Some(&backend))
-            .await
-            .unwrap();
+        let out =
+            collapse_descriptions("entity", "Tom", &["only one".into()], &cfg, Some(&backend))
+                .await
+                .unwrap();
         assert!(out.is_none());
         assert_eq!(backend.call_count(), 0, "must not call LLM for 1 instance");
     }
@@ -284,11 +285,10 @@ mod tests {
         };
         let big = "x".repeat(60);
         let backend = RecordingBackend::new("synthesized");
-        let out =
-            collapse_descriptions("entity", "Tom", &[big.clone(), big], &cfg, Some(&backend))
-                .await
-                .unwrap()
-                .unwrap();
+        let out = collapse_descriptions("entity", "Tom", &[big.clone(), big], &cfg, Some(&backend))
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(out, "synthesized");
         assert_eq!(backend.call_count(), 1);
     }

--- a/graphrag-core/src/entity/element_summary.rs
+++ b/graphrag-core/src/entity/element_summary.rs
@@ -1,0 +1,407 @@
+//! Element-summary collapse for entities and relationships.
+//!
+//! Implements Edge et al. 2024 §2.2: when the same element (entity or
+//! relationship) is described in multiple chunks, the LLM synthesizes a
+//! single coherent description from the per-instance descriptions. Below a
+//! cost-guard threshold the descriptions are concatenated locally to avoid
+//! unnecessary LLM calls.
+
+use std::collections::HashMap;
+
+#[cfg(test)]
+use async_trait::async_trait;
+
+use crate::core::backend::{ChatBackend, ChatParams};
+use crate::core::Result;
+
+/// Configuration knobs for element-summary collapse.
+#[derive(Debug, Clone)]
+pub struct ElementSummaryConfig {
+    /// Master switch. When `false`, [`collapse`] is a no-op.
+    pub enabled: bool,
+    /// Minimum number of instance descriptions required to trigger
+    /// summarization. Elements with fewer instances are returned unchanged.
+    pub min_instances: usize,
+    /// Total character budget below which instances are concatenated locally
+    /// instead of being sent to the LLM. Rough proxy for token count to
+    /// avoid pulling tiktoken into this hot path.
+    pub max_chars_for_concat: usize,
+    /// Sampling temperature passed to the chat backend.
+    pub temperature: f32,
+    /// Cap on tokens for the synthesized description.
+    pub max_output_tokens: u32,
+}
+
+impl Default for ElementSummaryConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            min_instances: 2,
+            max_chars_for_concat: 800,
+            temperature: 0.0,
+            max_output_tokens: 256,
+        }
+    }
+}
+
+/// Prompt template for synthesizing a single description from multiple
+/// instance descriptions of the same element.
+pub const ELEMENT_SUMMARY_PROMPT: &str = r#"You are a helpful assistant that summarizes information about an entity or relationship.
+
+Below are several descriptions of the same {kind} "{name}" extracted from different parts of a document. Some descriptions may overlap, contradict each other, or capture different aspects. Synthesize a single coherent description that:
+- Resolves contradictions sensibly
+- Preserves all distinct factual information
+- Reads as one fluent paragraph
+- Stays in third person and avoids meta-commentary about the synthesis itself
+
+Descriptions:
+{descriptions}
+
+Synthesized description:"#;
+
+/// Render a list of descriptions into a numbered block for the prompt.
+fn format_descriptions(descriptions: &[String]) -> String {
+    descriptions
+        .iter()
+        .enumerate()
+        .map(|(i, d)| format!("{}. {}", i + 1, d.trim()))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Build the LLM prompt for collapsing multiple descriptions of one element.
+///
+/// `kind` is a short label like "entity" or "relationship", and `name` is a
+/// human-readable identifier such as the entity name or `source -> target`.
+pub fn build_summary_prompt(kind: &str, name: &str, descriptions: &[String]) -> String {
+    ELEMENT_SUMMARY_PROMPT
+        .replace("{kind}", kind)
+        .replace("{name}", name)
+        .replace("{descriptions}", &format_descriptions(descriptions))
+}
+
+/// Decide whether to call the LLM, concatenate locally, or return as-is.
+///
+/// Returns `Ok(Some(text))` with the (possibly synthesized) description, or
+/// `Ok(None)` when fewer than `min_instances` descriptions exist (caller is
+/// expected to keep its existing single description).
+pub async fn collapse_descriptions(
+    kind: &str,
+    name: &str,
+    descriptions: &[String],
+    config: &ElementSummaryConfig,
+    backend: Option<&dyn ChatBackend>,
+) -> Result<Option<String>> {
+    if !config.enabled {
+        return Ok(None);
+    }
+    if descriptions.len() < config.min_instances {
+        return Ok(None);
+    }
+
+    let total_chars: usize = descriptions.iter().map(|d| d.len()).sum();
+    if total_chars < config.max_chars_for_concat || backend.is_none() {
+        // Below cost-guard or no backend available: concatenate locally.
+        let joined = descriptions
+            .iter()
+            .map(|d| d.trim().to_string())
+            .filter(|d| !d.is_empty())
+            .collect::<Vec<_>>()
+            .join(" | ");
+        return Ok(Some(joined));
+    }
+
+    let prompt = build_summary_prompt(kind, name, descriptions);
+    let params = ChatParams {
+        max_tokens: Some(config.max_output_tokens),
+        temperature: Some(config.temperature),
+        num_ctx: None,
+    };
+    let response = backend.unwrap().complete(&prompt, &params).await?;
+    Ok(Some(response.trim().to_string()))
+}
+
+/// Collapse a map of `key -> descriptions` into `key -> single description`.
+///
+/// Keys with fewer than `min_instances` descriptions are dropped from the
+/// output (callers should fall back to whatever single description they
+/// already have on the element).
+pub async fn collapse_all<K: Clone + std::hash::Hash + Eq>(
+    kind: &str,
+    items: HashMap<K, (String, Vec<String>)>,
+    config: &ElementSummaryConfig,
+    backend: Option<&dyn ChatBackend>,
+) -> Result<HashMap<K, String>> {
+    let mut out = HashMap::with_capacity(items.len());
+    for (key, (name, descriptions)) in items {
+        if let Some(summary) =
+            collapse_descriptions(kind, &name, &descriptions, config, backend).await?
+        {
+            out.insert(key, summary);
+        }
+    }
+    Ok(out)
+}
+
+/// Group `EntityData` instances by `(name, type)` and collapse descriptions.
+///
+/// Returns a map keyed by `(lowercased_name, type)` pointing at the
+/// synthesized description for every group meeting the `min_instances`
+/// threshold.
+pub async fn collapse_entity_descriptions(
+    entities: &[crate::entity::prompts::EntityData],
+    config: &ElementSummaryConfig,
+    backend: Option<&dyn ChatBackend>,
+) -> Result<HashMap<(String, String), String>> {
+    let mut groups: HashMap<(String, String), (String, Vec<String>)> = HashMap::new();
+    for e in entities {
+        let key = (e.name.to_lowercase(), e.entity_type.clone());
+        let entry = groups
+            .entry(key)
+            .or_insert_with(|| (e.name.clone(), Vec::new()));
+        if !e.description.trim().is_empty() {
+            entry.1.push(e.description.clone());
+        }
+    }
+    collapse_all("entity", groups, config, backend).await
+}
+
+/// Group `RelationshipData` instances by `(source, target)` and collapse.
+///
+/// Returns a map keyed by `(lowercased_source, lowercased_target)` pointing
+/// at the synthesized description for every group meeting the
+/// `min_instances` threshold.
+pub async fn collapse_relationship_descriptions(
+    relationships: &[crate::entity::prompts::RelationshipData],
+    config: &ElementSummaryConfig,
+    backend: Option<&dyn ChatBackend>,
+) -> Result<HashMap<(String, String), String>> {
+    let mut groups: HashMap<(String, String), (String, Vec<String>)> = HashMap::new();
+    for r in relationships {
+        let key = (r.source.to_lowercase(), r.target.to_lowercase());
+        let entry = groups
+            .entry(key)
+            .or_insert_with(|| (format!("{} -> {}", r.source, r.target), Vec::new()));
+        if !r.description.trim().is_empty() {
+            entry.1.push(r.description.clone());
+        }
+    }
+    collapse_all("relationship", groups, config, backend).await
+}
+
+/// Recording chat backend for tests: stores every prompt seen and returns a
+/// canned response.
+#[cfg(test)]
+pub struct RecordingBackend {
+    pub canned: String,
+    pub calls: std::sync::Mutex<Vec<String>>,
+}
+
+#[cfg(test)]
+impl RecordingBackend {
+    pub fn new(canned: impl Into<String>) -> Self {
+        Self {
+            canned: canned.into(),
+            calls: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+
+    pub fn call_count(&self) -> usize {
+        self.calls.lock().unwrap().len()
+    }
+}
+
+#[cfg(test)]
+#[async_trait]
+impl ChatBackend for RecordingBackend {
+    async fn complete(&self, prompt: &str, _params: &ChatParams) -> Result<String> {
+        self.calls.lock().unwrap().push(prompt.to_string());
+        Ok(self.canned.clone())
+    }
+}
+
+/// Chat backend that panics if invoked — used to assert the path skipped LLM.
+#[cfg(test)]
+pub struct PanicBackend;
+
+#[cfg(test)]
+#[async_trait]
+impl ChatBackend for PanicBackend {
+    async fn complete(&self, _prompt: &str, _params: &ChatParams) -> Result<String> {
+        panic!("PanicBackend::complete called when LLM should have been skipped");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Single description: returns None so caller keeps the existing one.
+    #[tokio::test]
+    async fn collapse_single_description_returns_none() {
+        let cfg = ElementSummaryConfig::default();
+        let backend = RecordingBackend::new("synth");
+        let out = collapse_descriptions("entity", "Tom", &["only one".into()], &cfg, Some(&backend))
+            .await
+            .unwrap();
+        assert!(out.is_none());
+        assert_eq!(backend.call_count(), 0, "must not call LLM for 1 instance");
+    }
+
+    /// Below the char budget: concatenate locally without invoking the LLM.
+    #[tokio::test]
+    async fn collapse_below_budget_concatenates_locally() {
+        let cfg = ElementSummaryConfig {
+            max_chars_for_concat: 800,
+            ..Default::default()
+        };
+        let backend = RecordingBackend::new("never used");
+        let out = collapse_descriptions(
+            "entity",
+            "Tom",
+            &["a young boy".into(), "the protagonist".into()],
+            &cfg,
+            Some(&backend),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        assert!(out.contains("a young boy"));
+        assert!(out.contains("the protagonist"));
+        assert_eq!(
+            backend.call_count(),
+            0,
+            "below char budget must skip the LLM"
+        );
+    }
+
+    /// Above the char budget with a backend: call the LLM exactly once.
+    #[tokio::test]
+    async fn collapse_above_budget_calls_llm() {
+        let cfg = ElementSummaryConfig {
+            max_chars_for_concat: 50,
+            ..Default::default()
+        };
+        let big = "x".repeat(60);
+        let backend = RecordingBackend::new("synthesized");
+        let out =
+            collapse_descriptions("entity", "Tom", &[big.clone(), big], &cfg, Some(&backend))
+                .await
+                .unwrap()
+                .unwrap();
+        assert_eq!(out, "synthesized");
+        assert_eq!(backend.call_count(), 1);
+    }
+
+    /// Disabled config: returns None even with multiple instances.
+    #[tokio::test]
+    async fn collapse_disabled_returns_none() {
+        let cfg = ElementSummaryConfig {
+            enabled: false,
+            ..Default::default()
+        };
+        let backend = RecordingBackend::new("never used");
+        let out = collapse_descriptions(
+            "entity",
+            "Tom",
+            &["a".into(), "b".into()],
+            &cfg,
+            Some(&backend),
+        )
+        .await
+        .unwrap();
+        assert!(out.is_none());
+        assert_eq!(backend.call_count(), 0);
+    }
+
+    /// `collapse_all` only emits keys that met the `min_instances` threshold.
+    #[tokio::test]
+    async fn collapse_all_filters_by_min_instances() {
+        let cfg = ElementSummaryConfig {
+            min_instances: 2,
+            ..Default::default()
+        };
+        let backend = RecordingBackend::new("synth");
+        let mut items: HashMap<String, (String, Vec<String>)> = HashMap::new();
+        items.insert("tom".into(), ("Tom".into(), vec!["a".into(), "b".into()]));
+        items.insert("huck".into(), ("Huck".into(), vec!["only one".into()]));
+        let out = collapse_all("entity", items, &cfg, Some(&backend))
+            .await
+            .unwrap();
+        assert!(out.contains_key("tom"));
+        assert!(!out.contains_key("huck"));
+    }
+
+    /// Below budget without a backend still concatenates locally.
+    #[tokio::test]
+    async fn collapse_without_backend_below_budget_concatenates() {
+        let cfg = ElementSummaryConfig::default();
+        let out = collapse_descriptions(
+            "entity",
+            "Tom",
+            &["alpha".into(), "beta".into()],
+            &cfg,
+            None,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        assert!(out.contains("alpha") && out.contains("beta"));
+    }
+
+    /// `collapse_entity_descriptions` groups by name+type, drops singletons.
+    #[tokio::test]
+    async fn collapse_entity_descriptions_groups_by_name_and_type() {
+        use crate::entity::prompts::EntityData;
+        let cfg = ElementSummaryConfig::default();
+        let entities = vec![
+            EntityData {
+                name: "Tom".into(),
+                entity_type: "PERSON".into(),
+                description: "a young boy".into(),
+            },
+            EntityData {
+                name: "tom".into(), // case-insensitive grouping
+                entity_type: "PERSON".into(),
+                description: "the protagonist".into(),
+            },
+            EntityData {
+                name: "Huck".into(),
+                entity_type: "PERSON".into(),
+                description: "Tom's friend".into(),
+            },
+        ];
+        let backend = RecordingBackend::new("synth");
+        let out = collapse_entity_descriptions(&entities, &cfg, Some(&backend))
+            .await
+            .unwrap();
+        assert!(out.contains_key(&("tom".to_string(), "PERSON".to_string())));
+        assert!(!out.contains_key(&("huck".to_string(), "PERSON".to_string())));
+    }
+
+    /// `collapse_relationship_descriptions` groups by source/target pair.
+    #[tokio::test]
+    async fn collapse_relationship_descriptions_groups_by_pair() {
+        use crate::entity::prompts::RelationshipData;
+        let cfg = ElementSummaryConfig::default();
+        let relationships = vec![
+            RelationshipData {
+                source: "Tom".into(),
+                target: "Huck".into(),
+                description: "best friends".into(),
+                strength: 0.9,
+            },
+            RelationshipData {
+                source: "tom".into(),
+                target: "huck".into(),
+                description: "go on adventures together".into(),
+                strength: 0.8,
+            },
+        ];
+        let backend = RecordingBackend::new("synth");
+        let out = collapse_relationship_descriptions(&relationships, &cfg, Some(&backend))
+            .await
+            .unwrap();
+        assert!(out.contains_key(&("tom".to_string(), "huck".to_string())));
+    }
+}

--- a/graphrag-core/src/entity/gleaning_extractor.rs
+++ b/graphrag-core/src/entity/gleaning_extractor.rs
@@ -39,7 +39,10 @@ pub struct GleaningConfig {
 impl Default for GleaningConfig {
     fn default() -> Self {
         Self {
-            max_gleaning_rounds: 4, // Microsoft GraphRAG uses 4 rounds
+            // Edge et al. 2024 §2.1 default: a single gleaning round.
+            // Higher values trade index time for marginal recall and can be
+            // overridden via `entities.max_gleaning_rounds` in config.
+            max_gleaning_rounds: 1,
             completion_threshold: 0.85,
             entity_confidence_threshold: 0.7,
             use_llm_completion_check: true, // Always use LLM for real gleaning
@@ -522,7 +525,8 @@ mod tests {
         let extractor = GleaningEntityExtractor::new(ollama_client, config);
 
         let stats = extractor.get_statistics();
-        assert_eq!(stats.config.max_gleaning_rounds, 4);
+        // Paper default is 1 (Edge et al. 2024 §2.1)
+        assert_eq!(stats.config.max_gleaning_rounds, 1);
         assert!(stats.llm_available);
     }
 

--- a/graphrag-core/src/entity/llm_extractor.rs
+++ b/graphrag-core/src/entity/llm_extractor.rs
@@ -160,9 +160,16 @@ impl LLMEntityExtractor {
         Ok((entities, relationships))
     }
 
-    /// Check if extraction is complete using LLM judgment
+    /// Check if extraction is complete using LLM judgment.
     ///
-    /// Uses the LLM to determine if all significant entities have been extracted.
+    /// Returns `Ok(true)` when the LLM judges the extraction COMPLETE (no more
+    /// entities to add). Follows Edge et al. 2024 §2.1 semantics:
+    ///   YES = entities were missed, continue gleaning  → returns `false`
+    ///   NO  = extraction is complete                    → returns `true`
+    ///
+    /// Backends that support `logit_bias` (e.g. OpenAI) should constrain the
+    /// reply to a single YES/NO token; backends that do not (Anthropic, Ollama)
+    /// fall back to string parsing of the first non-whitespace token.
     #[cfg(feature = "async")]
     pub async fn check_completion(
         &self,
@@ -172,25 +179,16 @@ impl LLMEntityExtractor {
     ) -> Result<bool> {
         tracing::debug!("LLM completion check for chunk: {}", chunk.id);
 
-        // Build completion check prompt
         let prompt =
             self.prompt_builder
                 .build_completion_prompt(&chunk.content, entities, relationships);
 
-        // Call LLM with logit bias for YES/NO response
         let llm_response = self.call_llm_completion_check(&prompt).await?;
-
-        // Parse YES/NO response
-        let response_trimmed = llm_response.trim().to_uppercase();
-        let is_complete = response_trimmed.starts_with("YES") || response_trimmed.contains("YES");
+        let is_complete = parse_completion_response(&llm_response);
 
         tracing::debug!(
-            "LLM completion check result: {} (response: {})",
-            if is_complete {
-                "COMPLETE"
-            } else {
-                "INCOMPLETE"
-            },
+            "LLM completion check: {} (raw: {:?})",
+            if is_complete { "COMPLETE" } else { "INCOMPLETE" },
             llm_response.trim()
         );
 
@@ -486,6 +484,36 @@ impl LLMEntityExtractor {
     }
 }
 
+/// Parse the YES/NO response from a gleaning completion-check call.
+///
+/// Returns `true` when the LLM signals that extraction is COMPLETE (no more
+/// entities to add). The prompt asks the model to answer YES if entities were
+/// missed; we therefore invert: the first standalone token decides the answer
+/// and unrecognized output is treated as INCOMPLETE so gleaning continues.
+fn parse_completion_response(response: &str) -> bool {
+    let trimmed = response.trim();
+    let first_token: String = trimmed
+        .chars()
+        .take_while(|c| c.is_ascii_alphabetic())
+        .collect::<String>()
+        .to_ascii_uppercase();
+
+    match first_token.as_str() {
+        "NO" => true,   // Extraction is COMPLETE
+        "YES" => false, // More entities were missed
+        _ => {
+            // Fall back to substring matching to be robust against verbose
+            // responses; default to INCOMPLETE if neither token appears.
+            let upper = trimmed.to_ascii_uppercase();
+            if upper.contains("NO") && !upper.contains("YES") {
+                true
+            } else {
+                false
+            }
+        },
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -525,6 +553,29 @@ Here's the extraction:
         let json = LLMEntityExtractor::find_json_in_text(text);
         assert!(json.is_some());
         assert_eq!(json.unwrap(), "{ \"entities\": [] }");
+    }
+
+    /// Plain "NO" response means extraction is complete.
+    #[test]
+    fn test_parse_completion_response_no_means_complete() {
+        assert!(parse_completion_response("NO"));
+        assert!(parse_completion_response("no\n"));
+        assert!(parse_completion_response("  No.  "));
+    }
+
+    /// Plain "YES" response means more entities should be extracted.
+    #[test]
+    fn test_parse_completion_response_yes_means_incomplete() {
+        assert!(!parse_completion_response("YES"));
+        assert!(!parse_completion_response("yes\n"));
+        assert!(!parse_completion_response("Yes, more entities exist."));
+    }
+
+    /// Unrecognized output defaults to INCOMPLETE so gleaning continues.
+    #[test]
+    fn test_parse_completion_response_unknown_defaults_incomplete() {
+        assert!(!parse_completion_response(""));
+        assert!(!parse_completion_response("maybe"));
     }
 
     #[test]

--- a/graphrag-core/src/entity/llm_extractor.rs
+++ b/graphrag-core/src/entity/llm_extractor.rs
@@ -506,14 +506,16 @@ fn parse_completion_response(response: &str) -> bool {
         "NO" => true,   // Extraction is COMPLETE
         "YES" => false, // More entities were missed
         _ => {
-            // Fall back to substring matching to be robust against verbose
-            // responses; default to INCOMPLETE if neither token appears.
-            let upper = trimmed.to_ascii_uppercase();
-            if upper.contains("NO") && !upper.contains("YES") {
-                true
-            } else {
-                false
-            }
+            // Fall back to word-boundary matching so verbose responses
+            // containing words like "KNOW", "NOTHING", "NONE", or
+            // "ENOUGH" are not mistaken for an isolated "NO" token.
+            // Default to INCOMPLETE if neither word appears.
+            let upper = trimmed.to_uppercase();
+            let words: std::collections::HashSet<&str> = upper
+                .split(|c: char| !c.is_alphanumeric())
+                .filter(|w| !w.is_empty())
+                .collect();
+            words.contains("NO") && !words.contains("YES")
         },
     }
 }
@@ -580,6 +582,32 @@ Here's the extraction:
     fn test_parse_completion_response_unknown_defaults_incomplete() {
         assert!(!parse_completion_response(""));
         assert!(!parse_completion_response("maybe"));
+    }
+
+    /// Substring "NO" inside other words must not classify as complete.
+    #[test]
+    fn parse_completion_response_does_not_match_no_in_word() {
+        assert!(!parse_completion_response(
+            "NOTHING WAS MISSED. KNOW WHAT I MEAN?"
+        ));
+        assert!(!parse_completion_response("ENOUGH context, KNOW more?"));
+        assert!(!parse_completion_response("NONE of the above"));
+    }
+
+    /// An isolated "NO" word (in any form) must classify as complete.
+    #[test]
+    fn parse_completion_response_recognizes_isolated_no() {
+        assert!(parse_completion_response("NO"));
+        assert!(parse_completion_response("No, the extraction is complete."));
+        assert!(parse_completion_response("no - all entities found"));
+    }
+
+    /// Ambiguous "not sure" must not classify as complete (no isolated NO/YES).
+    #[test]
+    fn parse_completion_response_handles_not_sure() {
+        assert!(!parse_completion_response(
+            "Not sure if there are more entities."
+        ));
     }
 
     #[test]

--- a/graphrag-core/src/entity/llm_extractor.rs
+++ b/graphrag-core/src/entity/llm_extractor.rs
@@ -188,7 +188,11 @@ impl LLMEntityExtractor {
 
         tracing::debug!(
             "LLM completion check: {} (raw: {:?})",
-            if is_complete { "COMPLETE" } else { "INCOMPLETE" },
+            if is_complete {
+                "COMPLETE"
+            } else {
+                "INCOMPLETE"
+            },
             llm_response.trim()
         );
 

--- a/graphrag-core/src/entity/mod.rs
+++ b/graphrag-core/src/entity/mod.rs
@@ -2,6 +2,8 @@
 pub mod atomic_fact_extractor;
 /// Bidirectional entity-chunk index for fast lookups
 pub mod bidirectional_index;
+/// Element-summary collapse for entities/relationships described in many chunks (paper §2.2)
+pub mod element_summary;
 /// Gleaning-based entity extraction module
 pub mod gleaning_extractor;
 /// GLiNER-Relex joint NER + RE extractor (feature-gated: `gliner`)
@@ -20,6 +22,10 @@ pub mod string_similarity_linker;
 
 pub use atomic_fact_extractor::{AtomicFact, AtomicFactExtractor};
 pub use bidirectional_index::{BidirectionalIndex, IndexStatistics};
+pub use element_summary::{
+    build_summary_prompt, collapse_all, collapse_descriptions, collapse_entity_descriptions,
+    collapse_relationship_descriptions, ElementSummaryConfig, ELEMENT_SUMMARY_PROMPT,
+};
 pub use gleaning_extractor::{ExtractionCompletionStatus, GleaningConfig, GleaningEntityExtractor};
 #[cfg(feature = "gliner")]
 pub use gliner_extractor::GLiNERExtractor;

--- a/graphrag-core/src/entity/prompts.rs
+++ b/graphrag-core/src/entity/prompts.rs
@@ -50,9 +50,13 @@ Text: {input_text}
 Output:
 "#;
 
-/// Gleaning continuation prompt for additional rounds
+/// Gleaning continuation prompt for additional rounds.
+///
+/// Wording follows Edge et al. 2024 §2.1: the prompt asserts that "MANY entities
+/// were missed" to bias the model toward producing additional output, rather
+/// than the softer "may have missed" framing.
 pub const GLEANING_CONTINUATION_PROMPT: &str = r#"-Goal-
-You previously extracted entities and relationships from a text document. Review your previous extraction and the original text to identify any additional entities or relationships you may have missed in the first pass.
+MANY entities were missed in the last extraction. Review your previous extraction and the original text and add any entities and relationships that were missed.
 
 -Steps-
 1. Review the entities you previously identified:
@@ -95,8 +99,14 @@ Text: {input_text}
 Output:
 "#;
 
-/// Completion check prompt to determine if extraction is complete
-pub const COMPLETION_CHECK_PROMPT: &str = r#"Based on the text below and the entities/relationships already extracted, are there any significant entities or relationships that have been missed?
+/// Completion check prompt to determine if extraction is complete.
+///
+/// Wording follows Edge et al. 2024 §2.1: rather than asking whether anything
+/// "may have been missed", the prompt asserts "MANY entities were missed" and
+/// asks the model to answer YES or NO. The decision is intended to be taken on
+/// a single token using `logit_bias` to force a YES/NO answer; backends that
+/// do not support `logit_bias` fall back to string parsing.
+pub const COMPLETION_CHECK_PROMPT: &str = r#"It appears MANY entities were missed in the last extraction. Answer YES if there are still entities or relationships that need to be added, or NO if the extraction is complete.
 
 Text:
 {input_text}
@@ -107,13 +117,7 @@ Current Entities ({entity_count}):
 Current Relationships ({relationship_count}):
 {relationships_summary}
 
-Think carefully about:
-1. Are all important characters, people, organizations mentioned in the text captured?
-2. Are all significant locations, places, settings identified?
-3. Are all key events, objects, concepts extracted?
-4. Are all meaningful relationships between entities documented?
-
-Respond with ONLY "YES" if the extraction is complete and thorough, or "NO" if there are still significant entities or relationships missing.
+Answer with ONLY "YES" if more entities or relationships should be added, or "NO" if the extraction is complete.
 
 Answer (YES or NO):"#;
 
@@ -375,6 +379,30 @@ mod tests {
 
         assert!(prompt.contains("Tom"));
         assert!(prompt.contains("YES or NO"));
+    }
+
+    /// Paper-aligned wording: continuation prompt asserts entities were missed.
+    #[test]
+    fn test_continuation_prompt_uses_paper_wording() {
+        let builder = PromptBuilder::new(vec!["PERSON".to_string()]);
+        let prompt = builder.build_continuation_prompt("Some text", &[], &[]);
+        assert!(
+            prompt.contains("MANY entities were missed"),
+            "continuation prompt must use paper wording, got: {}",
+            prompt
+        );
+    }
+
+    /// Paper-aligned wording: completion check asserts entities were missed.
+    #[test]
+    fn test_completion_prompt_uses_paper_wording() {
+        let builder = PromptBuilder::new(vec!["PERSON".to_string()]);
+        let prompt = builder.build_completion_prompt("Some text", &[], &[]);
+        assert!(
+            prompt.contains("MANY entities were missed"),
+            "completion prompt must use paper wording, got: {}",
+            prompt
+        );
     }
 
     #[test]

--- a/graphrag-core/src/lib.rs
+++ b/graphrag-core/src/lib.rs
@@ -553,21 +553,29 @@ impl GraphRAG {
         let total_chunks = chunks.len();
 
         // PHASE 1: Extract and add all entities
-        // Pipeline selection based on config.approach (semantic/algorithmic/hybrid)
-        // - Semantic: config.entities.use_gleaning = true (LLM-based with iterative refinement)
-        // - Algorithmic: config.entities.use_gleaning = false (pattern-based extraction)
-        // - Hybrid: config.entities.use_gleaning = true (uses LLM + pattern fusion)
+        //
+        // Mode selection follows `EntityConfig::resolved_mode`:
+        //   - explicit `entities.mode` wins
+        //   - else `use_gleaning` toggles between LlmGleaning and LlmSinglePass
+        //   - if Ollama is disabled, the mode is forced to Algorithmic
+        //
+        // Algorithmic mode never invokes the LLM and is the only way to fully
+        // skip per-chunk LLM calls at index time (see issue #8).
+        let resolved_mode = self
+            .config
+            .entities
+            .resolved_mode(self.config.ollama.enabled);
 
-        // DEBUG: Log current configuration state
         #[cfg(feature = "tracing")]
         tracing::info!(
-            "build_graph() - Config state: approach='{}', use_gleaning={}, ollama.enabled={}",
+            "build_graph() - approach='{}', mode={:?}, use_gleaning={}, ollama.enabled={}",
             self.config.approach,
+            resolved_mode,
             self.config.entities.use_gleaning,
             self.config.ollama.enabled
         );
 
-        if self.config.entities.use_gleaning && self.config.ollama.enabled {
+        if resolved_mode == crate::config::EntityExtractionMode::LlmGleaning {
             // LLM-based extraction with gleaning
             #[cfg(feature = "async")]
             {
@@ -842,8 +850,8 @@ impl GraphRAG {
                     );
                 }
             }
-        } else if self.config.ollama.enabled {
-            // LLM single-pass extraction (Ollama enabled, gleaning disabled)
+        } else if resolved_mode == crate::config::EntityExtractionMode::LlmSinglePass {
+            // LLM single-pass extraction (mode = LlmSinglePass; Ollama enabled).
             //
             // Uses LLMEntityExtractor directly for one extraction round per chunk.
             // num_ctx is calculated dynamically from the built prompt + 20% margin,


### PR DESCRIPTION
## Summary

Bundles three GraphRAG-paper alignment changes for entity extraction:

- **Closes #99** — paper-aligned gleaning prompts + correct YES/NO semantics + default \`max_gleaning_rounds\` 4 → 1
- **Closes #8** — \`EntityExtractionMode { Algorithmic, LlmSinglePass, LlmGleaning }\` enum with \`use_gleaning\` back-compat
- **Closes #97 (preview)** — \`element_summary\` LLM-collapse module landed as preview API; full indexing-pipeline wiring deferred (see below)

### #99 — Gleaning fidelity

- Rewrote \`GLEANING_CONTINUATION_PROMPT\` and \`COMPLETION_CHECK_PROMPT\` to use the paper's \"MANY entities were missed\" wording.
- Inverted YES/NO semantics in \`check_completion\` to match the paper: YES = continue gleaning, NO = complete.
- Lowered default \`max_gleaning_rounds\` from 3-4 to 1 across \`GleaningConfig::default\`, \`config/mod.rs\`, and \`config/setconfig.rs\`. \`PIPELINE_ARCHITECTURE.md\` was already documenting 1 — code now matches.
- \`logit_bias\` plumbing kept as scope follow-up; the new prompt phrasing makes the string-parse fallback more reliable.

### #8 — \`EntityExtractionMode\`

- New enum with snake_case serde aliases.
- \`EntityConfig::resolved_mode(ollama_enabled)\` precedence: explicit \`mode\` → legacy \`use_gleaning\` → forced \`Algorithmic\` if Ollama disabled.
- \`build_graph\` dispatch in \`lib.rs\` uses the resolved mode instead of \`use_gleaning\` directly. \`mode = \"algorithmic\"\` is now the only way to fully skip per-chunk LLM extraction.

### #97 — Element summary (preview)

New module \`graphrag-core/src/entity/element_summary.rs\` with:
- \`collapse_descriptions\` / \`collapse_all\` for entities and relationships
- \`ElementSummaryConfig\` (enabled, min_instances, max_chars_for_concat = 800)
- 800-char cost guard: below the budget, descriptions are concatenated locally; above it, the chat backend is called

**Status: preview API.** \`build_graph\` does NOT invoke this module today because \`Entity\` has no \`description\` field — extractors drop \`EntityData::description\` during \`convert_data_to_entities\`. Wiring it end-to-end requires an \`Entity::description\` schema change (~127-147 lines including parquet schema evolution and the indexing-pipeline orchestration), which exceeded the scope ceiling for this PR. The module's docstring, the README \`[entities.element_summary]\` table, and \`PIPELINE_ARCHITECTURE.md\` all flag the preview status.

## Review fixes (codex + gemini, 4 findings)

- **fix(core/entity): use word-boundary matching in completion parser** — codex P3 + gemini. Original \`upper.contains(\"NO\") && !upper.contains(\"YES\")\` matched \"NOTHING WAS MISSED\", \"KNOW\", \"ENOUGH\", \"none\", \"not sure\" → premature gleaning stop. Now splits on non-alphanumeric and matches \`NO\` / \`YES\` as full tokens.
- **fix(core/config): preserve mode + element_summary across JSON I/O** — codex P3 + gemini. Manual \`Config::from_file\` parser hardcoded \`mode: None\` and \`element_summary: default()\`, silently dropping user TOML/JSON config. Also fixed \`Config::to_file\` to serialize them. The \`from_toml_file\` path uses serde and was already correct via \`#[serde(default)]\`.
- **fix(core/config): plumb entities.mode through SetConfig::to_graphrag_config** — codex P2. CLI / convenience constructors load configs through \`SetConfig\`, which only mapped legacy \`use_gleaning\` and \`max_gleaning_rounds\`. Added \`mode: Option<String>\` field to \`EntityExtractionTopLevelConfig\` and a \`parse_entity_extraction_mode_str\` helper.
- **docs(core/entity): mark element_summary as preview** — codex P1. The dead-code finding led to the option-B disposition above; the module doc, README, and PIPELINE_ARCHITECTURE all now clearly mark preview status.

## Test plan

- [x] \`cargo fmt --all\` clean
- [x] \`cargo build --workspace --exclude graphrag_py --exclude graphrag-wasm\` clean
- [x] \`cargo nextest run -p graphrag-core --lib\` — 434 passed, 12 skipped (was 423; +11)

New regression tests:
- 3 word-boundary completion-parser tests
- 3 JSON config round-trip tests (+ helper)
- 4 SetConfig→Config mode plumbing tests + 1 helper test
- 8 element_summary unit tests (recording/panic mock backend pattern)
- 4 \`config::entity_mode_tests\` for back-compat precedence

## Out of scope (preview deferrals)

- \`Entity::description\` schema change to wire \`element_summary\` into \`build_graph\` end-to-end (#97 follow-up; ~127-147 lines)
- \`logit_bias\` plumbing through \`ChatBackend\` (#99 follow-up — the trait surface needs a parallel \`complete_constrained\` method or a \`logit_bias\` field on \`ChatParams\`)

Closes #99, #8, #97