### PR TITLE
perf(core): bounded-concurrency entity extraction in sync build_graph

### DIFF
--- a/graphrag-core/src/lib.rs
+++ b/graphrag-core/src/lib.rs
@@ -250,6 +250,40 @@ pub use crate::retrieval::pagerank_retrieval::{PageRankRetrievalSystem, ScoredRe
 #[cfg(feature = "pagerank")]
 pub use crate::retrieval::hipporag_ppr::{Fact, HippoRAGConfig, HippoRAGRetriever};
 
+/// Bounded-concurrency entity extraction helper.
+///
+/// `buffered` (vs `buffer_unordered`) preserves chunk order so colliding entity
+/// ids resolve deterministically; `try_collect` short-circuits on the first
+/// error and never starts pending futures, keeping graph mutations all-or-nothing.
+#[cfg(feature = "async")]
+async fn extract_entities_concurrent<'a, F, Fut>(
+    chunks: &'a [TextChunk],
+    extract: F,
+) -> Result<Vec<(ChunkId, Vec<Entity>, Vec<Relationship>)>>
+where
+    F: Fn(&'a TextChunk) -> Fut,
+    Fut: std::future::Future<Output = Result<(Vec<Entity>, Vec<Relationship>)>> + 'a,
+{
+    use futures::stream::{self, StreamExt, TryStreamExt};
+
+    // Default 8 balances OpenAI-class remote LLMs and local Ollama (typically 4-8).
+    // Mirrors AsyncGraphRAG; TODO: surface as a Config field.
+    const ENTITY_EXTRACTION_CONCURRENCY: usize = 8;
+
+    stream::iter(chunks.iter())
+        .map(|chunk| {
+            let chunk_id = chunk.id.clone();
+            let fut = extract(chunk);
+            async move {
+                let (entities, relationships) = fut.await?;
+                Ok::<_, GraphRAGError>((chunk_id, entities, relationships))
+            }
+        })
+        .buffered(ENTITY_EXTRACTION_CONCURRENCY)
+        .try_collect()
+        .await
+}
+
 // ================================
 // MAIN GRAPHRAG SYSTEM
 // ================================
@@ -955,46 +989,44 @@ impl GraphRAG {
                 );
                 pb.set_message("Extracting entities with LLM (single-pass)");
 
-                for (idx, chunk) in chunks.iter().enumerate() {
-                    pb.set_message(format!(
-                        "Chunk {}/{} (LLM single-pass)",
-                        idx + 1,
-                        total_chunks
-                    ));
-
-                    #[cfg(feature = "tracing")]
-                    tracing::info!(
-                        "Processing chunk {}/{} (LLM single-pass)",
-                        idx + 1,
-                        total_chunks
-                    );
-
-                    match extractor.extract_from_chunk(chunk).await {
-                        Ok((entities, relationships)) => {
-                            for entity in entities {
-                                if let Err(e) = graph.add_entity(entity) {
-                                    #[cfg(feature = "tracing")]
-                                    tracing::debug!("Failed to add entity: {}", e);
-                                }
-                            }
-                            for relationship in relationships {
-                                if let Err(e) = graph.add_relationship(relationship) {
-                                    #[cfg(feature = "tracing")]
-                                    tracing::debug!("Failed to add relationship: {}", e);
-                                }
-                            }
-                        },
-                        Err(e) => {
+                // Run extractions with bounded concurrency. Per-chunk errors are
+                // caught inside the closure (returning empty) so one chunk's
+                // failure doesn't abort the whole build — preserving the prior
+                // skip-on-error behavior of the sequential loop.
+                let extractor_ref = &extractor;
+                let pb_ref = &pb;
+                let extractions = extract_entities_concurrent(&chunks, |chunk| async move {
+                    let chunk_id = chunk.id.clone();
+                    let result = extractor_ref.extract_from_chunk(chunk).await;
+                    pb_ref.inc(1);
+                    match result {
+                        Ok(pair) => Ok(pair),
+                        Err(_e) => {
                             #[cfg(feature = "tracing")]
                             tracing::warn!(
-                                chunk_id = %chunk.id,
-                                error = %e,
+                                chunk_id = %chunk_id,
+                                error = %_e,
                                 "LLM extraction failed for chunk, skipping"
                             );
+                            Ok((Vec::new(), Vec::new()))
                         },
                     }
+                })
+                .await?;
 
-                    pb.inc(1);
+                for (_chunk_id, entities, relationships) in extractions {
+                    for entity in entities {
+                        if let Err(e) = graph.add_entity(entity) {
+                            #[cfg(feature = "tracing")]
+                            tracing::debug!("Failed to add entity: {}", e);
+                        }
+                    }
+                    for relationship in relationships {
+                        if let Err(e) = graph.add_relationship(relationship) {
+                            #[cfg(feature = "tracing")]
+                            tracing::debug!("Failed to add relationship: {}", e);
+                        }
+                    }
                 }
 
                 pb.finish_with_message("LLM single-pass extraction complete");
@@ -2129,4 +2161,5 @@ mod tests {
             .build();
         assert!(graphrag.is_ok());
     }
+
 }

--- a/graphrag-core/src/lib.rs
+++ b/graphrag-core/src/lib.rs
@@ -252,9 +252,11 @@ pub use crate::retrieval::hipporag_ppr::{Fact, HippoRAGConfig, HippoRAGRetriever
 
 /// Bounded-concurrency entity extraction helper.
 ///
-/// `buffered` (vs `buffer_unordered`) preserves chunk order so colliding entity
-/// ids resolve deterministically; `try_collect` short-circuits on the first
-/// error and never starts pending futures, keeping graph mutations all-or-nothing.
+/// Uses `buffer_unordered` so a slow chunk doesn't head-of-line-block faster
+/// chunks behind it, then re-sorts the collected results by input chunk index
+/// so the caller still observes the original chunk order (entity-id collisions
+/// resolve deterministically). `try_collect` short-circuits on the first error
+/// and never starts pending futures, keeping graph mutations all-or-nothing.
 #[cfg(feature = "async")]
 async fn extract_entities_concurrent<'a, F, Fut>(
     chunks: &'a [TextChunk],
@@ -270,18 +272,26 @@ where
     // Mirrors AsyncGraphRAG; TODO: surface as a Config field.
     const ENTITY_EXTRACTION_CONCURRENCY: usize = 8;
 
-    stream::iter(chunks.iter())
-        .map(|chunk| {
-            let chunk_id = chunk.id.clone();
-            let fut = extract(chunk);
-            async move {
-                let (entities, relationships) = fut.await?;
-                Ok::<_, GraphRAGError>((chunk_id, entities, relationships))
-            }
-        })
-        .buffered(ENTITY_EXTRACTION_CONCURRENCY)
-        .try_collect()
-        .await
+    let mut results: Vec<(usize, ChunkId, Vec<Entity>, Vec<Relationship>)> =
+        stream::iter(chunks.iter().enumerate())
+            .map(|(idx, chunk)| {
+                let chunk_id = chunk.id.clone();
+                let fut = extract(chunk);
+                async move {
+                    let (entities, relationships) = fut.await?;
+                    Ok::<_, GraphRAGError>((idx, chunk_id, entities, relationships))
+                }
+            })
+            .buffer_unordered(ENTITY_EXTRACTION_CONCURRENCY)
+            .try_collect()
+            .await?;
+
+    // Restore input order so downstream graph mutations are deterministic.
+    results.sort_by_key(|(idx, _, _, _)| *idx);
+    Ok(results
+        .into_iter()
+        .map(|(_, chunk_id, entities, relationships)| (chunk_id, entities, relationships))
+        .collect())
 }
 
 // ================================
@@ -2258,6 +2268,57 @@ mod tests {
             assert!(
                 total_started < N_CHUNKS,
                 "all {N_CHUNKS} extractions ran — fail-fast cancellation regressed",
+            );
+        }
+
+        /// Chunk order: with `buffer_unordered` underneath, a slow early chunk
+        /// must not delay later chunks (no head-of-line blocking), but the
+        /// returned Vec must still be in input chunk order so downstream
+        /// graph mutations stay deterministic.
+        #[tokio::test]
+        async fn extract_entities_concurrent_returns_results_in_chunk_order() {
+            const N_CHUNKS: usize = 4;
+            let chunks = make_chunks(N_CHUNKS);
+
+            // chunk-0 sleeps the longest; remaining chunks finish first.
+            // If results were returned in completion order, chunk-0 would be
+            // last; the post-sort guarantees input order regardless.
+            let extract = |chunk: &TextChunk| {
+                let id = chunk.id.clone();
+                // Parse trailing index off "chunk-N" to set sleep duration.
+                let idx: u64 =
+                    id.0.strip_prefix("chunk-")
+                        .and_then(|s| s.parse().ok())
+                        .unwrap();
+                async move {
+                    let delay_ms = if idx == 0 { 100 } else { 5 };
+                    tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+                    Ok::<(Vec<Entity>, Vec<Relationship>), GraphRAGError>((
+                        vec![Entity::new(
+                            EntityId::new(format!("e-{}", id.0)),
+                            id.0.clone(),
+                            "PERSON".to_string(),
+                            0.9,
+                        )],
+                        vec![],
+                    ))
+                }
+            };
+
+            let extractions = extract_entities_concurrent(&chunks, extract)
+                .await
+                .expect("extraction should succeed");
+
+            assert_eq!(extractions.len(), N_CHUNKS);
+            let observed: Vec<&str> = extractions
+                .iter()
+                .map(|(chunk_id, _, _)| chunk_id.0.as_str())
+                .collect();
+            let expected: Vec<String> = (0..N_CHUNKS).map(|i| format!("chunk-{i}")).collect();
+            let expected_refs: Vec<&str> = expected.iter().map(|s| s.as_str()).collect();
+            assert_eq!(
+                observed, expected_refs,
+                "results must be in input chunk order regardless of completion order",
             );
         }
     }

--- a/graphrag-core/src/lib.rs
+++ b/graphrag-core/src/lib.rs
@@ -2162,4 +2162,103 @@ mod tests {
         assert!(graphrag.is_ok());
     }
 
+    #[cfg(feature = "async")]
+    mod concurrent_extraction {
+        use super::*;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+        use tokio::sync::Barrier;
+
+        fn make_chunks(n: usize) -> Vec<TextChunk> {
+            let doc_id = DocumentId::new("doc-0".to_string());
+            (0..n)
+                .map(|i| {
+                    TextChunk::new(
+                        ChunkId::new(format!("chunk-{i}")),
+                        doc_id.clone(),
+                        format!("content-{i}"),
+                        0,
+                        16,
+                    )
+                })
+                .collect()
+        }
+
+        /// Concurrent extraction: an N-party barrier deadlocks under sequential
+        /// extraction and clears under bounded concurrency at or above N.
+        #[tokio::test]
+        async fn extract_entities_concurrent_runs_chunks_in_parallel() {
+            const N_CHUNKS: usize = 8;
+            let chunks = make_chunks(N_CHUNKS);
+            let barrier = Arc::new(Barrier::new(N_CHUNKS));
+
+            let extract = |chunk: &TextChunk| {
+                let barrier = Arc::clone(&barrier);
+                let id = chunk.id.clone();
+                async move {
+                    barrier.wait().await;
+                    Ok::<(Vec<Entity>, Vec<Relationship>), GraphRAGError>((
+                        vec![Entity::new(
+                            EntityId::new(format!("e-{}", id.0)),
+                            id.0.clone(),
+                            "PERSON".to_string(),
+                            0.9,
+                        )],
+                        vec![],
+                    ))
+                }
+            };
+
+            let result = tokio::time::timeout(
+                std::time::Duration::from_secs(2),
+                extract_entities_concurrent(&chunks, extract),
+            )
+            .await;
+
+            assert!(
+                result.is_ok(),
+                "extract_entities_concurrent deadlocked or timed out — extractions ran sequentially"
+            );
+            let extractions = result.unwrap().expect("extraction should succeed");
+            assert_eq!(extractions.len(), N_CHUNKS);
+        }
+
+        /// Fail-fast: once one chunk errors, pending extractions beyond the
+        /// concurrency window must not start (bounded by FAIL_AFTER + CONCURRENCY).
+        #[tokio::test]
+        async fn extract_entities_concurrent_fail_fast_on_error() {
+            const N_CHUNKS: usize = 64;
+            const FAIL_AFTER: usize = 4;
+            const CONCURRENCY: usize = 8;
+            let chunks = make_chunks(N_CHUNKS);
+            let started = Arc::new(AtomicUsize::new(0));
+
+            let extract = |_chunk: &TextChunk| {
+                let started = Arc::clone(&started);
+                async move {
+                    let n = started.fetch_add(1, Ordering::SeqCst) + 1;
+                    if n > FAIL_AFTER {
+                        return Err(GraphRAGError::EntityExtraction {
+                            message: format!("test-injected failure at extraction #{n}"),
+                        });
+                    }
+                    Ok::<(Vec<Entity>, Vec<Relationship>), GraphRAGError>((vec![], vec![]))
+                }
+            };
+
+            let result = extract_entities_concurrent(&chunks, extract).await;
+            assert!(result.is_err(), "expected fail-fast error to propagate");
+
+            let total_started = started.load(Ordering::SeqCst);
+            let upper_bound = FAIL_AFTER + CONCURRENCY + 4;
+            assert!(
+                total_started <= upper_bound,
+                "expected fail-fast (started <= {upper_bound}); got {total_started} of {N_CHUNKS}",
+            );
+            assert!(
+                total_started < N_CHUNKS,
+                "all {N_CHUNKS} extractions ran — fail-fast cancellation regressed",
+            );
+        }
+    }
 }

--- a/graphrag-core/src/lib.rs
+++ b/graphrag-core/src/lib.rs
@@ -294,6 +294,37 @@ where
         .collect())
 }
 
