### PR TITLE
chore(core): clean up dead_code allows and remove unused helpers

### DIFF
--- a/graphrag-core/src/async_graphrag.rs
+++ b/graphrag-core/src/async_graphrag.rs
@@ -62,7 +62,7 @@ impl LLMClient for AsyncLanguageModelAdapter {
 
 /// Async version of the main GraphRAG system
 pub struct AsyncGraphRAG {
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Retained for builder round-trip; pipeline wiring still in progress.
     config: Config,
     knowledge_graph: Arc<RwLock<Option<KnowledgeGraph>>>,
     document_trees: Arc<RwLock<HashMap<DocumentId, DocumentTree>>>,

--- a/graphrag-core/src/caching/distributed.rs
+++ b/graphrag-core/src/caching/distributed.rs
@@ -253,8 +253,8 @@ where
 {
     l1: L1Cache<K, V>,
     #[cfg(feature = "redis_storage")]
-    #[allow(dead_code)]
     l2: Option<L2Cache>,
+    // Placeholder so the struct layout matches across features; not read when redis_storage is off.
     #[cfg(not(feature = "redis_storage"))]
     #[allow(dead_code)]
     l2: Option<()>,

--- a/graphrag-core/src/config/loader.rs
+++ b/graphrag-core/src/config/loader.rs
@@ -106,8 +106,11 @@ fn load_yaml_config(_content: &str) -> Result<Config> {
 }
 
 /// Raw configuration structure that matches the TOML file
+// Many sub-structs map config keys we accept on disk but do not yet propagate
+// into `Config` via `convert_raw_config`. Keeping them keeps the schema honest
+// (unknown-field warnings stay accurate) while the wiring is filled in. (#27)
 #[derive(Debug, serde::Deserialize, Default)]
-#[allow(dead_code)]
+#[allow(dead_code)] // TODO(#27): wire remaining sections through convert_raw_config.
 struct RawConfig {
     #[serde(default)]
     system: SystemConfig,
@@ -150,7 +153,7 @@ struct RawConfig {
 }
 
 #[derive(Debug, serde::Deserialize, Default)]
-#[allow(dead_code)]
+#[allow(dead_code)] // TODO(#27): map into Config; preserved so deserialization stays lenient.
 struct SystemConfig {
     log_level: Option<String>,
     max_memory_mb: Option<u64>,
@@ -159,7 +162,7 @@ struct SystemConfig {
 }
 
 #[derive(Debug, serde::Deserialize, Default)]
-#[allow(dead_code)]
+#[allow(dead_code)] // TODO(#27): map into Config; preserved so deserialization stays lenient.
 struct FeaturesConfig {
     text_processing: Option<bool>,
     entity_extraction: Option<bool>,
@@ -171,7 +174,7 @@ struct FeaturesConfig {
 }
 
 #[derive(Debug, serde::Deserialize, Default)]
-#[allow(dead_code)]
+#[allow(dead_code)] // TODO(#27): map into Config; preserved so deserialization stays lenient.
 struct RawTextProcessingConfig {
     enabled: Option<bool>,
     chunk_size: Option<usize>,
@@ -187,7 +190,7 @@ struct RawTextProcessingConfig {
 }
 
 #[derive(Debug, serde::Deserialize, Default)]
-#[allow(dead_code)]
+#[allow(dead_code)] // TODO(#27): map into Config; preserved so deserialization stays lenient.
 struct RawEnrichmentConfig {
     enabled: Option<bool>,
     auto_detect_format: Option<bool>,
@@ -210,7 +213,7 @@ struct RawEnrichmentConfig {
 }
 
 #[derive(Debug, serde::Deserialize, Default)]
-#[allow(dead_code)]
+#[allow(dead_code)] // TODO(#27): map into Config; preserved so deserialization stays lenient.
 struct RawEntityExtractionConfig {
     enabled: Option<bool>,
     min_confidence: Option<f32>,

--- a/graphrag-core/src/core/traits.rs
+++ b/graphrag-core/src/core/traits.rs
@@ -1139,6 +1139,7 @@ impl AsyncTimer {
 pub struct Timer {
     /// Name of the operation being timed
     #[allow(dead_code)]
+    // Surfaced via Debug-style traces; kept for downstream MetricsCollector impls.
     name: String,
     /// Start time of the timer
     start: std::time::Instant,

--- a/graphrag-core/src/entity/gleaning_extractor.rs
+++ b/graphrag-core/src/entity/gleaning_extractor.rs
@@ -473,7 +473,7 @@ pub struct GleaningStatistics {
 
 impl GleaningStatistics {
     /// Print statistics to stdout
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Public diagnostic helper; called by downstream binaries and examples.
     pub fn print(&self) {
         tracing::info!("🔍 REAL LLM Gleaning Extraction Statistics");
         tracing::info!("  Max rounds: {}", self.config.max_gleaning_rounds);

--- a/graphrag-core/src/entity/mod.rs
+++ b/graphrag-core/src/entity/mod.rs
@@ -676,12 +676,6 @@ impl EntityExtractor {
         is_proper_format && (word.len() >= 3 || has_name_ending || has_name_prefix)
     }
 
-    /// Check if a word is a title
-    #[allow(dead_code)]
-    fn is_title(&self, word: &str) -> bool {
-        matches!(word, "Dr." | "Mr." | "Ms." | "Mrs." | "Prof.")
-    }
-
     /// Check if a name is likely a person name
     fn is_likely_person_name(&self, name: &str) -> bool {
         let parts: Vec<&str> = name.split_whitespace().collect();

--- a/graphrag-core/src/entity/semantic_merging.rs
+++ b/graphrag-core/src/entity/semantic_merging.rs
@@ -406,7 +406,7 @@ pub struct MergingStatistics {
 
 impl MergingStatistics {
     /// Print statistics to stdout
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Public diagnostic helper; called by downstream binaries and examples.
     pub fn print(&self) {
         tracing::info!("Entity Merging Statistics");
         tracing::info!("  Similarity threshold: {:.2}", self.similarity_threshold);

--- a/graphrag-core/src/graph/incremental.rs
+++ b/graphrag-core/src/graph/incremental.rs
@@ -1326,15 +1326,18 @@ impl IncrementalGraphManager {
 
 /// Incremental PageRank calculator for efficient updates
 #[cfg(feature = "incremental")]
-#[allow(dead_code)]
 pub struct IncrementalPageRank {
     scores: DashMap<EntityId, f64>,
-    adjacency_changes: DashMap<EntityId, Vec<(EntityId, f64)>>, // Node -> [(neighbor, weight)]
+    // Reserved for delta-PageRank propagation; not yet consumed by `update_incremental`.
+    #[allow(dead_code)]
+    adjacency_changes: DashMap<EntityId, Vec<(EntityId, f64)>>,
     damping_factor: f64,
     tolerance: f64,
     max_iterations: usize,
+    // Tracked for periodic full-recompute heuristics; reader is pending.
+    #[allow(dead_code)]
     last_full_computation: DateTime<Utc>,
-    incremental_threshold: usize, // Number of changes before full recomputation
+    incremental_threshold: usize,
     pending_changes: RwLock<usize>,
 }
 
@@ -1611,8 +1614,8 @@ pub struct BatchProcessor {
     metrics: RwLock<BatchMetrics>,
 }
 
+#[cfg(feature = "incremental")]
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 struct PendingBatch {
     changes: Vec<ChangeRecord>,
     created_at: Instant,
@@ -1843,7 +1846,6 @@ impl GraphRAGError {
 
 /// Production implementation of IncrementalGraphStore with full ACID guarantees
 #[cfg(feature = "incremental")]
-#[allow(dead_code)]
 pub struct ProductionGraphStore {
     graph: Arc<RwLock<KnowledgeGraph>>,
     transactions: DashMap<TransactionId, Transaction>,
@@ -1852,25 +1854,36 @@ pub struct ProductionGraphStore {
     conflict_resolver: Arc<ConflictResolver>,
     cache_invalidation: Arc<SelectiveInvalidation>,
     monitor: Arc<UpdateMonitor>,
+    // Held for batch-update wiring; current code path goes directly through `apply_change`.
+    #[allow(dead_code)]
     batch_processor: Arc<BatchProcessor>,
     incremental_pagerank: Arc<IncrementalPageRank>,
     event_publisher: broadcast::Sender<ChangeEvent>,
+    // Captured at construction for future runtime tuning hooks.
+    #[allow(dead_code)]
     config: IncrementalConfig,
 }
 
 /// Transaction state for ACID operations
+#[cfg(feature = "incremental")]
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 struct Transaction {
+    // Tx id is also the DashMap key; field is for debug/logging.
+    #[allow(dead_code)]
     id: TransactionId,
     changes: Vec<ChangeRecord>,
     status: TransactionStatus,
+    // Recorded for transaction-age metrics; reader pending.
+    #[allow(dead_code)]
     created_at: DateTime<Utc>,
+    // Reserved for per-transaction isolation policy enforcement.
+    #[allow(dead_code)]
     isolation_level: IsolationLevel,
 }
 
+#[cfg(feature = "incremental")]
 #[derive(Debug, Clone, PartialEq)]
-#[allow(dead_code)]
+#[allow(dead_code)] // Variants reserved for two-phase commit / abort flows; ABI-stable surface.
 enum TransactionStatus {
     Active,
     Preparing,
@@ -1878,8 +1891,9 @@ enum TransactionStatus {
     Aborted,
 }
 
+#[cfg(feature = "incremental")]
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
+#[allow(dead_code)] // Variants reserved for isolation-level configuration; ABI-stable surface.
 enum IsolationLevel {
     ReadUncommitted,
     ReadCommitted,
@@ -2546,7 +2560,7 @@ impl IncrementalGraphStore for ProductionGraphStore {
 }
 
 // Helper trait for extracting entity ID from ChangeData
-#[allow(dead_code)]
+#[allow(dead_code)] // Used only when feature = "incremental" is enabled.
 trait ChangeDataExt {
     fn get_entity_id(&self) -> Option<EntityId>;
 }

--- a/graphrag-core/src/graph/mod.rs
+++ b/graphrag-core/src/graph/mod.rs
@@ -363,7 +363,7 @@ pub struct GraphStatistics {
 
 impl GraphStatistics {
     /// Print graph statistics
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Public diagnostic helper; called by downstream binaries and examples.
     pub fn print(&self) {
         tracing::info!("Graph Statistics:");
         tracing::info!("  Documents: {}", self.document_count);

--- a/graphrag-core/src/incremental/mod.rs
+++ b/graphrag-core/src/incremental/mod.rs
@@ -433,7 +433,7 @@ struct ChangeDetector {
     /// Document hashes for change detection
     document_hashes: HashMap<String, String>,
     /// Entity version tracking
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Reserved for entity-level version tracking; reader pending.
     entity_versions: HashMap<String, u32>,
 }
 
@@ -665,26 +665,6 @@ impl IncrementalGraphManager {
     /// Get statistics about lazy propagation
     pub fn get_propagation_stats(&self) -> PropagationStats {
         self.lazy_propagation.propagation_stats()
-    }
-
-    /// Queue a node update for lazy propagation
-    ///
-    /// The update will be deferred until threshold is reached or force propagate is called.
-    #[allow(dead_code)]
-    fn queue_lazy_update(
-        &self,
-        node_id: String,
-        affected_relationships: Vec<String>,
-    ) -> Result<String> {
-        if !self.config.enable_lazy_propagation {
-            return Ok(String::new()); // Skip if disabled
-        }
-
-        self.lazy_propagation
-            .queue_node_update(node_id, affected_relationships)
-            .map_err(|e| GraphRAGError::IncrementalUpdate {
-                message: format!("Failed to queue lazy update: {}", e),
-            })
     }
 
     /// Create a snapshot of the current graph state
@@ -1146,12 +1126,14 @@ pub struct GraphStats {
 struct ExtractionResult {
     entities: Vec<ExtractedEntity>,
     relationships: Vec<ExtractedRelationship>,
+    // Concept extraction not yet wired through `apply_incremental_update`.
     #[allow(dead_code)]
     concepts: Vec<ExtractedConcept>,
 }
 
 struct ExtractedEntity {
     name: String,
+    // Reserved for typed-entity routing; current update path uses `name` only.
     #[allow(dead_code)]
     entity_type: String,
     attributes: HashMap<String, String>,
@@ -1160,12 +1142,13 @@ struct ExtractedEntity {
 struct ExtractedRelationship {
     source: String,
     target: String,
+    // Reserved for relationship-typed graph edges; reader pending.
     #[allow(dead_code)]
     relationship_type: String,
     confidence: f32,
 }
 
-#[allow(dead_code)]
+#[allow(dead_code)] // Stub type for upcoming concept extraction; fields shape the schema.
 struct ExtractedConcept {
     name: String,
     description: String,

--- a/graphrag-core/src/lib.rs
+++ b/graphrag-core/src/lib.rs
@@ -288,7 +288,7 @@ pub struct GraphRAG {
     query_planner: Option<query::planner::QueryPlanner>,
     critic: Option<critic::Critic>,
     #[cfg(feature = "parallel-processing")]
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Held for upcoming parallel-pipeline integration; reader pending.
     parallel_processor: Option<parallel::ParallelProcessor>,
     /// Optional override for chat-completion calls. When set, the built-in
     /// Ollama client is bypassed for the final answer-generation step in

--- a/graphrag-core/src/lightrag/graph_indexer.rs
+++ b/graphrag-core/src/lightrag/graph_indexer.rs
@@ -51,7 +51,7 @@ pub struct GraphIndexer {
     /// List of entity types to recognize during extraction
     entity_types: Vec<String>,
     /// Maximum depth for relationship traversal (reserved for future implementation)
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Reserved for future relationship-traversal depth limiting.
     max_depth: usize,
 }
 

--- a/graphrag-core/src/retrieval/mod.rs
+++ b/graphrag-core/src/retrieval/mod.rs
@@ -1906,7 +1906,7 @@ pub struct RetrievalStatistics {
 
 impl RetrievalStatistics {
     /// Print retrieval statistics
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Public diagnostic helper; called by downstream binaries and examples.
     pub fn print(&self) {
         tracing::info!("Retrieval System Statistics:");
         tracing::info!("  Indexed vectors: {}", self.indexed_vectors);

--- a/graphrag-core/src/rograg/processor.rs
+++ b/graphrag-core/src/rograg/processor.rs
@@ -106,7 +106,7 @@ pub struct RogragProcessorBuilder {
 #[cfg(feature = "rograg")]
 #[derive(Debug)]
 struct ProcessingContext {
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Captured for diagnostic logging; reader pending.
     query: String,
     start_time: Instant,
     decomposition_time: Option<Duration>,

--- a/graphrag-core/src/summarization/mod.rs
+++ b/graphrag-core/src/summarization/mod.rs
@@ -617,7 +617,7 @@ impl DocumentTree {
         Ok(result)
     }
 
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Used only when feature = "parallel-processing" is enabled.
     fn generate_parallel_summary(
         &self,
         text: &str,

--- a/graphrag-core/src/text/chunk_enricher.rs
+++ b/graphrag-core/src/text/chunk_enricher.rs
@@ -191,7 +191,7 @@ pub struct EnrichmentStatistics {
 
 impl EnrichmentStatistics {
     /// Print statistics summary
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Public diagnostic helper; called by downstream binaries and examples.
     pub fn print_summary(&self) {
         tracing::info!("\nChunk Enrichment Statistics:");
         tracing::info!("  Total chunks: {}", self.total_chunks);


### PR DESCRIPTION
## Summary

Closes **#27** — audited 34 \`#[allow(dead_code)]\` annotations + the two empty modules cited in the issue.

### Outcome

| Action | Count |
|--------|-------|
| Dead helpers deleted | 2 |
| Unnecessary \`allow\`s removed | ~4 (field IS used in feature-gated paths) |
| Struct-level \`allow\`s narrowed to per-field | several |
| \`allow\`s retained with \`// reason\` for self-documentation | 30 |

### Specifics

- **Deleted private helpers with zero call sites**: \`EntityExtractor::is_title\` and \`queue_lazy_update\` (verified safe — no reflection/serde/trait-object reachability).
- **Narrowed struct-level \`allow\`s** in \`graph/incremental.rs\` (\`PendingBatch\`, \`IncrementalPageRank\`, \`ProductionGraphStore\`, \`Transaction\`, \`TransactionStatus\`, \`IsolationLevel\`) — most fields are reachable through feature-gated paths, so the broad allow was hiding visibility into which fields are genuinely unused.
- **Annotated remaining allows with reasons** — diagnostic helpers (\`*::print\`/\`*::print_summary\` methods that consumers may use), feature-gated paths (\`#[cfg(feature = "incremental")]\`), and reserved-for-future-feature stubs (\`AsyncGraphRAG.config\`, \`GraphRAG.parallel_processor\`, \`ChangeDetector.entity_versions\`, \`ExtractionResult.concepts\`, etc.).

### MSRV note

Workspace \`rust-version = \"1.75\"\`, which predates \`#[expect(dead_code, reason = ...)]\` (1.81+). Used \`#[allow(dead_code)] // <reason>\` instead.

### Empty modules

\`graphrag-core/src/phase_saver.rs\` and \`graphrag-core/src/automatic_entity_linking.rs\` were already deleted on \`main\`. Nothing to do.

### Flagged for follow-up (NOT addressed here)

\`graphrag-core/src/config/loader.rs\` \`RawConfig\` and substructs accept many TOML keys that \`convert_raw_config\` silently drops — same silent-drop bug shape as the resolved #23. Marked with \`TODO(#27)\` so it surfaces in greps. Fixing would require wiring ~80 fields through to \`Config\` and is a feature project, not a cleanup pass.

## Test plan

- [x] \`cargo fmt --all\` clean
- [x] \`cargo build --workspace --exclude graphrag_py --exclude graphrag-wasm\` clean
- [x] \`cargo nextest run -p graphrag-core --lib\` — 407 passed, 12 skipped (no regressions)

## Review

- **Codex**: \"patch is correct\" — verified deletions are safe, narrowed allows still cover real dead code, feature-gating changes apply to private types only (no public API regression).
- **Gemini**: review didn't produce findings (the diff with TOML/bash-looking content tripped its tool parser).

## Note on conflicts

PR #127 (\`feat/group-g-incremental-split\`) is open and splits \`graphrag-core/src/graph/incremental.rs\` into a directory module. This PR's edits to \`incremental.rs\` will need a mechanical rebase if #127 lands first. The changes are attribute/comment edits plus 2 small deletions, so the resolution is straightforward.

Closes #27