### PR TITLE
docs: reconcile README/HOW_IT_WORKS/PIPELINE with current paper-alignment state

### DIFF
--- a/HOW_IT_WORKS.md
+++ b/HOW_IT_WORKS.md
@@ -4,6 +4,10 @@
 
 ---
 
+> **Status vs. the GraphRAG paper.** This document describes the *intended* GraphRAG-style pipeline. Several stages of the original Microsoft GraphRAG paper (arxiv 2404.16130) are not yet wired up on `main` - most notably paper-style **Global Search** (map-reduce over community reports) and LLM-generated **community reports**. Token-based chunking, hierarchical Leiden contraction, paper-aligned gleaning defaults, element-summary collapse, and a paper-aligned Local Search mode are all in flight on open PRs (#126, #128, #130, #131). See [Status vs. paper in the root README](README.md#status-vs-paper) for the full stage-by-stage breakdown before benchmarking against the paper's results.
+
+---
+
 ## 🎯 What is GraphRAG?
 
 GraphRAG (Graph-based Retrieval-Augmented Generation) is an intelligent system that transforms unstructured text into a **knowledge graph** and uses it to answer questions with unprecedented accuracy and context awareness.
@@ -814,7 +818,7 @@ let scores = pagerank.compute_personalized(
 // Ranks entities by importance: 27x faster retrieval!
 ```
 
-**C. Community Detection** (Hierarchical Clustering)
+**C. Community Detection** (Leiden clustering)
 ```
 Community 1: Tom Sawyer storyline (347 entities)
   ├─ Subgraph: Treasure hunting (45 entities)
@@ -824,6 +828,8 @@ Community 1: Tom Sawyer storyline (347 entities)
 Community 2: Philosophical concepts (189 entities)
   └─ From Symposium document
 ```
+
+> **Status:** `main` runs a single-level Leiden today. Multi-level / hierarchical Leiden (super-graph contraction, the paper's "C0/C1/C2/..." hierarchy) is in flight on PR #128. LLM-generated **community reports** for each community - which the paper feeds into Global Search - are not yet implemented (issue #95).
 
 **Module**: `src/graph/mod.rs`, `src/graph/incremental.rs`
 **Performance**:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ![GraphRAG Network Visualization](examples/readme.jpg)
 
-A high-performance, modular Rust implementation of GraphRAG (Graph-based Retrieval Augmented Generation) with **three deployment architectures**: Server-Only, WASM-Only (100% client-side), and Hybrid. Build knowledge graphs from documents and query them with natural language, with GPU acceleration support via WebGPU.
+A high-performance, modular Rust implementation of graph-based retrieval-augmented generation, inspired by Microsoft's GraphRAG paper (arxiv 2404.16130) and adjacent work (LightRAG, HippoRAG, Fast-GraphRAG). It supports **three deployment architectures**: Server-Only, WASM-Only (100% client-side), and Hybrid. Build knowledge graphs from documents and query them with natural language, with GPU acceleration support via WebGPU.
+
+> **Status vs. the GraphRAG paper.** This project does *not* implement every stage of the original paper yet. Most notably, paper-style **Global Search** (map-reduce over community reports) and LLM-generated **community reports** are not yet wired in. See the [Status vs. paper](#status-vs-paper) section below before benchmarking against the paper's numbers.
 
 [![CI](https://github.com/mfaulk/graphrag-rs/actions/workflows/ci.yml/badge.svg)](https://github.com/mfaulk/graphrag-rs/actions/workflows/ci.yml)
 [![Rust](https://img.shields.io/badge/rust-1.70+-orange.svg)](https://www.rust-lang.org)
@@ -370,7 +372,7 @@ QUERY (ask())
 
 | Phase | Goal | Key Parameters |
 |-------|------|----------------|
-| **1. Chunking** | Split text | `chunk_size` (300), `chunk_overlap` (30) |
+| **1. Chunking** | Split text | `chunk_size` (1000), `chunk_overlap` (200) |
 | **2. Extraction** | Identify entities | `approach` (hybrid), `entity_types` |
 | **3. Relationships** | Connect entities | `extract_relationships` (true) |
 | **4. Graph** | Build network | `max_connections` (50), `enable_pagerank` |
@@ -379,6 +381,24 @@ QUERY (ask())
 | **7. Generation** | Answer query | `chat_model` (gpt-4o), `temperature` (0.0) |
 
 See **[PIPELINE_ARCHITECTURE.md](graphrag-core/PIPELINE_ARCHITECTURE.md)** for detailed configuration and performance tuning.
+
+## Status vs. paper
+
+Marketing the project as a "Rust implementation of GraphRAG" overstates what is wired up today. Here is what each stage of the original GraphRAG paper (arxiv 2404.16130) currently looks like in this codebase:
+
+| Pipeline stage | Status | Notes |
+|---|---|---|
+| Document chunking | In progress: token-based via `tiktoken-rs` (cl100k_base) on PR #126; `main` uses a hierarchical char-based chunker | PR #126 |
+| LLM entity extraction with gleaning | In progress: paper-aligned prompts and `max_gleanings = 1` default land in PR #131; `main` defaults to `max_gleaning_rounds = 3` | PR #131 |
+| Hierarchical Leiden (super-graph contraction) | In progress: real multi-level Leiden lands in PR #128; `main` runs a single-level Leiden | PR #128 |
+| Element summaries (LLM collapse of duplicate descriptions) | Preview only: API exists in PR #131; full wiring needs `Entity::description` (Wave 3 A) | PR #131 + Wave 3 A |
+| Community reports (LLM-generated structured summaries) | Not yet implemented | Issue #95 (blocked on #94 / #97) |
+| Local Search (entity-anchored, token-budgeted retrieval) | In progress: `--mode local` lands in PR #130 | PR #130 |
+| Global Search (map-reduce over community reports + helpfulness scoring) | Not yet implemented | Issue #93 |
+
+**On query modes:** the default mode is `--mode hybrid`, which is *this project's own* blend (LightRAG dual-level + PageRank/PPR + cross-encoder reranking) rather than the paper's modes. Once PR #130 merges, `--mode local` will provide the paper-aligned Local Search. Paper-aligned `--mode global` remains future work, tracked in issue #93.
+
+**Note for benchmarking:** because Global Search is not yet implemented, comparisons against the GraphRAG paper's reported numbers should be interpreted carefully and ideally restricted to Local Search / hybrid retrieval. Until PRs #126, #128, #130, and #131 merge, several other stages (token-based chunking, hierarchical Leiden, paper-aligned gleaning defaults, element-summary collapse) are also still in flight on `main`.
 
 ### 4. CLI Usage
 

--- a/README.md
+++ b/README.md
@@ -388,17 +388,17 @@ Marketing the project as a "Rust implementation of GraphRAG" overstates what is 
 
 | Pipeline stage | Status | Notes |
 |---|---|---|
-| Document chunking | In progress: token-based via `tiktoken-rs` (cl100k_base) on PR #126; `main` uses a hierarchical char-based chunker | PR #126 |
+| Document chunking | In progress: token-based via `tiktoken-rs` (cl100k_base) on PR #126; `main` uses char-based chunking via `TextProcessor::chunk_text` (a `chunk_text_hierarchical` helper exists in `graphrag-core/src/text/mod.rs` but is not on the active ingestion path) | PR #126 |
 | LLM entity extraction with gleaning | In progress: paper-aligned prompts and `max_gleanings = 1` default land in PR #131; `main` defaults to `max_gleaning_rounds = 3` | PR #131 |
 | Hierarchical Leiden (super-graph contraction) | In progress: real multi-level Leiden lands in PR #128; `main` runs a single-level Leiden | PR #128 |
 | Element summaries (LLM collapse of duplicate descriptions) | Preview only: API exists in PR #131; full wiring needs `Entity::description` (Wave 3 A) | PR #131 + Wave 3 A |
 | Community reports (LLM-generated structured summaries) | Not yet implemented | Issue #95 (blocked on #94 / #97) |
-| Local Search (entity-anchored, token-budgeted retrieval) | In progress: `--mode local` lands in PR #130 | PR #130 |
+| Local Search (entity-anchored, token-budgeted retrieval) | In progress: `--mode local` retrieval flag lands in PR #130 (not yet on `main`) | PR #130 |
 | Global Search (map-reduce over community reports + helpfulness scoring) | Not yet implemented | Issue #93 |
 
-**On query modes:** the default mode is `--mode hybrid`, which is *this project's own* blend (LightRAG dual-level + PageRank/PPR + cross-encoder reranking) rather than the paper's modes. Once PR #130 merges, `--mode local` will provide the paper-aligned Local Search. Paper-aligned `--mode global` remains future work, tracked in issue #93.
+**On query modes:** today on `main` the CLI does *not* expose a `--mode {local,global,hybrid}` flag. The TUI offers `/mode ask|explain|reason`, which selects answer *style* (plain answer, answer with sources/confidence, or query-decomposition reasoning) rather than retrieval strategy; retrieval itself defaults to this project's hybrid blend (LightRAG dual-level + PageRank/PPR + cross-encoder reranking). After PR #130 merges, `graphrag query --mode local` will become available and will provide the paper-aligned Local Search. Paper-aligned `--mode global` remains future work, tracked in issue #93.
 
-**Note for benchmarking:** because Global Search is not yet implemented, comparisons against the GraphRAG paper's reported numbers should be interpreted carefully and ideally restricted to Local Search / hybrid retrieval. Until PRs #126, #128, #130, and #131 merge, several other stages (token-based chunking, hierarchical Leiden, paper-aligned gleaning defaults, element-summary collapse) are also still in flight on `main`.
+**Note for benchmarking:** today (on `main`) only the project's hybrid retrieval is available, so comparisons against the GraphRAG paper's reported numbers should be interpreted with that caveat in mind. After PR #130 merges, Local Search becomes available and is the appropriate paper-aligned retrieval mode to benchmark; Global Search remains unimplemented (#93). Until PRs #126, #128, #130, and #131 merge, several other stages (token-based chunking, hierarchical Leiden, paper-aligned gleaning defaults, element-summary collapse) are also still in flight on `main`.
 
 ### 4. CLI Usage
 

--- a/graphrag-core/PIPELINE_ARCHITECTURE.md
+++ b/graphrag-core/PIPELINE_ARCHITECTURE.md
@@ -16,6 +16,9 @@ This document details the 7-phase architecture of the GraphRAG pipeline, coverin
 | `chunk_size` | Maximum chunk size (characters today; token-based via tiktoken-rs is in flight on PR #126) | 1000 |
 | `chunk_overlap` | Overlap between adjacent chunks | 200 |
 
+> [!NOTE]
+> **Known default inconsistency.** The `Config` struct (`graphrag-core/src/config/mod.rs`) defaults `chunk_size = 1000` / `chunk_overlap = 200`, while `SetConfig` (`graphrag-core/src/config/setconfig.rs`, used by file-loaded configs) defaults `chunk_size = 512` / `chunk_overlap = 64`. The two paths disagree on defaults; effective values therefore depend on whether a `Config` is built programmatically or loaded from a TOML file. Tracked as a follow-up.
+
 ### Guidelines
 - **Small Chunks (100-300 tokens):** Best for granular retrieval and precise fact extraction.
 - **Large Chunks (500-1000 tokens):** Better for capturing broader context and thematic relationships.
@@ -94,17 +97,21 @@ This document details the 7-phase architecture of the GraphRAG pipeline, coverin
 ### Configuration
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `strategy` | Retrieval strategy (`vector`, `graph`, `hybrid`, `local`, `global`) | `hybrid` |
+| `strategy` | Retrieval strategy (today: `vector`, `graph`, `hybrid`; planned: `local` via PR #130, `global` not yet implemented per #93) | `hybrid` |
 | `top_k` | Number of results to return | `10` |
 | `retrieval.score_threshold` | Minimum similarity score | `0.7` |
 
 ### Strategies
+
+**Available on `main` today:**
 1.  **Vector:** Standard semantic search using embeddings.
 2.  **Graph:** Traverses the knowledge graph to find related entities.
-3.  **Hybrid:** Combines Vector and Graph search for best coverage.
-4.  **Local:** Focuses on immediate neighborhood of query entities.
-5.  **Global:** Scans entire graph/communities for broad queries.
-6.  **Text:** Keyword-based search (BM25 or similar).
+3.  **Hybrid:** Combines Vector and Graph search for best coverage. (Default.)
+4.  **Text:** Keyword-based search (BM25 or similar).
+
+**Planned / in progress (not yet on `main`):**
+5.  **Local:** Focuses on immediate neighborhood of query entities. Paper-aligned Local Search lands in PR #130.
+6.  **Global:** Scans entire graph/communities for broad queries. Paper-aligned Global Search is not yet implemented (tracked in issue #93).
 
 ## Phase 7: Answer Generation (Query)
 **Goal:** Synthesize a final answer from retrieved context.
@@ -187,14 +194,14 @@ The table below tracks how each stage of the GraphRAG paper (arxiv 2404.16130) m
 
 | Pipeline stage | Status | Notes |
 |---|---|---|
-| Document chunking | In progress: token-based via `tiktoken-rs` (cl100k_base) | PR #126 - char-based hierarchical chunker on `main` today |
+| Document chunking | In progress: token-based via `tiktoken-rs` (cl100k_base) | PR #126 - `main` today uses char-based chunking via `TextProcessor::chunk_text` (a `chunk_text_hierarchical` helper exists in `graphrag-core/src/text/mod.rs` but is not on the active ingestion path) |
 | LLM entity extraction with gleaning | In progress: paper-aligned prompts and `max_gleanings = 1` default | PR #131 (also adds logit-bias / `LOOP` continuation) |
 | Hierarchical Leiden (super-graph contraction) | In progress: real multi-level | PR #128 - single-level Leiden on `main` today |
 | Element summaries (LLM collapse of duplicate descriptions) | Preview only: API exists; needs `Entity::description` wiring | PR #131 + Wave 3 A wiring |
 | Community reports (LLM-generated structured summaries) | Not yet implemented | Tracked in issue #95 (blocked on #94 / #97) |
-| Local Search (entity-anchored, token-budgeted context window) | In progress: `--mode local` retrieval mode | PR #130 |
+| Local Search (entity-anchored, token-budgeted context window) | In progress: `--mode local` retrieval flag (not yet on `main`) | PR #130 |
 | Global Search (map-reduce over community reports + helpfulness scoring) | Not yet implemented | Tracked in issue #93 |
 
-**Default query mode** is `--mode hybrid` (this project's own LightRAG/PageRank-based blend), not the paper's mode. Once PR #130 merges, `--mode local` will provide the paper-aligned Local Search; Global Search remains future work (#93).
+**On query modes today:** `main` does *not* expose a `--mode {local,global,hybrid}` retrieval flag. The TUI's `/mode ask|explain|reason` selects answer style (plain / explained / reasoning), not retrieval strategy; retrieval defaults to this project's hybrid blend (LightRAG dual-level + PageRank/PPR + cross-encoder reranking). After PR #130 merges, `graphrag query --mode local` will become available and will provide the paper-aligned Local Search. Paper-aligned Global Search remains future work (#93).
 
-**For benchmarking:** any comparison to the GraphRAG paper's reported numbers should account for the absent Global Search stage and (until the PRs above merge) the absent token-based chunking, hierarchical Leiden, paper-aligned gleaning defaults, and element-summary collapse.
+**For benchmarking:** today (on `main`) the only available retrieval is the project's hybrid blend, so any comparison to the GraphRAG paper's reported numbers should be interpreted with that caveat in mind. After PR #130 merges, Local Search becomes the appropriate paper-aligned retrieval mode to benchmark against. Comparisons should also account for the still-absent Global Search stage and (until the other PRs above merge) the absent token-based chunking, hierarchical Leiden, paper-aligned gleaning defaults, and element-summary collapse.

--- a/graphrag-core/PIPELINE_ARCHITECTURE.md
+++ b/graphrag-core/PIPELINE_ARCHITECTURE.md
@@ -2,6 +2,9 @@
 
 This document details the 7-phase architecture of the GraphRAG pipeline, covering both Indexing (Graph Construction) and Query (Retrieval & Generation).
 
+> [!IMPORTANT]
+> **Status vs. the GraphRAG paper (arxiv 2404.16130).** This pipeline is *inspired by* Microsoft GraphRAG but does not yet implement every stage of the paper. See the [Status vs. paper](#status-vs-paper) table at the bottom of this document, or the matching section in the [root README](../README.md), before benchmarking against the paper's results.
+
 ## Phase 1: Chunking (Indexing)
 **Goal:** Split documents into manageable segments for processing.
 > [!NOTE]
@@ -10,8 +13,8 @@ This document details the 7-phase architecture of the GraphRAG pipeline, coverin
 ### Configuration
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `chunk_size` | Maximum number of tokens per chunk | 300 |
-| `chunk_overlap` | Number of overlapping tokens between chunks | 30 |
+| `chunk_size` | Maximum chunk size (characters today; token-based via tiktoken-rs is in flight on PR #126) | 1000 |
+| `chunk_overlap` | Overlap between adjacent chunks | 200 |
 
 ### Guidelines
 - **Small Chunks (100-300 tokens):** Best for granular retrieval and precise fact extraction.
@@ -41,7 +44,7 @@ This document details the 7-phase architecture of the GraphRAG pipeline, coverin
 |-----------|-------------|---------|
 | `extract_relationships` | Enable/disable relationship extraction | `true` |
 | `use_gleaning` | Enable multi-pass extraction for missed relationships | `true` |
-| `max_gleanings` | Maximum number of gleaning passes | `1` |
+| `max_gleaning_rounds` | Maximum number of gleaning passes (config default; the paper uses `max_gleanings = 1` and that is what PR #131 wires up for paper-aligned runs) | `3` |
 
 ### Methods
 1.  **Co-occurrence:** rapid identification based on proximity in text.
@@ -125,8 +128,8 @@ This document details the 7-phase architecture of the GraphRAG pipeline, coverin
 
 | Section | Parameter | Type | Default | Description |
 |---------|-----------|------|---------|-------------|
-| **Chunking** | `chunk_size` | int | 300 | Max tokens per chunk |
-| | `chunk_overlap` | int | 30 | Overlap tokens |
+| **Chunking** | `chunk_size` | int | 1000 | Max chunk size (chars today; tokens once PR #126 lands) |
+| | `chunk_overlap` | int | 200 | Overlap |
 | **Extraction** | `entity_extraction.approach` | enum | hybrid | Extraction method |
 | | `entity_extraction.entity_types` | list | [...] | Target entities |
 | | `entity_extraction.use_gleaning` | bool | true | Multi-pass extraction |
@@ -148,7 +151,9 @@ This document details the 7-phase architecture of the GraphRAG pipeline, coverin
 |---------------|-----------------------------|---------------|---------------|
 | **Light** (Algo Extract, Vector Only) | ~30s | ~500ms | Low |
 | **Balanced** (Hybrid Extract, Hybrid Search) | ~2m | ~1.5s | Medium |
-| **Deep** (All Semantic, Global Search) | ~10m | ~5s+ | High |
+| **Deep** (All Semantic, hybrid + Local Search) | ~10m | ~5s+ | High |
+
+> Paper-style **Global Search** (map-reduce over community reports) is not yet implemented - see [Status vs. paper](#status-vs-paper).
 
 ---
 
@@ -173,3 +178,23 @@ GraphRAG-rs implements techniques from several cutting-edge research papers. Her
 - **Graph Construction:** ~10-30s
 - **Embedding:** ~10-30s
 - **Total Indexing:** ~3-6 mins (highly dependent on LLM speed)
+
+---
+
+## Status vs. paper
+
+The table below tracks how each stage of the GraphRAG paper (arxiv 2404.16130) maps to what is on `main` today. Use it to gauge what to expect when comparing this implementation to the paper's results.
+
+| Pipeline stage | Status | Notes |
+|---|---|---|
+| Document chunking | In progress: token-based via `tiktoken-rs` (cl100k_base) | PR #126 - char-based hierarchical chunker on `main` today |
+| LLM entity extraction with gleaning | In progress: paper-aligned prompts and `max_gleanings = 1` default | PR #131 (also adds logit-bias / `LOOP` continuation) |
+| Hierarchical Leiden (super-graph contraction) | In progress: real multi-level | PR #128 - single-level Leiden on `main` today |
+| Element summaries (LLM collapse of duplicate descriptions) | Preview only: API exists; needs `Entity::description` wiring | PR #131 + Wave 3 A wiring |
+| Community reports (LLM-generated structured summaries) | Not yet implemented | Tracked in issue #95 (blocked on #94 / #97) |
+| Local Search (entity-anchored, token-budgeted context window) | In progress: `--mode local` retrieval mode | PR #130 |
+| Global Search (map-reduce over community reports + helpfulness scoring) | Not yet implemented | Tracked in issue #93 |
+
+**Default query mode** is `--mode hybrid` (this project's own LightRAG/PageRank-based blend), not the paper's mode. Once PR #130 merges, `--mode local` will provide the paper-aligned Local Search; Global Search remains future work (#93).
+
+**For benchmarking:** any comparison to the GraphRAG paper's reported numbers should account for the absent Global Search stage and (until the PRs above merge) the absent token-based chunking, hierarchical Leiden, paper-aligned gleaning defaults, and element-summary collapse.

--- a/graphrag-core/README.md
+++ b/graphrag-core/README.md
@@ -2,14 +2,16 @@
 
 The core library for GraphRAG-rs, providing portable functionality for both native and WASM deployments.
 
+> **Status vs. the GraphRAG paper.** This crate is *inspired by* Microsoft GraphRAG (arxiv 2404.16130) but does not yet implement every stage of the paper - notably Global Search and LLM-generated community reports. See the [Status vs. paper](../README.md#status-vs-paper) section in the root README for stage-by-stage status before benchmarking.
+
 ## Overview
 
 `graphrag-core` is the foundational library that powers GraphRAG-rs. It provides:
 
 - **Embedding Generation**: 8 provider backends (HuggingFace, OpenAI, Voyage AI, Cohere, Jina, Mistral, Together AI, Ollama)
-- **Entity Extraction**: TRUE LLM-based gleaning extraction with multi-round refinement (Microsoft GraphRAG-style)
-- **Graph Construction**: Incremental updates, PageRank, community detection
-- **Retrieval Strategies**: Vector, BM25, PageRank, hybrid, adaptive
+- **Entity Extraction**: LLM-based gleaning extraction with multi-round refinement (Microsoft GraphRAG-style prompts; paper-aligned `max_gleanings = 1` default arrives with PR #131)
+- **Graph Construction**: Incremental updates, PageRank, single-level Leiden community detection (multi-level hierarchical Leiden is in flight on PR #128)
+- **Retrieval Strategies**: Vector, BM25, PageRank, hybrid, adaptive (paper-aligned Local Search arrives with PR #130; Global Search is not yet implemented - issue #93)
 - **Configuration System**: Hierarchical TOML-based configuration with environment variable overrides
 - **Cross-Platform**: Works on native (Linux, macOS, Windows) and WASM
 


### PR DESCRIPTION
## Summary

Closes **#104** — README, HOW_IT_WORKS.md, and PIPELINE_ARCHITECTURE.md described the paper's pipeline as if it were the runtime behavior. Now they distinguish:

- ✅ on \`main\` today
- 🟡 in progress on PR #X
- ❌ not yet implemented (issue #Y)

## What changed

- New **\"Status vs. paper\" tables** in README and PIPELINE_ARCHITECTURE.md mapping each paper stage to its current state.
- **Reconciled defaults** — \`chunk_size\` 300→1000, \`max_gleaning_rounds\` 1→3, etc. (the docs were ahead of the code in some places, behind in others).
- **Toned down marketing**: lead paragraph softened from \"high-performance, modular Rust implementation of GraphRAG\" to \"inspired by Microsoft's GraphRAG paper... and adjacent work.\"
- **Benchmark caveat** explicitly states what's missing today vs. after-PRs-merge.

## Review fixes (codex + gemini, 5 findings)

- **docs: pin README status section to actual main CLI/chunker state** — codex P1 (conf 0.97) + P2 (conf 0.85) + P3 (conf 0.88).
  - Initial draft referenced \`--mode local\` / \`--mode global\` / \`--mode hybrid\` as if they were CLI flags. Verified against \`graphrag-cli/src/action.rs:11-19\` — the actual \`QueryMode\` is \`Ask | Explain | Reason\`. \`--mode local\` becomes available only after PR #130 merges. Reworded.
  - Initial draft said main uses a \"hierarchical char-based chunker.\" Verified ingestion path uses \`TextProcessor::chunk_text\` (legacy splitter), not \`chunk_text_hierarchical\`. Dropped \"hierarchical.\"
  - Benchmark caveat now distinguishes \"today (on main): hybrid only\" vs. \"after PR #130 merges: Local Search becomes paper-aligned.\"
- **docs: pin PIPELINE_ARCHITECTURE to actual main retrieval state** — codex P2 (conf 0.95) + gemini.
  - Resolved intra-doc contradiction: Phase 6 previously listed \`local\` and \`global\` as available strategies while the new Status table marked them as in-progress / not implemented. Split into \"Available on main today\" (Vector/Graph/Hybrid/Text) vs. \"Planned / in progress\" (Local/Global).
  - Added \`[!NOTE]\` documenting the \`chunk_size\` discrepancy: \`Config\` defaults to 1000, \`SetConfig\` (file-loaded) defaults to 512. Code-level fix flagged as follow-up.

## Test plan

Docs-only PR — no CI changes needed; existing checks still apply.

## Verified factual claims (all checked against \`main\`)

- \`graphrag-core/src/config/mod.rs:1295\`: \`default_chunk_size = 1000\`
- \`graphrag-core/src/config/setconfig.rs:1166\`: \`default_chunk_size = 512\` (discrepancy noted in docs)
- \`graphrag-core/src/config/mod.rs:1335\`: \`default_max_gleaning_rounds = 3\`
- \`graphrag-core/src/graph/leiden.rs\`: hierarchical_leiden runs single-level only on main
- No \`tiktoken-rs\` references on main (#126 in flight)
- No \`element_summary\` / \`community_report\` / \`global_search\` code paths on main
- \`graphrag-cli/src/action.rs\`: \`QueryMode\` exposes only \`Ask | Explain | Reason\`

## Remaining open items not addressed

- \`Config\` vs \`SetConfig\` chunk_size code-level inconsistency (1000 vs 512) — flagged as follow-up; should probably get its own issue
- Marketing claims in README's production/SDK section (\"+20% accuracy\", \"99% cost savings\") deliberately not touched — those are not paper-alignment claims and rewriting them is out of scope for this docs-honesty pass

Closes #104