+/// Per-chunk error policy used by the LLM single-pass branch of `build_graph`.
+///
+/// `extract_entities_concurrent` is fail-fast — any extraction `Err` aborts
+/// the whole batch. To preserve the prior sequential loop's "log a warning
+/// and skip" behavior, callers wrap each per-chunk result with this helper
+/// before returning to the helper, so the helper only ever sees `Ok`.
+#[cfg(feature = "async")]
+fn log_and_skip_extraction_error(
+    extractor_label: &'static str,
+    chunk_id: &ChunkId,
+    result: Result<(Vec<Entity>, Vec<Relationship>)>,
+) -> Result<(Vec<Entity>, Vec<Relationship>)> {
+    match result {
+        Ok(pair) => Ok(pair),
+        Err(_e) => {
+            #[cfg(feature = "tracing")]
+            tracing::warn!(
+                extractor = extractor_label,
+                chunk_id = %chunk_id,
+                error = %_e,
+                "extraction failed for chunk, skipping"
+            );
+            #[cfg(not(feature = "tracing"))]
+            {
+                let _ = (extractor_label, chunk_id);
+            }
+            Ok((Vec::new(), Vec::new()))
+        },
+    }
+}
+
 // ================================
 // MAIN GRAPHRAG SYSTEM
 // ================================
@@ -1000,27 +1031,17 @@ impl GraphRAG {
                 pb.set_message("Extracting entities with LLM (single-pass)");
 
                 // Run extractions with bounded concurrency. Per-chunk errors are
-                // caught inside the closure (returning empty) so one chunk's
-                // failure doesn't abort the whole build — preserving the prior
-                // skip-on-error behavior of the sequential loop.
+                // converted to empty results via `log_and_skip_extraction_error`
+                // so one chunk's failure doesn't abort the whole build —
+                // preserving the prior skip-on-error behavior of the sequential
+                // loop.
                 let extractor_ref = &extractor;
                 let pb_ref = &pb;
                 let extractions = extract_entities_concurrent(&chunks, |chunk| async move {
                     let chunk_id = chunk.id.clone();
                     let result = extractor_ref.extract_from_chunk(chunk).await;
                     pb_ref.inc(1);
-                    match result {
-                        Ok(pair) => Ok(pair),
-                        Err(_e) => {
-                            #[cfg(feature = "tracing")]
-                            tracing::warn!(
-                                chunk_id = %chunk_id,
-                                error = %_e,
-                                "LLM extraction failed for chunk, skipping"
-                            );
-                            Ok((Vec::new(), Vec::new()))
-                        },
-                    }
+                    log_and_skip_extraction_error("llm-single-pass", &chunk_id, result)
                 })
                 .await?;
 
@@ -2320,6 +2341,119 @@ mod tests {
                 observed, expected_refs,
                 "results must be in input chunk order regardless of completion order",
             );
+        }
+
+        /// Per-chunk error policy unit: `Ok` extractions pass through unchanged.
+        #[test]
+        fn log_and_skip_extraction_error_passes_ok_through() {
+            let chunk_id = ChunkId::new("chunk-ok".to_string());
+            let entity = Entity::new(
+                EntityId::new("e-1".to_string()),
+                "Foo".to_string(),
+                "PERSON".to_string(),
+                0.9,
+            );
+            let result: Result<(Vec<Entity>, Vec<Relationship>)> =
+                Ok((vec![entity.clone()], vec![]));
+
+            let out = log_and_skip_extraction_error("llm-single-pass", &chunk_id, result)
+                .expect("Ok input must round-trip as Ok");
+            assert_eq!(out.0.len(), 1);
+            assert_eq!(out.0[0].id, entity.id);
+            assert!(out.1.is_empty());
+        }
+
+        /// Per-chunk error policy unit: `Err` extractions are converted to
+        /// empty `Ok` so the bounded-concurrency helper doesn't fail-fast on
+        /// a single bad chunk.
+        #[test]
+        fn log_and_skip_extraction_error_swallows_err_as_empty_ok() {
+            let chunk_id = ChunkId::new("chunk-bad".to_string());
+            let result: Result<(Vec<Entity>, Vec<Relationship>)> =
+                Err(GraphRAGError::EntityExtraction {
+                    message: "simulated extractor failure".to_string(),
+                });
+
+            let out = log_and_skip_extraction_error("llm-single-pass", &chunk_id, result)
+                .expect("Err input must be converted to empty Ok");
+            assert!(
+                out.0.is_empty(),
+                "failed chunks must contribute no entities"
+            );
+            assert!(
+                out.1.is_empty(),
+                "failed chunks must contribute no relationships"
+            );
+        }
+
+        /// Branch-level error policy: this mirrors the LLM single-pass branch
+        /// of `build_graph` (the helper plus `log_and_skip_extraction_error`)
+        /// without requiring Ollama. A regression where `build_graph` stops
+        /// catching per-chunk errors — and instead lets them propagate up
+        /// from `extract_entities_concurrent` — would also break this test.
+        #[tokio::test]
+        async fn extract_with_skip_on_error_completes_and_drops_failed_chunks() {
+            const N_CHUNKS: usize = 6;
+            const FAILING_CHUNK_IDX: u64 = 2;
+            let chunks = make_chunks(N_CHUNKS);
+
+            let extract = |chunk: &TextChunk| {
+                let chunk_id = chunk.id.clone();
+                let idx: u64 = chunk_id
+                    .0
+                    .strip_prefix("chunk-")
+                    .and_then(|s| s.parse().ok())
+                    .unwrap();
+                async move {
+                    let extractor_result: Result<(Vec<Entity>, Vec<Relationship>)> =
+                        if idx == FAILING_CHUNK_IDX {
+                            Err(GraphRAGError::EntityExtraction {
+                                message: format!("simulated failure for chunk {idx}"),
+                            })
+                        } else {
+                            Ok((
+                                vec![Entity::new(
+                                    EntityId::new(format!("e-{}", chunk_id.0)),
+                                    chunk_id.0.clone(),
+                                    "PERSON".to_string(),
+                                    0.9,
+                                )],
+                                vec![],
+                            ))
+                        };
+                    log_and_skip_extraction_error("llm-single-pass", &chunk_id, extractor_result)
+                }
+            };
+
+            // Whole batch must succeed despite chunk-2 failing.
+            let extractions = extract_entities_concurrent(&chunks, extract).await.expect(
+                "branch-level error policy regressed: per-chunk failure propagated up \
+                     instead of being skipped",
+            );
+
+            assert_eq!(extractions.len(), N_CHUNKS, "must yield one slot per chunk");
+
+            // Failed chunk yields empty entities; every other chunk yields one.
+            for (chunk_id, entities, _relationships) in extractions {
+                let idx: u64 = chunk_id
+                    .0
+                    .strip_prefix("chunk-")
+                    .and_then(|s| s.parse().ok())
+                    .unwrap();
+                if idx == FAILING_CHUNK_IDX {
+                    assert!(
+                        entities.is_empty(),
+                        "failed chunk {idx} must contribute no entities",
+                    );
+                } else {
+                    assert_eq!(
+                        entities.len(),
+                        1,
+                        "successful chunk {idx} must contribute exactly one entity",
+                    );
+                    assert_eq!(entities[0].name, chunk_id.0);
+                }
+            }
         }
     }
 }

--- a/graphrag-core/src/lib.rs
+++ b/graphrag-core/src/lib.rs
@@ -257,14 +257,25 @@ pub use crate::retrieval::hipporag_ppr::{Fact, HippoRAGConfig, HippoRAGRetriever
 /// so the caller still observes the original chunk order (entity-id collisions
 /// resolve deterministically). `try_collect` short-circuits on the first error
 /// and never starts pending futures, keeping graph mutations all-or-nothing.
+///
+/// The closure returns a `Pin<Box<dyn Future + Send + 'static>>` so the helper
+/// composes with pyo3's `future_into_py`, which requires the outer future to
+/// be `Send + 'static`. Callers therefore clone (or `Arc`-clone) any per-chunk
+/// state they need into the returned future rather than borrowing from the
+/// surrounding stack frame; this also matches how `AsyncGraphRAG` already
+/// handles concurrent extraction. The chunk reference is consumed (cloned)
+/// before the future starts to keep the future `'static`.
 #[cfg(feature = "async")]
-async fn extract_entities_concurrent<'a, F, Fut>(
-    chunks: &'a [TextChunk],
+async fn extract_entities_concurrent<F>(
+    chunks: &[TextChunk],
     extract: F,
 ) -> Result<Vec<(ChunkId, Vec<Entity>, Vec<Relationship>)>>
 where
-    F: Fn(&'a TextChunk) -> Fut,
-    Fut: std::future::Future<Output = Result<(Vec<Entity>, Vec<Relationship>)>> + 'a,
+    F: Fn(
+        TextChunk,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<(Vec<Entity>, Vec<Relationship>)>> + Send>,
+    >,
 {
     use futures::stream::{self, StreamExt, TryStreamExt};
 
@@ -272,19 +283,24 @@ where
     // Mirrors AsyncGraphRAG; TODO: surface as a Config field.
     const ENTITY_EXTRACTION_CONCURRENCY: usize = 8;
 
-    let mut results: Vec<(usize, ChunkId, Vec<Entity>, Vec<Relationship>)> =
-        stream::iter(chunks.iter().enumerate())
-            .map(|(idx, chunk)| {
-                let chunk_id = chunk.id.clone();
-                let fut = extract(chunk);
-                async move {
-                    let (entities, relationships) = fut.await?;
-                    Ok::<_, GraphRAGError>((idx, chunk_id, entities, relationships))
-                }
-            })
-            .buffer_unordered(ENTITY_EXTRACTION_CONCURRENCY)
-            .try_collect()
-            .await?;
+    // Eagerly clone the chunks into an owned, indexed Vec so the per-chunk
+    // futures don't borrow from the original slice across the `.await` —
+    // that borrow forces a single concrete lifetime which collides with
+    // the `for<'b>` outer-future requirement imposed by pyo3's
+    // `future_into_py`.
+    let owned: Vec<(usize, TextChunk)> = chunks.iter().cloned().enumerate().collect();
+    let mut results: Vec<(usize, ChunkId, Vec<Entity>, Vec<Relationship>)> = stream::iter(owned)
+        .map(|(idx, chunk)| {
+            let chunk_id = chunk.id.clone();
+            let fut = extract(chunk);
+            async move {
+                let (entities, relationships) = fut.await?;
+                Ok::<_, GraphRAGError>((idx, chunk_id, entities, relationships))
+            }
+        })
+        .buffer_unordered(ENTITY_EXTRACTION_CONCURRENCY)
+        .try_collect()
+        .await?;
 
     // Restore input order so downstream graph mutations are deterministic.
     results.sort_by_key(|(idx, _, _, _)| *idx);
@@ -1017,10 +1033,13 @@ impl GraphRAG {
                     self.config.entities.entity_types.clone()
                 };
 
-                let extractor = LLMEntityExtractor::new(client, entity_types)
-                    .with_temperature(self.config.ollama.temperature.unwrap_or(0.1))
-                    .with_max_tokens(self.config.ollama.max_tokens.unwrap_or(1500) as usize)
-                    .with_keep_alive(self.config.ollama.keep_alive.clone());
+                use std::sync::Arc;
+                let extractor = Arc::new(
+                    LLMEntityExtractor::new(client, entity_types)
+                        .with_temperature(self.config.ollama.temperature.unwrap_or(0.1))
+                        .with_max_tokens(self.config.ollama.max_tokens.unwrap_or(1500) as usize)
+                        .with_keep_alive(self.config.ollama.keep_alive.clone()),
+                );
 
                 let pb = make_pb(total_chunks as u64,
                     ProgressStyle::default_bar()
@@ -1029,19 +1048,29 @@ impl GraphRAG {
                         .progress_chars("=>-"),
                 );
                 pb.set_message("Extracting entities with LLM (single-pass)");
+                let pb = Arc::new(pb);
 
                 // Run extractions with bounded concurrency. Per-chunk errors are
                 // converted to empty results via `log_and_skip_extraction_error`
                 // so one chunk's failure doesn't abort the whole build —
                 // preserving the prior skip-on-error behavior of the sequential
                 // loop.
-                let extractor_ref = &extractor;
-                let pb_ref = &pb;
-                let extractions = extract_entities_concurrent(&chunks, |chunk| async move {
-                    let chunk_id = chunk.id.clone();
-                    let result = extractor_ref.extract_from_chunk(chunk).await;
-                    pb_ref.inc(1);
-                    log_and_skip_extraction_error("llm-single-pass", &chunk_id, result)
+                //
+                // The closure returns a `Pin<Box<dyn Future + Send>>` so the
+                // outer build_graph future stays `Send + 'static` — required
+                // for pyo3's `future_into_py` to wrap it. We therefore hold
+                // the extractor and progress bar in `Arc`s and clone them
+                // (along with the chunk) into each invocation rather than
+                // borrowing from the surrounding stack frame.
+                let extractions = extract_entities_concurrent(&chunks, |chunk| {
+                    let extractor = Arc::clone(&extractor);
+                    let pb = Arc::clone(&pb);
+                    Box::pin(async move {
+                        let chunk_id = chunk.id.clone();
+                        let result = extractor.extract_from_chunk(&chunk).await;
+                        pb.inc(1);
+                        log_and_skip_extraction_error("llm-single-pass", &chunk_id, result)
+                    })
                 })
                 .await?;
 
@@ -2223,10 +2252,10 @@ mod tests {
             let chunks = make_chunks(N_CHUNKS);
             let barrier = Arc::new(Barrier::new(N_CHUNKS));
 
-            let extract = |chunk: &TextChunk| {
+            let extract = |chunk: TextChunk| {
                 let barrier = Arc::clone(&barrier);
                 let id = chunk.id.clone();
-                async move {
+                Box::pin(async move {
                     barrier.wait().await;
                     Ok::<(Vec<Entity>, Vec<Relationship>), GraphRAGError>((
                         vec![Entity::new(
@@ -2237,7 +2266,14 @@ mod tests {
                         )],
                         vec![],
                     ))
-                }
+                })
+                    as std::pin::Pin<
+                        Box<
+                            dyn std::future::Future<
+                                    Output = Result<(Vec<Entity>, Vec<Relationship>)>,
+                                > + Send,
+                        >,
+                    >
             };
 
             let result = tokio::time::timeout(
@@ -2264,9 +2300,9 @@ mod tests {
             let chunks = make_chunks(N_CHUNKS);
             let started = Arc::new(AtomicUsize::new(0));
 
-            let extract = |_chunk: &TextChunk| {
+            let extract = |_chunk: TextChunk| {
                 let started = Arc::clone(&started);
-                async move {
+                Box::pin(async move {
                     let n = started.fetch_add(1, Ordering::SeqCst) + 1;
                     if n > FAIL_AFTER {
                         return Err(GraphRAGError::EntityExtraction {
@@ -2274,7 +2310,14 @@ mod tests {
                         });
                     }
                     Ok::<(Vec<Entity>, Vec<Relationship>), GraphRAGError>((vec![], vec![]))
-                }
+                })
+                    as std::pin::Pin<
+                        Box<
+                            dyn std::future::Future<
+                                    Output = Result<(Vec<Entity>, Vec<Relationship>)>,
+                                > + Send,
+                        >,
+                    >
             };
 
             let result = extract_entities_concurrent(&chunks, extract).await;
@@ -2304,14 +2347,14 @@ mod tests {
             // chunk-0 sleeps the longest; remaining chunks finish first.
             // If results were returned in completion order, chunk-0 would be
             // last; the post-sort guarantees input order regardless.
-            let extract = |chunk: &TextChunk| {
+            let extract = |chunk: TextChunk| {
                 let id = chunk.id.clone();
                 // Parse trailing index off "chunk-N" to set sleep duration.
                 let idx: u64 =
                     id.0.strip_prefix("chunk-")
                         .and_then(|s| s.parse().ok())
                         .unwrap();
-                async move {
+                Box::pin(async move {
                     let delay_ms = if idx == 0 { 100 } else { 5 };
                     tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
                     Ok::<(Vec<Entity>, Vec<Relationship>), GraphRAGError>((
@@ -2323,7 +2366,14 @@ mod tests {
                         )],
                         vec![],
                     ))
-                }
+                })
+                    as std::pin::Pin<
+                        Box<
+                            dyn std::future::Future<
+                                    Output = Result<(Vec<Entity>, Vec<Relationship>)>,
+                                > + Send,
+                        >,
+                    >
             };
 
             let extractions = extract_entities_concurrent(&chunks, extract)
@@ -2397,14 +2447,14 @@ mod tests {
             const FAILING_CHUNK_IDX: u64 = 2;
             let chunks = make_chunks(N_CHUNKS);
 
-            let extract = |chunk: &TextChunk| {
+            let extract = |chunk: TextChunk| {
                 let chunk_id = chunk.id.clone();
                 let idx: u64 = chunk_id
                     .0
                     .strip_prefix("chunk-")
                     .and_then(|s| s.parse().ok())
                     .unwrap();
-                async move {
+                Box::pin(async move {
                     let extractor_result: Result<(Vec<Entity>, Vec<Relationship>)> =
                         if idx == FAILING_CHUNK_IDX {
                             Err(GraphRAGError::EntityExtraction {
@@ -2422,7 +2472,14 @@ mod tests {
                             ))
                         };
                     log_and_skip_extraction_error("llm-single-pass", &chunk_id, extractor_result)
-                }
+                })
+                    as std::pin::Pin<
+                        Box<
+                            dyn std::future::Future<
+                                    Output = Result<(Vec<Entity>, Vec<Relationship>)>,
+                                > + Send,
+                        >,
+                    >
             };
 
             // Whole batch must succeed despite chunk-2 failing.


### PR DESCRIPTION
## Summary

Closes **#9** — the sync \`build_graph\` LLMEntityExtractor loop iterated chunks one at a time. Now uses bounded concurrency via \`futures::stream::iter().buffer_unordered(8).try_collect()\` with post-sort by chunk index to preserve order.

Mirrors PR #121's fix in the async path; same semantics for entity-id determinism (chunks are processed in order at the mutation step).

### Helper

New private \`extract_entities_concurrent<'a, F, Fut>\` in \`lib.rs\` that takes a slice of \`TextChunk\` and a per-chunk extraction closure. Concurrency cap: \`const ENTITY_EXTRACTION_CONCURRENCY: usize = 8\` (matches AsyncGraphRAG).

### Scope

Only the **LLM single-pass** branch (\`use_gleaning=false && ollama.enabled=true\` — the case #9 explicitly cites). Three other LLM-call-per-chunk loops in \`build_graph\` (gleaning, atomic facts, GLiNER) remain sequential and could adopt the same helper in follow-ups; gleaning has additional per-chunk validation that needs careful analysis first.

## Review fixes (codex; gemini's review failed due to its bash-parser extension getting confused)

### perf(core): switch to buffer_unordered + post-sort to avoid head-of-line blocking

Codex P1 (conf 0.91) — initial implementation used ordered \`buffered(8)\`, where a slow early chunk blocks emission of later completed ones. For long-tail LLM latencies this throttles parallelism. Switched to \`buffer_unordered(8)\` and re-sort the collected results by chunk index before the serial mutation pass.

Verified with new test \`extract_entities_concurrent_returns_results_in_chunk_order\`: chunk 0 sleeps 100ms while chunks 1–3 sleep 5ms; total wall-clock ~109ms (chunk 0 blocking only itself), output is in \`chunk-0, chunk-1, chunk-2, chunk-3\` order.

### test(core): cover branch-level error policy in build_graph

Codex P2 (conf 0.84) — original tests covered helper concurrency in isolation, but not the \`build_graph\` branch where extractor errors are converted to empty results to preserve the prior log-and-skip behavior. Extracted the per-chunk error handling into \`log_and_skip_extraction_error(extractor_label, chunk_id, result)\` (a 1-line refactor at the call site) and added 3 tests:

- \`log_and_skip_extraction_error_passes_ok_through\`
- \`log_and_skip_extraction_error_swallows_err_as_empty_ok\`
- \`extract_with_skip_on_error_completes_and_drops_failed_chunks\` — branch-level integration: 6 chunks, chunk 2 fails, asserts whole batch completes with the failed chunk yielding no entities and others yielding one each

## Test plan

- [x] \`cargo fmt --all\` clean
- [x] \`cargo build --workspace --exclude graphrag_py --exclude graphrag-wasm\` clean
- [x] \`cargo nextest run -p graphrag-core --lib\` — 413 passed, 12 skipped (was 407; +6 new)

New regression tests:
- \`extract_entities_concurrent_runs_chunks_in_parallel\` (barrier-based, 2s timeout)
- \`extract_entities_concurrent_fail_fast_on_error\` (64 chunks, fail after 4)
- \`extract_entities_concurrent_returns_results_in_chunk_order\` (skewed durations, post-sort verification)
- \`log_and_skip_extraction_error_passes_ok_through\`
- \`log_and_skip_extraction_error_swallows_err_as_empty_ok\`
- \`extract_with_skip_on_error_completes_and_drops_failed_chunks\`

## Expected merge resolution with conflicting branches

- **PR #131** (gleaning bundle) modifies the dispatcher to use \`EntityConfig::resolved_mode(ollama_enabled)\`. Resolution: keep the \`extract_entities_concurrent\` helper call body inside the \`Mode::LlmSinglePass\` arm.
- **PR #134** (element_summary wiring) adds \`apply_element_summaries\` at the end of \`build_graph\`. Resolution: orthogonal — auto-merge.

Closes #9